### PR TITLE
[ADD][FIX] #87 Filtrar enquestes per curs de l'alumne/professor

### DIFF
--- a/app/Entities/Poll/Poll.php
+++ b/app/Entities/Poll/Poll.php
@@ -12,17 +12,18 @@ class Poll extends Model
 {
     use \Intranet\Entities\Concerns\BatoiModels;
     
-    protected $fillable = ['title','desde','hasta','idPPoll'];
+    protected $fillable = ['title', 'desde', 'hasta', 'idPPoll', 'curs'];
     protected $rules = [
-        'title' => 'required',
-        'desde' => 'required',
-        'hasta' => 'required',
-        'idPPoll' => 'required'
+        'title'   => 'required',
+        'desde'   => 'required',
+        'hasta'   => 'required',
+        'idPPoll' => 'required',
     ];
     protected $inputTypes = [
-        'desde' => ['type' => 'date'],
-        'hasta' => ['type' => 'date'],
-        'idPPoll' => ['type' => 'select']
+        'desde'   => ['type' => 'date'],
+        'hasta'   => ['type' => 'date'],
+        'idPPoll' => ['type' => 'select'],
+        'curs'    => ['type' => 'select'],
     ];
     public $timestamps = false;
     
@@ -75,9 +76,18 @@ class Poll extends Model
         return $modelo::vista();
     }
 
-    public function getIdPPollOptions()
+    public function getIdPPollOptions(): array
     {
         return hazArray(PPoll::all(), 'id', 'title');
+    }
+
+    /**
+     * Retorna les opcions de curs disponibles per al selector del formulari.
+     * La clau buida representa "tots els cursos" (valor NULL a BD).
+     */
+    public function getCursOptions(): array
+    {
+        return ['' => 'Tots els cursos', 1 => '1r curs', 2 => '2n curs'];
     }
 
     public function getDesdeAttribute($entrada)

--- a/app/Http/Controllers/PanelPollResponseController.php
+++ b/app/Http/Controllers/PanelPollResponseController.php
@@ -2,29 +2,45 @@
 
 namespace Intranet\Http\Controllers;
 
-use Intranet\Entities\Fct;
-use Response;
 use Intranet\UI\Botones\BotonImg;
 use Intranet\Entities\Poll\Poll;
 
+/**
+ * Controlador per mostrar les enquestes actives que l'usuari ha de respondre.
+ * Filtra per tipus d'usuari (alumne/professor) i per curs del grup.
+ */
 class PanelPollResponseController extends PollController
 {
 
     protected function iniBotones()
     {
-        $this->panel->setBoton('grid', new BotonImg('poll.do', ['img' =>'fa-check-square-o']));
+        $this->panel->setBoton('grid', new BotonImg('poll.do', ['img' => 'fa-check-square-o']));
     }
 
-    protected function search()
+    /**
+     * Retorna les enquestes actives que corresponen a l'usuari autenticat,
+     * filtrades per tipus d'usuari i per curs del seu grup.
+     *
+     * @return array
+     */
+    protected function search(): array
     {
         $polls = Poll::all();
-        $key = isset(AuthUser()->nia)?'nia':'dni';
-        $activas =  $polls->where('state', 'Activa')->where('keyUser', $key);
+        $key = isset(AuthUser()->nia) ? 'nia' : 'dni';
+        $activas = $polls->where('state', 'Activa')->where('keyUser', $key);
+
+        $userCurs = $this->getUserCurs();
+        
+        if ($userCurs !== null) {
+            $activas = $activas->filter(
+                fn($poll) => $poll->curs === null || (int) $poll->curs === $userCurs
+            );
+        }
 
         $usuario = [];
         foreach ($activas as $activa) {
             $modelo = $activa->modelo;
-        if ($modelo::has()) {
+            if ($modelo::has()) {
                 $usuario[] = $activa;
             }
         }

--- a/app/Http/Controllers/PanelPollResultController.php
+++ b/app/Http/Controllers/PanelPollResultController.php
@@ -6,27 +6,43 @@ use Intranet\UI\Botones\BotonImg;
 use Intranet\Entities\Poll\Poll;
 use Intranet\Entities\Poll\PPoll;
 
+/**
+ * Controlador per mostrar els resultats d'enquestes finalitzades als professors.
+ * Filtra per tipus d'enquesta segons el rol i per curs del grup del professor.
+ */
 class PanelPollResultController extends PollController
 {
-    protected $gridFields = [ 'id','title'];
+    protected $gridFields = ['id', 'title'];
 
     protected function iniBotones()
     {
-        $this->panel->setBoton('grid',new BotonImg('poll.show',['img' =>'fa-eye']));
+        $this->panel->setBoton('grid', new BotonImg('poll.show', ['img' => 'fa-eye']));
     }
 
+    /**
+     * Retorna les enquestes finalitzades visibles per a l'usuari autenticat,
+     * filtrades per rol i per curs del seu grup.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     protected function search()
     {
         if (esRol(AuthUser()->rol, config('roles.rol.tutor'))) {
-            $ppolls = hazArray(PPoll::all(),'id','id');
+            $ppolls = hazArray(PPoll::all(), 'id', 'id');
+        } else {
+            $ppolls = hazArray(PPoll::where('what', 'Profesor')->get(), 'id', 'id');
         }
-        else {
-            $ppolls = hazArray(PPoll::where('what', 'Profesor')->get(),'id','id');
+
+        $query = Poll::whereIn('idPPoll', $ppolls)->where('hasta', '<=', now());
+
+        $userCurs = $this->getUserCurs();
+        
+        if ($userCurs !== null) {
+            $query->where(function ($q) use ($userCurs): void {
+                $q->whereNull('curs')->orWhere('curs', $userCurs);
+            });
         }
-        return Poll::whereIn('idPPoll', $ppolls)
-            ->where('hasta', '<=', now())
-            ->get();
+
+        return $query->get();
     }
-
-
 }

--- a/app/Http/Controllers/PollController.php
+++ b/app/Http/Controllers/PollController.php
@@ -4,6 +4,7 @@ namespace Intranet\Http\Controllers;
 
 use Intranet\Application\Grupo\GrupoService;
 use Intranet\Application\Poll\PollWorkflowService;
+use Intranet\Entities\Grupo;
 use Intranet\Exceptions\NotFoundDomainException;
 use Intranet\Http\Controllers\Core\IntranetController;
 
@@ -48,6 +49,27 @@ class PollController extends IntranetController
         }
 
         return $this->pollWorkflowService;
+    }
+
+    /**
+     * Retorna el curs (1 o 2) de l'usuari autenticat basant-se en el seu grup.
+     * Per a alumnes, el curs prové del seu grup assignat.
+     * Per a professors/tutors, prové del grup que tutoritzen.
+     * Retorna null si no es pot determinar el curs.
+     */
+    protected function getUserCurs(): ?int
+    {
+        $user = AuthUser();
+        if (isset($user->nia)) {
+            $grupo = $user->Grupo->first();
+            return $grupo ? (int) $grupo->curso : null;
+        }
+        $grupoCodi = $user->GrupoTutoria;
+        if ($grupoCodi) {
+            $grupo = Grupo::find($grupoCodi);
+            return $grupo ? (int) $grupo->curso : null;
+        }
+        return null;
     }
 
     protected function iniBotones()

--- a/database/migrations/2026_03_13_100000_add_curs_to_polls_table.php
+++ b/database/migrations/2026_03_13_100000_add_curs_to_polls_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Afegeix la columna `curs` a la taula `polls` per filtrar
+ * enquestes per any del cicle formatiu (1r o 2n).
+ * NULL indica que l'enquesta és visible per a tots els cursos.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('polls', function (Blueprint $table): void {
+            $table->unsignedTinyInteger('curs')->nullable()->after('hasta');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('polls', function (Blueprint $table): void {
+            $table->dropColumn('curs');
+        });
+    }
+};


### PR DESCRIPTION
- Afegeix columna `curs` (nullable tinyint) a la taula `polls` per indicar el curs destinatari (NULL = tots els cursos, 1 = 1r, 2 = 2n)
- Actualitza Poll: `$fillable`, `$inputTypes` i `getCursOptions()` per al selector al formulari d'administració
- Afegeix `getUserCurs()` a PollController (compartit per subcontroladors): obté el curs de l'alumne via Grupo o del professor via GrupoTutoria
- PanelPollResponseController: filtra les enquestes actives per curs de l'usuari
- PanelPollResultController: filtra els resultats per curs via whereNull/orWhere