### PR TITLE
[MOD] Afig detall modal per a les col·laboracions

### DIFF
--- a/app/Http/Controllers/ColaboracionController.php
+++ b/app/Http/Controllers/ColaboracionController.php
@@ -13,6 +13,7 @@ use Intranet\Http\Requests\ColaboracionRequest;
 use Intranet\Http\Traits\Autorizacion;
 use Intranet\Presentation\Crud\ColaboracionCrudSchema;
 use Intranet\Services\Document\PdfFormService;
+use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Response;
 
@@ -147,12 +148,17 @@ class ColaboracionController extends ModalController
 
 
     /**
-     * @param $id
+     * Mostra el detall de la col·laboració.
+     *
+     * Manté l'accés directe per URL i, quan la petició arriba en mode modal,
+     * retorna només el parcial del contingut per incrustar-lo al diàleg.
+     *
+     * @param Request $request
+     * @param int|string $id
      * @throws NotFoundDomainException
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\RedirectResponse|\Illuminate\View\View
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-
-    public function show($id)
+    public function show(Request $request, $id)
     {
         $elemento = $this->findModelOrFail(
             Colaboracion::class,
@@ -160,7 +166,26 @@ class ColaboracionController extends ModalController
             'Col·laboració no trobada',
             ['colaboracion_id' => $id]
         );
-        return redirect(route('empresa.detalle',$elemento->Centro->idEmpresa));
+
+        $elemento->loadMissing([
+            'Centro.Empresa',
+            'Centro.instructores',
+            'Ciclo',
+            'Propietario',
+        ]);
+
+        $ultimContacte = Activity::query()
+            ->modelo('Colaboracion')
+            ->id($elemento->id)
+            ->notUpdate()
+            ->latest('created_at')
+            ->first();
+
+        if ($request->boolean('modal') || $request->ajax()) {
+            return view('colaboracion.partials.show', compact('elemento', 'ultimContacte'));
+        }
+
+        return view('colaboracion.show', compact('elemento', 'ultimContacte'));
     }
 
     public function printAnexeIV($colaboracion)

--- a/public/js/Colaboracion/modal.js
+++ b/public/js/Colaboracion/modal.js
@@ -1,15 +1,84 @@
 'use strict';
 
 (function () {
-    document.addEventListener('DOMContentLoaded', function () {
-        var formFct = document.getElementById('formFct');
-        if (!formFct) {
+    function showModal(id) {
+        if (window.intranetUiHelpers && typeof window.intranetUiHelpers.showModal === 'function') {
+            window.intranetUiHelpers.showModal(id);
             return;
         }
 
+        var modalElement = document.getElementById(id);
+        if (!modalElement) {
+            return;
+        }
+
+        if (window.bootstrap && window.bootstrap.Modal) {
+            window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
+        }
+    }
+
+    function fillColaboracionShowModal(html, title) {
+        var campos = document.getElementById('campos');
+        var modal = document.getElementById('show');
+        if (!campos || !modal) {
+            return;
+        }
+
+        var dialog = modal.querySelector('.modal-dialog');
+        if (dialog) {
+            dialog.className = 'modal-dialog modal-xl';
+        }
+
+        var titleNode = modal.querySelector('.modal-title');
+        if (titleNode) {
+            titleNode.textContent = title || 'Detall col·laboració';
+        }
+
+        campos.innerHTML = html;
+        showModal('show');
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var formFct = document.getElementById('formFct');
+
         document.addEventListener('click', function (event) {
+            var showTrigger = event.target.closest('.js-colaboracion-show');
+            if (showTrigger) {
+                event.preventDefault();
+
+                var url = showTrigger.getAttribute('href');
+                if (!url) {
+                    return;
+                }
+
+                var separator = url.indexOf('?') === -1 ? '?' : '&';
+                fetch(url + separator + 'modal=1', {
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest'
+                    }
+                })
+                    .then(function (response) {
+                        if (!response.ok) {
+                            throw new Error("No s'ha pogut carregar el detall");
+                        }
+                        return response.text();
+                    })
+                    .then(function (html) {
+                        fillColaboracionShowModal(
+                            html,
+                            showTrigger.getAttribute('data-show-title')
+                        );
+                    })
+                    .catch(function (error) {
+                        console.error(error);
+                        window.location.href = url;
+                    });
+
+                return;
+            }
+
             var trigger = event.target.closest('.fa-plus');
-            if (!trigger) {
+            if (!trigger || !formFct) {
                 return;
             }
 

--- a/resources/views/colaboracion/partials/show.blade.php
+++ b/resources/views/colaboracion/partials/show.blade.php
@@ -1,0 +1,100 @@
+<div class="row">
+    <div class="col-md-7 col-sm-12">
+        <div class="x_panel">
+            <div class="x_title">
+                <h2>{{ $elemento->Empresa }}</h2>
+                <div class="clearfix"></div>
+            </div>
+            <div class="x_content">
+                <p class="mb-3">
+                    <span class="badge bg-info-subtle text-dark border">
+                        {{ optional($elemento->Ciclo)->literal ?? 'Sense cicle' }}
+                    </span>
+                </p>
+
+                <ul class="list-unstyled user_data">
+                    <li>
+                        <em class="fa fa-map-marker user-profile-icon"></em>
+                        {{ $elemento->Centro->nombre }} / {{ $elemento->Centro->localidad }}
+                    </li>
+                    <li>
+                        <em class="fa fa-user user-profile-icon"></em>
+                        {{ $elemento->contacto ?: 'Sense contacte' }}
+                    </li>
+                    <li>
+                        <em class="fa fa-phone user-profile-icon"></em>
+                        {{ $elemento->telefono ?: 'Sense telèfon' }}
+                    </li>
+                    <li>
+                        <em class="fa fa-envelope user-profile-icon"></em>
+                        {{ $elemento->email ?: 'Sense email' }}
+                    </li>
+                    <li>
+                        <em class="fa fa-clock-o user-profile-icon"></em>
+                        {{ $elemento->Centro->horarios ?: 'Sense horari' }}
+                    </li>
+                    <li>
+                        <em class="fa fa-user-secret user-profile-icon"></em>
+                        {{ $elemento->profesor ?: 'Sense professor assignat' }}
+                    </li>
+                    <li>
+                        <em class="fa fa-suitcase user-profile-icon"></em>
+                        {{ $elemento->puestos }} lloc(s) de treball
+                    </li>
+                    <li>
+                        <em class="fa fa-file-text-o user-profile-icon"></em>
+                        {{ $elemento->Xestado ?: 'Sense estat' }}
+                    </li>
+                </ul>
+
+                @if ($ultimContacte)
+                    <hr/>
+                    <h4>Últim seguiment</h4>
+                    <p class="mb-1">
+                        <strong>{{ $ultimContacte->document ?: $ultimContacte->action }}</strong>
+                        · {{ $ultimContacte->created_at?->format('d/m/Y H:i') }}
+                    </p>
+                    @if (!empty($ultimContacte->comentari))
+                        <p class="text-muted">{{ $ultimContacte->comentari }}</p>
+                    @endif
+                @endif
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-5 col-sm-12">
+        <div class="x_panel">
+            <div class="x_title">
+                <h2>Instructors</h2>
+                <div class="clearfix"></div>
+            </div>
+            <div class="x_content">
+                @forelse ($elemento->Centro->instructores->sortBy('surnames') as $instructor)
+                    <div class="mb-3 pb-2" style="border-bottom: 1px solid #ececec;">
+                        <div><strong>{{ $instructor->nombre }}</strong></div>
+                        <div class="small text-muted">{{ $instructor->dni }}</div>
+                        <div class="small">{{ $instructor->email ?: 'Sense email' }}</div>
+                        <div class="small">{{ $instructor->telefono ?: 'Sense telèfon' }}</div>
+                    </div>
+                @empty
+                    <p class="text-muted mb-0">Sense instructors associats al centre.</p>
+                @endforelse
+            </div>
+        </div>
+
+        <div class="x_panel">
+            <div class="x_title">
+                <h2>Empresa</h2>
+                <div class="clearfix"></div>
+            </div>
+            <div class="x_content">
+                <p class="mb-2"><strong>{{ $elemento->Centro->Empresa->nombre }}</strong></p>
+                <p class="text-muted">{{ $elemento->Centro->Empresa->cif ?: '' }}</p>
+                <a href="{{ route('empresa.detalle', ['empresa' => $elemento->Centro->idEmpresa]) }}"
+                   class="btn btn-primary btn-sm">
+                    <em class="fa fa-building"></em> Anar a l'empresa
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/colaboracion/show.blade.php
+++ b/resources/views/colaboracion/show.blade.php
@@ -1,0 +1,9 @@
+<x-layouts.app :title="'Detall col·laboració ' . ($elemento->Empresa ?? $elemento->id)">
+    <div class="mb-3">
+        <a href="{{ route('colaboracion.index') }}" class="btn btn-default btn-sm">
+            <em class="fa fa-arrow-left"></em> Tornar a col·laboracions
+        </a>
+    </div>
+
+    @include('colaboracion.partials.show')
+</x-layouts.app>

--- a/resources/views/intranet/partials/colaboracion/departamento.blade.php
+++ b/resources/views/intranet/partials/colaboracion/departamento.blade.php
@@ -60,12 +60,16 @@
 
     <div class="mb-3">
         <label for="colaboracion-town-filter" class="form-label fw-semibold">Filtrar per poble</label>
-        <select id="colaboracion-town-filter" class="form-control">
-            <option value="">Tots els pobles</option>
+        <input id="colaboracion-town-filter"
+               class="form-control"
+               list="colaboracion-town-options"
+               type="search"
+               placeholder="Escriu part del poble">
+        <datalist id="colaboracion-town-options">
             @foreach ($townOptions as $townOption)
-                <option value="{{ $townOption }}">{{ $townOption }}</option>
+                <option value="{{ $townOption }}"></option>
             @endforeach
-        </select>
+        </datalist>
     </div>
 
     @forelse ($townGroups as $localidad => $townItems)
@@ -106,7 +110,8 @@
                                     @endphp
 
                                     <a href="{{ route('colaboracion.show', ['colaboracion' => $elemento->id]) }}"
-                                       class="text-decoration-none text-reset">
+                                       class="js-colaboracion-show text-decoration-none text-reset"
+                                       data-show-title="Detall col·laboració">
                                         <div class="rounded px-2 py-2"
                                              style="border:1px solid #e6e9ed;background:#fbfbfc;">
                                             <div class="d-flex flex-wrap gap-1 mb-1">
@@ -149,15 +154,30 @@
             }
 
             var groups = Array.from(document.querySelectorAll('.colaboracion-town-group'));
+            var normalizeTown = function (value) {
+                return (value || '')
+                    .toString()
+                    .normalize('NFD')
+                    .replace(/[\u0300-\u036f]/g, '')
+                    .toUpperCase()
+                    .replace(/[0-9]/g, ' ')
+                    .replace(/Y/g, 'I')
+                    .replace(/[^A-Z\s]/g, ' ')
+                    .replace(/\s+/g, ' ')
+                    .trim();
+            };
 
-            filter.addEventListener('change', function () {
-                var selectedTown = filter.value;
+            var applyTownFilter = function () {
+                var selectedTown = normalizeTown(filter.value);
 
                 groups.forEach(function (group) {
-                    var groupTown = group.getAttribute('data-town') || '';
-                    group.style.display = (!selectedTown || groupTown === selectedTown) ? '' : 'none';
+                    var groupTown = normalizeTown(group.getAttribute('data-town') || '');
+                    group.style.display = (!selectedTown || groupTown.indexOf(selectedTown) !== -1) ? '' : 'none';
                 });
-            });
+            };
+
+            filter.addEventListener('input', applyTownFilter);
+            filter.addEventListener('change', applyTownFilter);
         });
     </script>
 @endpush

--- a/resources/views/intranet/partials/profile/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/colaboracion.blade.php
@@ -16,12 +16,17 @@
 
 <div class="col-xs-12 mb-3">
     <label for="{{ $filterId }}" class="form-label fw-semibold">Filtrar per poble</label>
-    <select id="{{ $filterId }}" class="form-control mis-colaboraciones-town-filter" data-target-tab="{{ $tabName }}">
-        <option value="">Tots els pobles</option>
+    <input id="{{ $filterId }}"
+           class="form-control mis-colaboraciones-town-filter"
+           data-target-tab="{{ $tabName }}"
+           list="{{ $filterId }}-options"
+           type="search"
+           placeholder="Escriu part del poble">
+    <datalist id="{{ $filterId }}-options">
         @foreach ($townOptions as $townOption)
-            <option value="{{ $townOption }}">{{ $townOption }}</option>
+            <option value="{{ $townOption }}"></option>
         @endforeach
-    </select>
+    </datalist>
 </div>
 
 @foreach ($elementos as $elemento)
@@ -45,14 +50,27 @@
     @push('scripts')
         <script>
             document.addEventListener('DOMContentLoaded', function () {
+                var normalizeTown = function (value) {
+                    return (value || '')
+                        .toString()
+                        .normalize('NFD')
+                        .replace(/[\u0300-\u036f]/g, '')
+                        .toUpperCase()
+                        .replace(/[0-9]/g, ' ')
+                        .replace(/Y/g, 'I')
+                        .replace(/[^A-Z\s]/g, ' ')
+                        .replace(/\s+/g, ' ')
+                        .trim();
+                };
+
                 document.querySelectorAll('.mis-colaboraciones-town-filter').forEach(function (filter) {
-                    filter.addEventListener('change', function () {
-                        var selectedTown = filter.value;
+                    var applyTownFilter = function () {
+                        var selectedTown = normalizeTown(filter.value);
                         var targetTab = filter.getAttribute('data-target-tab') || '';
 
                         document.querySelectorAll('.mis-colaboraciones-town-group[data-target-tab="' + targetTab + '"]').forEach(function (group) {
-                            var groupTown = group.getAttribute('data-town') || '';
-                            var visible = !selectedTown || groupTown === selectedTown;
+                            var groupTown = normalizeTown(group.getAttribute('data-town') || '');
+                            var visible = !selectedTown || groupTown.indexOf(selectedTown) !== -1;
                             group.style.display = visible ? '' : 'none';
 
                             var next = group.nextElementSibling;
@@ -61,7 +79,10 @@
                                 next = next.nextElementSibling;
                             }
                         });
-                    });
+                    };
+
+                    filter.addEventListener('input', applyTownFilter);
+                    filter.addEventListener('change', applyTownFilter);
                 });
             });
         </script>


### PR DESCRIPTION
## Resum
- recupera un detall propi de la col·laboració sense saltar directament a l'empresa
- obri el detall en modal des del llistat departamental i manté la URL directa com a vista completa
- afegeix cerca tolerant per poble en col·laboracions i misColaboraciones

## Canvis principals
- `ColaboracionController@show` híbrid: vista completa o parcial modal
- nova vista `resources/views/colaboracion/show.blade.php`
- nou parcial `resources/views/colaboracion/partials/show.blade.php`
- JS específic `public/js/Colaboracion/modal.js`
- filtre de poble tolerant en les vistes de col·laboracions

## Verificació
- `php -l app/Http/Controllers/ColaboracionController.php`
- `php -l resources/views/colaboracion/show.blade.php`
- `php -l resources/views/colaboracion/partials/show.blade.php`
- `php -l resources/views/intranet/partials/colaboracion/departamento.blade.php`
- `php -l resources/views/intranet/partials/profile/colaboracion.blade.php`
- `node -c public/js/Colaboracion/modal.js`

Closes #111
