### PR TITLE
[MOD] Reestructura misColaboraciones

### DIFF
--- a/app/Application/Colaboracion/ColaboracionQueryService.php
+++ b/app/Application/Colaboracion/ColaboracionQueryService.php
@@ -106,6 +106,7 @@ class ColaboracionQueryService
 
         $meves->each(function ($mine) use ($pairKey, $relacionadesPerParella, $activitiesByColab): void {
             $llista = $relacionadesPerParella->get($pairKey($mine), collect());
+            $mine->contactos = $activitiesByColab->get($mine->id, collect());
 
             $llista->each(function ($related) use ($activitiesByColab): void {
                 $related->contactos = $activitiesByColab->get($related->id, collect());
@@ -117,4 +118,3 @@ class ColaboracionQueryService
         return $meves;
     }
 }
-

--- a/app/Application/Colaboracion/ColaboracionQueryService.php
+++ b/app/Application/Colaboracion/ColaboracionQueryService.php
@@ -107,9 +107,11 @@ class ColaboracionQueryService
         $meves->each(function ($mine) use ($pairKey, $relacionadesPerParella, $activitiesByColab): void {
             $llista = $relacionadesPerParella->get($pairKey($mine), collect());
             $mine->contactos = $activitiesByColab->get($mine->id, collect());
+            $mine->ultimaActividad = $mine->contactos->last();
 
             $llista->each(function ($related) use ($activitiesByColab): void {
                 $related->contactos = $activitiesByColab->get($related->id, collect());
+                $related->ultimaActividad = $related->contactos->last();
             });
 
             $mine->relacionadas = $llista->values();

--- a/app/Application/Colaboracion/ColaboracionService.php
+++ b/app/Application/Colaboracion/ColaboracionService.php
@@ -28,7 +28,9 @@ class ColaboracionService
         }
 
         $relacionades = $this->queryService->relatedByCenterDepartment($meves);
-        $activitiesByColab = $this->queryService->groupedActivitiesByColaboracion($relacionades);
+        $activitiesByColab = $this->queryService->groupedActivitiesByColaboracion(
+            $meves->concat($relacionades)->values()
+        );
 
         return $this->queryService
             ->attachRelatedAndContacts($meves, $relacionades, $activitiesByColab)
@@ -48,4 +50,3 @@ class ColaboracionService
         return optional($colaboraciones->first()->Ciclo)->literal;
     }
 }
-

--- a/docs/sprints/sprint-11-mis-colaboraciones-plan.md
+++ b/docs/sprints/sprint-11-mis-colaboraciones-plan.md
@@ -1,0 +1,165 @@
+# Sprint 11: Reestructuració de `misColaboraciones`
+
+## Objectiu
+
+Fer `misColaboraciones` més útil, més escanejable i més mantenible sense rehacer el mòdul a cegues ni obrir un tall gran de Livewire abans de temps.
+
+## Diagnòstic
+
+L'estat actual té quatre problemes principals:
+
+1. La vista barreja estructura, consultes i presentació.
+   - [`resources/views/intranet/partials/profile/colaboracion.blade.php`](/Users/igomis/Code/intranetBatoi/resources/views/intranet/partials/profile/colaboracion.blade.php) consulta `Activity` dins de Blade.
+2. La targeta té massa densitat informativa.
+   - [`resources/views/intranet/partials/profile/partials/colaboracion.blade.php`](/Users/igomis/Code/intranetBatoi/resources/views/intranet/partials/profile/partials/colaboracion.blade.php) mescla resum, historial, relacionades i accions.
+3. Hi ha doble agrupació.
+   - [`app/Http/Controllers/PanelColaboracionController.php`](/Users/igomis/Code/intranetBatoi/app/Http/Controllers/PanelColaboracionController.php) agrupa per `situation`, però després Blade torna a separar en `meues` i `altres`.
+4. El JS del domini és massa monolític.
+   - [`public/js/Colaboracion/grid.js`](/Users/igomis/Code/intranetBatoi/public/js/Colaboracion/grid.js) concentra grid, colors, accions i comportament del panell.
+
+## Decisió de disseny
+
+Per ara es mantenen les pestanyes com a organització principal. No es fa una migració a Livewire en este sprint.
+
+Raons:
+
+- la informació ja és massa densa i primer cal simplificar el model visual
+- Livewire ara mateix reproduiria el mateix acoblament en una altra tecnologia
+- les pestanyes per estat continuen tenint sentit com a eix del panell
+
+Livewire queda com a fase futura, només després de simplificar dades i targeta.
+
+## Model objectiu
+
+### Estructura del panell
+
+- pestanyes per estat
+- dins de cada pestanya, una sola llista
+- desaparix la separació en dos blocs grans `meues` / `altres`
+- `meua` o `d'altre tutor` passa a ser un badge o marca visual dins de la targeta
+
+### Estructura de la targeta
+
+Cada targeta ha de tindre tres zones:
+
+1. Capçalera
+   - centre / empresa
+   - cicle
+   - tutor responsable
+   - badge d'estat
+2. Cos curt
+   - últim contacte
+   - pròxima acció
+   - contacte principal
+3. Peu d'accions
+   - `avisar`
+   - `telefonico`
+   - `book`
+   - `resolve`
+   - `refuse`
+   - `switch`
+
+### Informació plegable
+
+Només queda desplegada quan l'usuari la demana:
+
+- relacionades
+- historial complet
+- notes/comentaris llargs
+
+## Fases d'implementació
+
+### Tall A: Preparació de dades
+
+- traure les consultes d'`Activity` fora de Blade
+- preparar en backend:
+  - `contactos`
+  - `ultima_actividad`
+  - `proxima_accion`
+  - `relacionadas`
+- garantir càrrega eficient i evitar N+1
+
+Fitxers probables:
+
+- [`app/Http/Controllers/PanelColaboracionController.php`](/Users/igomis/Code/intranetBatoi/app/Http/Controllers/PanelColaboracionController.php)
+- [`app/Application/Colaboracion/ColaboracionService.php`](/Users/igomis/Code/intranetBatoi/app/Application/Colaboracion/ColaboracionService.php)
+
+### Tall B: Simplificació de la vista principal
+
+- eliminar la doble separació `meues` / `altres`
+- renderitzar una sola llista per pestanya
+- afegir un badge de propietat
+
+Fitxers probables:
+
+- [`resources/views/intranet/partials/profile/colaboracion.blade.php`](/Users/igomis/Code/intranetBatoi/resources/views/intranet/partials/profile/colaboracion.blade.php)
+
+### Tall C: Redisseny de la targeta
+
+- reduir pes visual
+- prioritzar resum i pròxima acció
+- passar relacionades i historial a blocs plegables
+
+Fitxers probables:
+
+- [`resources/views/intranet/partials/profile/partials/colaboracion.blade.php`](/Users/igomis/Code/intranetBatoi/resources/views/intranet/partials/profile/partials/colaboracion.blade.php)
+- CSS associat si cal
+
+### Tall D: Desacoblament del JS
+
+- separar el que és grid/tables del que és accions de col·laboració
+- preparar el camí per a una futura migració del panell
+
+Fitxers probables:
+
+- [`public/js/Colaboracion/grid.js`](/Users/igomis/Code/intranetBatoi/public/js/Colaboracion/grid.js)
+
+### Tall E: Valoració de Livewire
+
+Només si els talls anteriors ja estan resolts.
+
+Livewire tindria sentit per a:
+
+- filtres en viu
+- cerca
+- comptadors per estat
+- expandir detall sense recàrrega
+
+No és objectiu del primer tall del sprint.
+
+## Criteris d'acceptació
+
+- `misColaboraciones` continua mostrant les mateixes col·laboracions útils
+- la vista no consulta `Activity` dins de Blade
+- cada pestanya mostra una única llista consistent
+- una targeta és escanejable sense llegir tot el detall
+- relacionades i historial no saturen la vista inicial
+- les accions actuals continuen funcionant
+
+## Riscos
+
+- trencar accions JS si es refà la targeta massa prompte
+- perdre informació rellevant en simplificar massa la vista
+- moure dades a backend sense cobrir tots els casos d'ús del tutor
+
+## Recomanació
+
+Començar per Tall A + Tall B en la primera passada.
+
+És el punt amb millor retorn:
+
+- millora rendiment
+- baixa l'acoblament
+- deixa el panell preparat per a una segona passada visual
+
+## Estat actual
+
+- Tall A executat:
+  - `contactos` del propi element ja es preparen en backend
+  - Blade ja no consulta `Activity`
+- Tall B iniciat:
+  - la vista principal ja renderitza una sola llista per pestanya
+  - `meua` / `altre tutor` passa a marcador visual dins de la targeta
+- Tall C iniciat:
+  - la targeta mostra primer resum curt, estat i últim contacte
+  - el detall llarg i les relacionades passen a blocs plegables

--- a/resources/views/components/ui/tabs.blade.php
+++ b/resources/views/components/ui/tabs.blade.php
@@ -1,10 +1,17 @@
 @props(['id', 'pestanyes','panel'])
 
+@php
+    $tabs = $panel->getPestanas();
+    $hasActiveTab = collect($tabs)->contains(
+        static fn ($pestana): bool => trim((string) $pestana->getActiva()) !== ''
+    );
+@endphp
+
 <div class="x_content">
     <div class="" role="tabpanel" data-example-id="togglable-tabs">
         <ul id="{{ $id }}" class="nav nav-tabs bar_tabs right" role="tablist">
-            @foreach ($panel->getPestanas() as $pestana)
-                @php($isActive = trim((string) $pestana->getActiva()) !== '')
+            @foreach ($tabs as $pestana)
+                @php($isActive = trim((string) $pestana->getActiva()) !== '' || (!$hasActiveTab && $loop->first))
                 <li class="nav-item" role="presentation">
                     <a href="#tab_{{ $pestana->getNombre()  }}"
                        class="nav-link {{ $isActive ? 'active' : '' }}"
@@ -20,8 +27,8 @@
         </ul>
 
         <div id="{{ $id }}Content" class="tab-content">
-            @foreach ($panel->getPestanas() as $pestana)
-                @php($isActive = trim((string) $pestana->getActiva()) !== '')
+            @foreach ($tabs as $pestana)
+                @php($isActive = trim((string) $pestana->getActiva()) !== '' || (!$hasActiveTab && $loop->first))
                 <div role="tabpanel"
                      class="tab-pane fade {{ $isActive ? 'show active' : '' }}"
                      id="tab_{{ $pestana->getNombre() }}"

--- a/resources/views/intranet/partials/profile/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/colaboracion.blade.php
@@ -1,23 +1,7 @@
-@php
-    $misElementos = $panel->getElementos($pestana)->where('tutor',authUser()->dni);
-    $otros =  $panel->getElementos($pestana)->where('tutor','!=',authUser()->dni);
-@endphp
-@foreach ($misElementos as $elemento)
-        @php
-            $contactos = \Intranet\Entities\Activity::modelo('Colaboracion')
-            ->id($elemento->id)
-            ->notUpdate()
-            ->orderBy('created_at')
-            ->get();
-        @endphp
-        @include ('intranet.partials.profile.partials.colaboracion')
-@endforeach
-@foreach ($otros as $elemento)
+@foreach ($panel->getElementos($pestana) as $elemento)
     @php
-        $contactos = \Intranet\Entities\Activity::modelo('Colaboracion')
-        ->id($elemento->id)
-        ->orderBy('created_at')
-        ->get();
+        $contactos = $elemento->contactos ?? collect();
+        $isMine = $elemento->tutor === authUser()->dni;
     @endphp
     @include ('intranet.partials.profile.partials.colaboracion')
 @endforeach

--- a/resources/views/intranet/partials/profile/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/colaboracion.blade.php
@@ -1,7 +1,21 @@
-@foreach ($panel->getElementos($pestana) as $elemento)
+@php
+    $elementos = $panel->getElementos($pestana)->sortBy('localidad')->values();
+    $localidadActual = null;
+@endphp
+
+@foreach ($elementos as $elemento)
     @php
         $contactos = $elemento->contactos ?? collect();
         $isMine = $elemento->tutor === authUser()->dni;
+        $localidad = $elemento->localidad;
     @endphp
+    @if ($localidadActual !== $localidad)
+        @php($localidadActual = $localidad)
+        <div class="col-xs-12" style="margin-top: 8px; margin-bottom: 6px;">
+            <div style="padding: 6px 10px; border-left: 4px solid #1abb9c; background: #f7f9fb;">
+                <strong><em class="fa fa-map-marker"></em> {{ $localidadActual }}</strong>
+            </div>
+        </div>
+    @endif
     @include ('intranet.partials.profile.partials.colaboracion')
 @endforeach

--- a/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
@@ -1,15 +1,71 @@
-
+@php
+    $estadoBadgeClass = match ((int) ($elemento->estado ?? 0)) {
+        2 => 'bg-success',
+        3 => 'bg-danger',
+        1 => 'bg-warning text-dark',
+        default => 'bg-secondary',
+    };
+    $estadoLabel = match ((int) ($elemento->estado ?? 0)) {
+        2 => 'Col·labora',
+        3 => 'No col·labora',
+        1 => 'Pendent',
+        default => 'Sense classificar',
+    };
+    $collapseId = 'colaboracion-detall-' . $elemento->id;
+    $relatedCollapseId = 'colaboracion-relacionades-' . $elemento->id;
+    $ultimContacte = $contactos->last();
+    $relacionadas = $elemento->relacionadas ?? collect();
+@endphp
 <div class="col-md-4 col-sm-4 col-xs-12 profile_details">
     <div id="{{$elemento->id}}" class="well profile_view"
          @if ($elemento->estado == 3) style='border-color: #90111a;border-width: medium' @endif
     >
         <div class="col-sm-12">
-            <div class="left col-md-9 col-xs-12">
+            <div class="left col-md-8 col-xs-12">
                 <h5>
                      {{$elemento->Centro->nombre}}
                 </h5>
-                @isset (authUser()->emailItaca)
+                <p class="mb-2">
+                    <span class="badge {{ $isMine ? 'bg-success' : 'bg-secondary' }}">
+                        {{ $isMine ? 'Meua' : 'Altre tutor' }}
+                    </span>
+                    <span class="badge {{ $estadoBadgeClass }}">
+                        {{ $estadoLabel }}
+                    </span>
+                </p>
+                <ul class="list-unstyled">
+                    <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
+                    <li><em class="fa fa-user"></em> {{$elemento->contacto ?: 'Sense contacte'}}</li>
+                    <li><em class="fa fa-phone"></em> {{$elemento->telefono ?: 'Sense telèfon'}}</li>
+                    <li><em class="fa fa-envelope"></em> {{$elemento->email ?: 'Sense email'}}</li>
+                    <li><em class="fa fa-user-secret"></em> {{$elemento->profesor ?? 'No assignada'}}</li>
+                </ul>
+
+                @if ($ultimContacte)
+                    <p class="small text-muted mb-2">
+                        <strong>Últim contacte:</strong>
+                        {{ $ultimContacte->created_at?->format('d/m/Y H:i') }}
+                    </p>
+                @endif
+
+                <p class="mb-3">
+                    <button class="btn btn-default btn-xs" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#{{ $collapseId }}" aria-expanded="false"
+                            aria-controls="{{ $collapseId }}">
+                        Més detall
+                    </button>
+                    @if($relacionadas->isNotEmpty())
+                        <button class="btn btn-default btn-xs" type="button" data-bs-toggle="collapse"
+                                data-bs-target="#{{ $relatedCollapseId }}" aria-expanded="false"
+                                aria-controls="{{ $relatedCollapseId }}">
+                            Altres cicles ({{ $relacionadas->count() }})
+                        </button>
+                    @endif
+                </p>
+
+                <div class="collapse" id="{{ $collapseId }}">
                     <ul class="list-unstyled">
+                @isset (authUser()->emailItaca)
                         <li>Conveni: <strong>
                                 {{$elemento->Centro->Empresa->concierto}}
                                 @if ($elemento->Centro->Empresa->conveniCaducat)
@@ -19,33 +75,31 @@
                                 @endif
                             </strong>
                         </li>
-                        <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
-                        <li><em class="fa fa-user"></em> {{$elemento->contacto}}</li>
-                        <li><em class="fa fa-phone"></em> {{$elemento->telefono}}</li>
-                        <li><em class="fa fa-envelope"></em> {{$elemento->email}}</li>
-                        <li><em class="fa fa-user-secret"></em> {{$elemento->profesor??'No assignada'}}</li>
-                    </ul>
                 @else
-                    <ul class="list-unstyled">
-                        <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
                         <li><em class="fa fa-clock-o"></em> {{$elemento->Centro->horarios}}</li>
                         <li><em class="fa fa-map-marker"></em> {{$elemento->Centro->direccion}}</li>
                         <li><em class="fa fa-folder"></em> {{$elemento->Centro->Empresa->actividad}}</li>
                         <li><em class="fa fa-envelope"></em> {{$elemento->Centro->Empresa->email}}</li>
-                    </ul>
                 @endisset
+                    </ul>
+                </div>
             </div>
-            <div class="col-md-3 col-xs-12 listActivity">
+
+            <div class="col-md-4 col-xs-12 listActivity">
+                <p class="small text-muted mb-1">
+                    <strong>Activitat recent</strong>
+                </p>
                 @foreach ($contactos as $contacto)
                     <x-activity :activity="$contacto" />
                     <br/>
                 @endforeach
             </div>
-            @if(($elemento->relacionadas ?? collect())->isNotEmpty())
-                <ul class="list-unstyled" style="margin-top:.5rem">
-                    <li><span class="badge bg-secondary">Altres cicles (mateix centre/departament)</span></li>
+            @if($relacionadas->isNotEmpty())
+                <div class="col-md-12 col-xs-12 collapse" id="{{ $relatedCollapseId }}" style="margin-top:.5rem">
+                    <ul class="list-unstyled">
+                        <li><span class="badge bg-secondary">Altres cicles (mateix centre/departament)</span></li>
 
-                    @foreach ($elemento->relacionadas as $rel)
+                    @foreach ($relacionadas as $rel)
                         <li class="small" style="margin-top:.25rem">
                             <em class="fa fa-institution"></em>
                             {{ optional($rel->Ciclo)->literal ?? ($rel->idCiclo ?? $rel->ciclo_id) }}
@@ -79,7 +133,8 @@
                             @endif
                         </li>
                     @endforeach
-                </ul>
+                    </ul>
+                </div>
             @endif
            
         </div>

--- a/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
@@ -13,7 +13,7 @@
     };
     $collapseId = 'colaboracion-detall-' . $elemento->id;
     $relatedCollapseId = 'colaboracion-relacionades-' . $elemento->id;
-    $ultimContacte = $contactos->last();
+    $ultimContacte = $elemento->ultimaActividad ?? null;
     $relacionadas = $elemento->relacionadas ?? collect();
 @endphp
 <div class="col-md-4 col-sm-4 col-xs-12 profile_details">
@@ -89,10 +89,12 @@
                 <p class="small text-muted mb-1">
                     <strong>Activitat recent</strong>
                 </p>
-                @foreach ($contactos as $contacto)
+                @forelse ($contactos as $contacto)
                     <x-activity :activity="$contacto" />
                     <br/>
-                @endforeach
+                @empty
+                    <p class="small text-muted">Sense activitat recent</p>
+                @endforelse
             </div>
             @if($relacionadas->isNotEmpty())
                 <div class="col-md-12 col-xs-12 collapse" id="{{ $relatedCollapseId }}" style="margin-top:.5rem">

--- a/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
@@ -25,6 +25,9 @@
                 <h5>
                      {{$elemento->Centro->nombre}}
                 </h5>
+                <p class="small text-muted mb-2">
+                    <em class="fa fa-map-marker"></em> {{$elemento->localidad}}
+                </p>
                 <p class="mb-2">
                     <span class="badge {{ $isMine ? 'bg-success' : 'bg-secondary' }}">
                         {{ $isMine ? 'Meua' : 'Altre tutor' }}
@@ -34,11 +37,9 @@
                     </span>
                 </p>
                 <ul class="list-unstyled">
-                    <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
                     <li><em class="fa fa-user"></em> {{$elemento->contacto ?: 'Sense contacte'}}</li>
                     <li><em class="fa fa-phone"></em> {{$elemento->telefono ?: 'Sense telèfon'}}</li>
                     <li><em class="fa fa-envelope"></em> {{$elemento->email ?: 'Sense email'}}</li>
-                    <li><em class="fa fa-user-secret"></em> {{$elemento->profesor ?? 'No assignada'}}</li>
                 </ul>
 
                 @if ($ultimContacte)
@@ -75,7 +76,10 @@
                                 @endif
                             </strong>
                         </li>
+                        <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
+                        <li><em class="fa fa-user-secret"></em> {{$elemento->profesor ?? 'No assignada'}}</li>
                 @else
+                        <li><em class="fa fa-group"></em> {{$elemento->puestos}} lloc(s) de treball</li>
                         <li><em class="fa fa-clock-o"></em> {{$elemento->Centro->horarios}}</li>
                         <li><em class="fa fa-map-marker"></em> {{$elemento->Centro->direccion}}</li>
                         <li><em class="fa fa-folder"></em> {{$elemento->Centro->Empresa->actividad}}</li>
@@ -141,15 +145,12 @@
            
         </div>
         <div class="col-xs-12 bottom text-center">
-            <div class="col-xs-12 col-sm-4 emphasis">
-                <p class="ratings">
-                    {{$elemento->localidad}}<br/>
-                </p>
-            </div>
-            <div class="col-xs-12 col-sm-8 emphasis">
+            <div class="col-xs-12 emphasis">
                 @isset (authUser()->emailItaca)
-                    <x-botones :panel="$panel" tipo="profile" :elemento="$elemento ?? null"/><br/>
-                    <x-botones :panel="$panel" tipo="nofct" :elemento="$elemento ?? null"/>
+                    <div class="d-flex flex-wrap justify-content-center gap-1">
+                        <x-botones :panel="$panel" tipo="profile" :elemento="$elemento ?? null" :centrado="false" />
+                        <x-botones :panel="$panel" tipo="nofct" :elemento="$elemento ?? null" :centrado="false" />
+                    </div>
                 @endisset
             </div>
         </div>

--- a/resources/views/layouts/partials/panel.blade.php
+++ b/resources/views/layouts/partials/panel.blade.php
@@ -11,10 +11,16 @@
                         {!! \Intranet\Services\UI\AppAlert::render() !!}
                     </div>
                     <div class="x_content">
+                        @php
+                            $tabs = $panel->getPestanas();
+                            $hasActiveTab = collect($tabs)->contains(
+                                static fn ($pestana): bool => trim((string) $pestana->getActiva()) !== ''
+                            );
+                        @endphp
                         <div class="" role="tabpanel" data-example-id="togglable-tabs">
                             <ul id="myTab1" class="nav nav-tabs bar_tabs right" role="tablist">
-                                @foreach ($panel->getPestanas() as $pestana)
-                                    @php($isActive = trim((string) $pestana->getActiva()) !== '')
+                                @foreach ($tabs as $pestana)
+                                    @php($isActive = trim((string) $pestana->getActiva()) !== '' || (!$hasActiveTab && $loop->first))
                                     <li class="nav-item" role="presentation">
                                         <a href="#tab_{{$pestana->getNombre()}}" class="nav-link {{ $isActive ? 'active' : '' }}" id="{{$pestana->getNombre()}}-tabb" role="tab" data-bs-toggle="tab" aria-controls="{{$pestana->getNombre()}}" aria-selected="{{ $isActive ? 'true' : 'false' }}">
                                             @if (strpos(__("messages.buttons.".$pestana->getNombre()),'essages')==1)
@@ -27,8 +33,8 @@
                                 @endforeach
                             </ul>
                             <div id="myTabContent1" class="tab-content">
-                                @foreach ($panel->getPestanas() as $pestana)
-                                    @php($isActive = trim((string) $pestana->getActiva()) !== '')
+                                @foreach ($tabs as $pestana)
+                                    @php($isActive = trim((string) $pestana->getActiva()) !== '' || (!$hasActiveTab && $loop->first))
                                     <div role="tabpanel" class="tab-pane fade {{ $isActive ? 'show active' : '' }}" id="tab_{{$pestana->getNombre()}}" aria-labelledby="{{$pestana->getNombre()}}-tab">
                                         @yield($pestana->getNombre())
                                     </div>

--- a/tests/Unit/Application/Colaboracion/ColaboracionQueryServiceTest.php
+++ b/tests/Unit/Application/Colaboracion/ColaboracionQueryServiceTest.php
@@ -51,7 +51,12 @@ class ColaboracionQueryServiceTest extends TestCase
 
         $this->assertCount(1, $resultat);
         $this->assertSame([$contacteMeu], $resultat->first()->contactos->all());
+        $this->assertSame($contacteMeu, $resultat->first()->ultimaActividad);
         $this->assertCount(1, $resultat->first()->relacionadas);
+        $this->assertSame(
+            $contacteRelacionat,
+            $resultat->first()->relacionadas->first()->ultimaActividad
+        );
         $this->assertSame(
             [$contacteRelacionat],
             $resultat->first()->relacionadas->first()->contactos->all()

--- a/tests/Unit/Application/Colaboracion/ColaboracionQueryServiceTest.php
+++ b/tests/Unit/Application/Colaboracion/ColaboracionQueryServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Colaboracion;
+
+use Illuminate\Support\Collection;
+use Intranet\Application\Colaboracion\ColaboracionQueryService;
+use Intranet\Entities\Activity;
+use Intranet\Entities\Colaboracion;
+use Tests\TestCase;
+
+class ColaboracionQueryServiceTest extends TestCase
+{
+    /**
+     * Verifica que el servici hidrata els contactes de la col·laboració principal
+     * i també de les relacionades, evitant consultes posteriors des de Blade.
+     */
+    public function test_attach_related_and_contacts_hidrata_contactes_principals_i_relacionats(): void
+    {
+        $service = new ColaboracionQueryService();
+
+        $meua = new Colaboracion();
+        $meua->id = 1;
+        $meua->idCentro = 10;
+        $meua->empresa = 'Empresa A';
+        $meua->setRelation('Ciclo', (object) ['departamento' => 'INF']);
+
+        $relacionada = new Colaboracion();
+        $relacionada->id = 2;
+        $relacionada->idCentro = 10;
+        $relacionada->empresa = 'Empresa A';
+        $relacionada->setRelation('Ciclo', (object) ['departamento' => 'INF']);
+
+        $contacteMeu = new Activity();
+        $contacteMeu->id = 101;
+
+        $contacteRelacionat = new Activity();
+        $contacteRelacionat->id = 202;
+
+        $activitiesByColab = new Collection([
+            1 => collect([$contacteMeu]),
+            2 => collect([$contacteRelacionat]),
+        ]);
+
+        $resultat = $service->attachRelatedAndContacts(
+            collect([$meua]),
+            collect([$relacionada]),
+            $activitiesByColab
+        );
+
+        $this->assertCount(1, $resultat);
+        $this->assertSame([$contacteMeu], $resultat->first()->contactos->all());
+        $this->assertCount(1, $resultat->first()->relacionadas);
+        $this->assertSame(
+            [$contacteRelacionat],
+            $resultat->first()->relacionadas->first()->contactos->all()
+        );
+    }
+}


### PR DESCRIPTION
## Resum

Esta PR reordena  per a fer-la més escanejable i menys acoblada a consultes en Blade.

## Canvis principals

- prepara  i  en backend per a evitar consultes d' des de la vista
- simplifica la vista principal a una sola llista per pestanya
- redissenya la targeta amb resum curt, activitat recent lateral i blocs plegables de detall/relacionades
- activa la primera pestanya per defecte quan cap ve marcada com a activa
- poleix la targeta amb agrupació visual per poble i millor disposició d'accions

## Verificació

- 
   PASS  Tests\Unit\Application\Colaboracion\ColaboracionQueryServiceTest
  ✓ attach related and contacts hidrata contactes principals i relacion… 0.23s  

  Tests:    1 passed (6 assertions)
  Duration: 0.67s

## Notes

- no inclou encara la fase de desacoblament del JS de col·laboracions
- Livewire queda fora d'esta PR