### PR TITLE
Documenta serveis i comprova docblocks

### DIFF
--- a/app/Services/AdviseService.php
+++ b/app/Services/AdviseService.php
@@ -4,6 +4,9 @@ namespace Intranet\Services;
 
 use Intranet\Componentes\Mensaje;
 
+/**
+ * Servei AdviseService.
+ */
 class AdviseService
 {
     protected object $element;

--- a/app/Services/AdviseTeacher.php
+++ b/app/Services/AdviseTeacher.php
@@ -12,6 +12,9 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use function hora, nameDay;
 
+/**
+ * Servei AdviseTeacher.
+ */
 class AdviseTeacher
 {
     public static function exec(object $elemento, ?string $mensaje = null, ?string $idEmisor = null, ?string $emisor = null): void

--- a/app/Services/AlertLogger.php
+++ b/app/Services/AlertLogger.php
@@ -5,6 +5,9 @@ namespace Intranet\Services;
 use Illuminate\Support\Facades\Log;
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei AlertLogger.
+ */
 class AlertLogger
 {
     public static function info($message,$channel='sao')

--- a/app/Services/AttachedFileService.php
+++ b/app/Services/AttachedFileService.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Storage;
 use Intranet\Entities\AlumnoFct;
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei AttachedFileService.
+ */
 class AttachedFileService
 {
     private static function safeFile($file, string $route, ?string $dni, ?string $title): int

--- a/app/Services/CalendarService.php
+++ b/app/Services/CalendarService.php
@@ -6,6 +6,9 @@ use Eluceo\iCal\Component\Calendar;
 use Eluceo\iCal\Component\Event;
 use DateTime;
 
+/**
+ * Servei CalendarService.
+ */
 class CalendarService
 {
 

--- a/app/Services/ConfirmAndSend.php
+++ b/app/Services/ConfirmAndSend.php
@@ -1,6 +1,9 @@
 <?php
 namespace Intranet\Services;
 
+/**
+ * Servei ConfirmAndSend.
+ */
 class ConfirmAndSend
 {
     public static function render($model, $id, $message=null, $route=null, $back=null)

--- a/app/Services/CotxeAccessService.php
+++ b/app/Services/CotxeAccessService.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Http;
 use Intranet\Entities\CotxeAcces;
 
+/**
+ * Servei CotxeAccessService.
+ */
 class CotxeAccessService
 {
     /**

--- a/app/Services/DigitalSignatureService.php
+++ b/app/Services/DigitalSignatureService.php
@@ -16,6 +16,9 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
+/**
+ * Servei DigitalSignatureService.
+ */
 class DigitalSignatureService
 {
     public static function readCertificat($certificat, $password): ManageCert

--- a/app/Services/Document/CreateOrUpdateDocumentAction.php
+++ b/app/Services/Document/CreateOrUpdateDocumentAction.php
@@ -5,6 +5,9 @@ namespace Intranet\Services\Document;
 use Illuminate\Http\Request;
 use Intranet\Entities\Documento;
 
+/**
+ * Servei CreateOrUpdateDocumentAction.
+ */
 class CreateOrUpdateDocumentAction
 {
     public function fromRequest(Request $request, array $overrides = [], ?Documento $document = null, $elemento = null): Documento

--- a/app/Services/Document/DocumentAccessChecker.php
+++ b/app/Services/Document/DocumentAccessChecker.php
@@ -2,6 +2,9 @@
 
 namespace Intranet\Services\Document;
 
+/**
+ * Servei DocumentAccessChecker.
+ */
 class DocumentAccessChecker
 {
     public function isAllowed(DocumentContext $context): bool

--- a/app/Services/Document/DocumentContext.php
+++ b/app/Services/Document/DocumentContext.php
@@ -4,6 +4,9 @@ namespace Intranet\Services\Document;
 
 use Intranet\Entities\Documento;
 
+/**
+ * Servei DocumentContext.
+ */
 class DocumentContext
 {
     private ?Documento $document;

--- a/app/Services/Document/DocumentPathService.php
+++ b/app/Services/Document/DocumentPathService.php
@@ -4,6 +4,9 @@ namespace Intranet\Services\Document;
 
 use Illuminate\Support\Facades\File;
 
+/**
+ * Servei DocumentPathService.
+ */
 class DocumentPathService
 {
     public function resolvePath(DocumentContext $context): ?string

--- a/app/Services/Document/DocumentResolver.php
+++ b/app/Services/Document/DocumentResolver.php
@@ -4,6 +4,9 @@ namespace Intranet\Services\Document;
 
 use Intranet\Entities\Documento;
 
+/**
+ * Servei DocumentResolver.
+ */
 class DocumentResolver
 {
     public function resolve($elemento = null, $documento = null): DocumentContext

--- a/app/Services/Document/DocumentResponder.php
+++ b/app/Services/Document/DocumentResponder.php
@@ -4,6 +4,9 @@ namespace Intranet\Services\Document;
 
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei DocumentResponder.
+ */
 class DocumentResponder
 {
     private DocumentAccessChecker $accessChecker;

--- a/app/Services/ExcelService.php
+++ b/app/Services/ExcelService.php
@@ -5,10 +5,16 @@ namespace Intranet\Services;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
+/**
+ * Servei ExcelService.
+ */
 class ExcelService
 {
+    /** @var mixed */
     protected $file;
+    /** @var mixed */
     protected $spreadsheet;
+    /** @var mixed */
     protected $cells;
 
     /**

--- a/app/Services/FDFPrepareService.php
+++ b/app/Services/FDFPrepareService.php
@@ -6,6 +6,9 @@ use Intranet\Http\PrintResources\PrintResource;
 use mikehaertl\pdftk\Pdf;
 use Exception;
 
+/**
+ * Servei FDFPrepareService.
+ */
 class FDFPrepareService
 {
     public static function exec(PrintResource $resource, $id=null)

--- a/app/Services/FctMailService.php
+++ b/app/Services/FctMailService.php
@@ -6,6 +6,9 @@ use Intranet\Finders\UniqueFinder;
 use Intranet\Finders\RequestFinder;
 use Intranet\Componentes\DocumentoFct;
 
+/**
+ * Servei FctMailService.
+ */
 class FctMailService
 {
     /**

--- a/app/Services/FitxatgeService.php
+++ b/app/Services/FitxatgeService.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Carbon;
 
 
+/**
+ * Servei FitxatgeService.
+ */
 class FitxatgeService
 {
     public function fitxar(string $dni = null):  Falta_profesor|bool|null

--- a/app/Services/FormBuilder.php
+++ b/app/Services/FormBuilder.php
@@ -4,11 +4,17 @@ namespace Intranet\Services;
 
 use Illuminate\View\View;
 
+/**
+ * Servei FormBuilder.
+ */
 class FormBuilder
 {
 
+    /** @var mixed */
     private $elemento;
+    /** @var mixed */
     private $default;
+    /** @var mixed */
     private $fillable;
 
 

--- a/app/Services/GestorService.php
+++ b/app/Services/GestorService.php
@@ -8,9 +8,14 @@ use Intranet\Services\Document\DocumentContext;
 use Intranet\Services\Document\DocumentResponder;
 use Intranet\Services\Document\DocumentResolver;
 
+/**
+ * Servei GestorService.
+ */
 class GestorService
 {
+    /** @var mixed */
     private $elemento;
+    /** @var mixed */
     private $document;
     private DocumentContext $context;
     private DocumentResponder $responder;

--- a/app/Services/GoogleCalendarService.php
+++ b/app/Services/GoogleCalendarService.php
@@ -7,9 +7,14 @@ use Google_Client;
 use Google_Service_Calendar;
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei GoogleCalendarService.
+ */
 class GoogleCalendarService
 {
+    /** @var mixed */
     protected $client;
+    /** @var mixed */
     protected $events;
 
     public function __construct()

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -6,6 +6,9 @@ use Illuminate\Http\UploadedFile;
 use Styde\Html\Facades\Alert;
 use Styde\Html\Str;
 
+/**
+ * Servei ImageService.
+ */
 class ImageService
 {
     const WIDTH  = 68;

--- a/app/Services/ItacaService.php
+++ b/app/Services/ItacaService.php
@@ -13,6 +13,9 @@ use Facebook\WebDriver\Interactions\WebDriverActions;
 use Intranet\Exceptions\IntranetException;
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei ItacaService.
+ */
 class ItacaService
 {
     private SeleniumService $ss;

--- a/app/Services/JWTTokenService.php
+++ b/app/Services/JWTTokenService.php
@@ -9,8 +9,12 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 
+/**
+ * Servei JWTTokenService.
+ */
 class JWTTokenService
 {
+    /** @var mixed */
     protected $config;
 
     const EXPIRATION_DATE = '15 October';

--- a/app/Services/MeetingOrderGenerateService.php
+++ b/app/Services/MeetingOrderGenerateService.php
@@ -7,9 +7,14 @@ namespace Intranet\Services;
 use Intranet\Entities\OrdenReunion;
 use Intranet\Entities\TipoReunion;
 
+/**
+ * Servei MeetingOrderGenerateService.
+ */
 class MeetingOrderGenerateService
 {
+    /** @var mixed */
     private $reunion;
+    /** @var mixed */
     private $tipo;
 
     public function __construct($reunion)

--- a/app/Services/NavigationService.php
+++ b/app/Services/NavigationService.php
@@ -5,6 +5,9 @@ namespace Intranet\Services;
 
 use Illuminate\Support\Facades\Request;
 
+/**
+ * Servei NavigationService.
+ */
 class NavigationService
 {
     public static function customBack($default = '/home')

--- a/app/Services/PerfilService.php
+++ b/app/Services/PerfilService.php
@@ -13,6 +13,9 @@ use Intranet\Entities\Comision;
 use Illuminate\Support\Facades\Cache;
 
 
+/**
+ * Servei PerfilService.
+ */
 class PerfilService
 {
     public function carregarDadesProfessor(string $dni): array

--- a/app/Services/PresenciaResumenService.php
+++ b/app/Services/PresenciaResumenService.php
@@ -6,6 +6,9 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * Servei PresenciaResumenService.
+ */
 class PresenciaResumenService
 {
     public function __construct(

--- a/app/Services/PrintReportService.php
+++ b/app/Services/PrintReportService.php
@@ -1,5 +1,4 @@
 <?php
-/*
 namespace Intranet\Services;
 
 use Intranet\Componentes\Pdf;
@@ -7,23 +6,33 @@ use Intranet\Finders\Finder;
 use Jenssegers\Date\Date;
 use Styde\Html\Facades\Alert;
 
+/**
+ * Servei PrintReportService.
+ */
 class PrintReportService
 {
+    /** @var mixed */
     private $finder;
+    /** @var mixed */
     private $document;
+    /** @var mixed */
     private $initialState;
+    /** @var mixed */
     private $finalState;
+    /** @var mixed */
     private $linked;
+    /** @var mixed */
     private $elements;
+    private string $class;
 
     /**
      * PrintReportService constructor.
-     * @param $model
-     * @param $initialState
-     * @param $finalState
-     * @param $orientation
-     * @param $linked
-
+     *
+     * @param Finder $finder
+     * @param mixed $initialState
+     * @param mixed $finalState
+     * @param bool  $linked
+     */
     public function __construct(Finder $finder, $initialState = null, $finalState = '_print', $linked = true)
     {
         $this->finder = $finder;
@@ -77,9 +86,4 @@ class PrintReportService
             }
         }
     }
-
-
-
 }
-
-*/

--- a/app/Services/RemoteLoginService.php
+++ b/app/Services/RemoteLoginService.php
@@ -5,6 +5,9 @@ namespace Intranet\Services;
 use Illuminate\Support\Facades\Http;
 use Intranet\Exceptions\IntranetException;
 
+/**
+ * Servei RemoteLoginService.
+ */
 class RemoteLoginService
 {
     public static function login($link,$user,$pass)

--- a/app/Services/SecretariaService.php
+++ b/app/Services/SecretariaService.php
@@ -5,9 +5,14 @@ use Illuminate\Support\Facades\Http;
 use Intranet\Exceptions\IntranetException;
 
 
+/**
+ * Servei SecretariaService.
+ */
 class SecretariaService
 {
+    /** @var mixed */
     protected $link;
+    /** @var mixed */
     protected $token;
 
     public function __construct()

--- a/app/Services/SeleniumService.php
+++ b/app/Services/SeleniumService.php
@@ -14,8 +14,12 @@ use Intranet\Exceptions\SeleniumException;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
+/**
+ * Servei SeleniumService.
+ */
 class SeleniumService
 {
+    /** @var mixed */
     private $driver;
 
     public function __construct( $dni, $password)

--- a/app/Services/SignaturaService.php
+++ b/app/Services/SignaturaService.php
@@ -4,6 +4,9 @@ namespace Intranet\Services;
 
 use Intranet\Entities\Profesor;
 
+/**
+ * Servei SignaturaService.
+ */
 class SignaturaService
 {
     public static function exec($dni, $style='', $ratio=1, $notFound=null)

--- a/app/Services/StateService.php
+++ b/app/Services/StateService.php
@@ -6,9 +6,14 @@ use Intranet\Entities\Documento;
 use Styde\Html\Facades\Alert;
 use function config, getClass, getClase;
 
+/**
+ * Servei StateService.
+ */
 class StateService
 {
+    /** @var mixed */
     private $element;
+    /** @var mixed */
     private $statesElement;
 
     public function __construct($class, $id = null)

--- a/app/Services/ValidatePdfMultipleSignatures.php
+++ b/app/Services/ValidatePdfMultipleSignatures.php
@@ -9,6 +9,9 @@ use LSNepomuceno\LaravelA1PdfSign\Exceptions\{FileNotFoundException,
     ProcessRunTimeException
 };
 use Throwable;
+/**
+ * Servei ValidatePdfMultipleSignatures.
+ */
 class ValidatePdfMultipleSignatures
 {
     private string $pdfPath, $plainTextContent, $pkcs7Path = '';

--- a/app/Services/VioletHasher.php
+++ b/app/Services/VioletHasher.php
@@ -2,6 +2,9 @@
 
 namespace Intranet\Services;
 
+/**
+ * Servei VioletHasher.
+ */
 class VioletHasher
 {
     public static function dniHash(string $dni, ?string $pepper = null): string

--- a/app/Services/ZipService.php
+++ b/app/Services/ZipService.php
@@ -1,6 +1,9 @@
 <?php
 namespace Intranet\Services;
 
+/**
+ * Servei ZipService.
+ */
 class ZipService
 {
     /**

--- a/tests/Unit/Services/ServicesDocumentationTest.php
+++ b/tests/Unit/Services/ServicesDocumentationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class ServicesDocumentationTest extends TestCase
+{
+    #[DataProvider('serviceClassProvider')]
+    public function testServicesHaveDocblocksAndTypedProperties(string $className): void
+    {
+        $this->assertTrue(class_exists($className), "No s'ha pogut carregar la classe $className");
+
+        $reflection = new ReflectionClass($className);
+
+        $this->assertNotFalse(
+            $reflection->getDocComment(),
+            "Falta el DocBlock de classe a $className"
+        );
+
+        foreach ($reflection->getProperties(
+            ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PRIVATE
+        ) as $property) {
+            if ($property->getDeclaringClass()->getName() !== $className) {
+                continue;
+            }
+
+            $this->assertTrue(
+                $property->getType() !== null || $property->getDocComment(),
+                sprintf('Cal documentar o tipar la propietat %s::$%s', $className, $property->getName())
+            );
+        }
+    }
+
+    public static function serviceClassProvider(): array
+    {
+        $basePath = dirname(__DIR__, 3) . '/app/Services';
+        $directoryIterator = new RecursiveDirectoryIterator($basePath, FilesystemIterator::SKIP_DOTS);
+        $iterator = new RecursiveIteratorIterator($directoryIterator);
+        $classes = [];
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relativePath = str_replace($basePath . DIRECTORY_SEPARATOR, '', $file->getRealPath());
+            $relativeClass = str_replace(DIRECTORY_SEPARATOR, '\\', substr($relativePath, 0, -4));
+            $classes[] = ['Intranet\\Services\\' . $relativeClass];
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+}


### PR DESCRIPTION
## Resum
- Afegits DocBlocks i anotacions de tipus bàsics a tots els serveis per garantir documentació mínima.
- Recuperat `PrintReportService` amb espai de noms vàlid i propietat tipada per evitar errors de càrrega.
- Nova prova `ServicesDocumentationTest` que verifica DocBlocks i tipatge de propietats en tots els serveis.

## Proves
- ./vendor/bin/phpunit --filter ServicesDocumentationTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694317e8fd888332962bea38cf00db67)