### PR TITLE
[ADD] Afig reserves d'alumnat sobre col·laboracions

### DIFF
--- a/app/Application/Colaboracion/ColaboracionPreasignacionService.php
+++ b/app/Application/Colaboracion/ColaboracionPreasignacionService.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intranet\Application\Colaboracion;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Intranet\Entities\Alumno;
+use Intranet\Entities\Colaboracion;
+use Intranet\Entities\ColaboracionPreasignacion;
+use RuntimeException;
+
+/**
+ * Casos d'ús de preassignació d'alumnat sobre col·laboracions.
+ */
+class ColaboracionPreasignacionService
+{
+    /**
+     * Hidrata el panell amb reserves i opcions d'alumnat disponibles per cicle.
+     *
+     * @param Collection<int, Colaboracion> $colaboraciones
+     * @return Collection<int, Colaboracion>
+     */
+    public function hydrateForPanel(Collection $colaboraciones, ?string $idProfesor = null): Collection
+    {
+        if ($colaboraciones->isEmpty()) {
+            return $colaboraciones;
+        }
+
+        $preasignacionesByColaboracion = ColaboracionPreasignacion::query()
+            ->with(['Alumno.Grupo', 'Profesor'])
+            ->whereIn('idColaboracion', $colaboraciones->pluck('id')->all())
+            ->orderByDesc('created_at')
+            ->get()
+            ->groupBy('idColaboracion');
+
+        $alumnosByCiclo = $this->availableAlumnoOptionsByCiclo(
+            $colaboraciones->pluck('idCiclo')->filter()->unique()->values()->all(),
+            $idProfesor
+        );
+
+        $colaboraciones->each(function (Colaboracion $colaboracion) use ($preasignacionesByColaboracion, $alumnosByCiclo): void {
+            $colaboracion->preasignacionesPanel = $preasignacionesByColaboracion
+                ->get($colaboracion->id, collect())
+                ->values();
+            $colaboracion->preasignacionAlumnoOptions = $alumnosByCiclo
+                ->get((int) $colaboracion->idCiclo, collect());
+        });
+
+        return $colaboraciones;
+    }
+
+    /**
+     * Crea una nova proposta o reserva per a una col·laboració.
+     *
+     * @throws RuntimeException
+     */
+    public function create(
+        int|string $idColaboracion,
+        string $idAlumno,
+        string $idProfesor,
+        string $estado = 'proposta',
+        ?string $observaciones = null
+    ): ColaboracionPreasignacion {
+        if (!in_array($estado, ColaboracionPreasignacion::STATES, true)) {
+            throw new RuntimeException('L\'estat de preassignació no és vàlid.');
+        }
+
+        $colaboracion = Colaboracion::query()->findOrFail($idColaboracion);
+
+        $this->guardDuplicateInColaboracion((int) $colaboracion->id, $idAlumno);
+        $this->guardAlumnoCycleConflict($colaboracion, $idAlumno);
+        $this->guardCapacity($colaboracion, $estado);
+
+        return ColaboracionPreasignacion::query()->create([
+            'idColaboracion' => (int) $colaboracion->id,
+            'idAlumno' => $idAlumno,
+            'idProfesor' => $idProfesor,
+            'estado' => $estado,
+            'observaciones' => $observaciones,
+        ]);
+    }
+
+    /**
+     * Retorna totes les preassignacions d'una col·laboració.
+     *
+     * @return EloquentCollection<int, ColaboracionPreasignacion>
+     */
+    public function byColaboracion(int|string $idColaboracion): EloquentCollection
+    {
+        return ColaboracionPreasignacion::query()
+            ->with(['Alumno', 'Profesor'])
+            ->where('idColaboracion', $idColaboracion)
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    /**
+     * Elimina una preassignació del panell del tutor.
+     *
+     * @throws RuntimeException
+     */
+    public function descartar(int|string $id): void
+    {
+        $preasignacion = ColaboracionPreasignacion::query()->find($id);
+        if (!$preasignacion) {
+            throw new RuntimeException('La preassignació no existeix.');
+        }
+
+        $preasignacion->delete();
+    }
+
+    /**
+     * Marca una reserva com a convertida després de crear la FCT real.
+     *
+     * @throws RuntimeException
+     */
+    public function marcarComConvertida(int|string $id): ColaboracionPreasignacion
+    {
+        $preasignacion = ColaboracionPreasignacion::query()->find($id);
+        if (!$preasignacion) {
+            throw new RuntimeException('La preassignació no existeix.');
+        }
+
+        $preasignacion->estado = 'convertida';
+        $preasignacion->save();
+
+        return $preasignacion->fresh();
+    }
+
+    /**
+     * Retorna opcions d'alumnat agrupades per cicle.
+     *
+     * @param array<int, int|string> $cicloIds
+     * @param string|null $idProfesor
+     * @return Collection<int, Collection<string, string>>
+     */
+    public function availableAlumnoOptionsByCiclo(array $cicloIds, ?string $idProfesor = null): Collection
+    {
+        if ($cicloIds === []) {
+            return collect();
+        }
+
+        $idProfesor = $idProfesor ?: (authUser()->dni ?? null);
+        $reservedAlumnoIdsByCiclo = ColaboracionPreasignacion::query()
+            ->select(['idAlumno', 'idColaboracion'])
+            ->whereIn('estado', ColaboracionPreasignacion::ACTIVE_STATES)
+            ->whereHas('Colaboracion', function ($query) use ($cicloIds): void {
+                $query->whereIn('idCiclo', $cicloIds);
+            })
+            ->with('Colaboracion:id,idCiclo')
+            ->get()
+            ->groupBy(fn (ColaboracionPreasignacion $preasignacion): int => (int) $preasignacion->Colaboracion->idCiclo)
+            ->map(fn (Collection $items): Collection => $items->pluck('idAlumno')->unique()->values());
+
+        $query = Alumno::query()
+            ->with('Grupo:codigo,idCiclo')
+            ->whereHas('Grupo', function ($query) use ($cicloIds): void {
+                $query->whereIn('idCiclo', $cicloIds);
+            });
+
+        if ($idProfesor) {
+            $query->MisAlumnos($idProfesor);
+        }
+
+        return $query
+            ->get()
+            ->flatMap(function (Alumno $alumno) {
+                return $alumno->Grupo
+                    ->pluck('idCiclo')
+                    ->filter()
+                    ->unique()
+                    ->map(function ($idCiclo) use ($alumno) {
+                        return [
+                            'idCiclo' => (int) $idCiclo,
+                            'nia' => (string) $alumno->nia,
+                            'label' => (string) $alumno->fullName,
+                        ];
+                    });
+            })
+            ->groupBy('idCiclo')
+            ->map(function (Collection $items, int $idCiclo) use ($reservedAlumnoIdsByCiclo): Collection {
+                $reservedIds = $reservedAlumnoIdsByCiclo->get($idCiclo, collect());
+
+                return $items
+                    ->reject(fn (array $item): bool => $reservedIds->contains($item['nia']))
+                    ->sortBy('label', SORT_NATURAL | SORT_FLAG_CASE)
+                    ->mapWithKeys(fn (array $item): array => [$item['nia'] => $item['label']]);
+            });
+    }
+
+    /**
+     * Evita duplicats actius per al mateix alumne dins de la mateixa col·laboració.
+     *
+     * @throws RuntimeException
+     */
+    private function guardDuplicateInColaboracion(int $idColaboracion, string $idAlumno): void
+    {
+        $exists = ColaboracionPreasignacion::query()
+            ->where('idColaboracion', $idColaboracion)
+            ->where('idAlumno', $idAlumno)
+            ->whereIn('estado', ColaboracionPreasignacion::ACTIVE_STATES)
+            ->exists();
+
+        if ($exists) {
+            throw new RuntimeException('L\'alumne ja està preassignat en esta col·laboració.');
+        }
+    }
+
+    /**
+     * Evita reserves simultànies del mateix alumne en el mateix cicle.
+     *
+     * @throws RuntimeException
+     */
+    private function guardAlumnoCycleConflict(Colaboracion $colaboracion, string $idAlumno): void
+    {
+        $conflict = ColaboracionPreasignacion::query()
+            ->where('idAlumno', $idAlumno)
+            ->whereIn('estado', ColaboracionPreasignacion::ACTIVE_STATES)
+            ->whereHas('Colaboracion', function ($query) use ($colaboracion): void {
+                $query->where('idCiclo', $colaboracion->idCiclo)
+                    ->where('id', '<>', $colaboracion->id);
+            })
+            ->exists();
+
+        if ($conflict) {
+            throw new RuntimeException('L\'alumne ja té una altra preassignació activa en este cicle.');
+        }
+    }
+
+    /**
+     * Respecta el límit de places ofert per la col·laboració.
+     *
+     * @throws RuntimeException
+     */
+    private function guardCapacity(Colaboracion $colaboracion, string $estado): void
+    {
+        if (!in_array($estado, ColaboracionPreasignacion::ACTIVE_STATES, true)) {
+            return;
+        }
+
+        $activeCount = ColaboracionPreasignacion::query()
+            ->where('idColaboracion', $colaboracion->id)
+            ->whereIn('estado', ColaboracionPreasignacion::ACTIVE_STATES)
+            ->count();
+
+        $puestos = max(1, (int) $colaboracion->puestos);
+
+        if ($activeCount >= $puestos) {
+            throw new RuntimeException('La col·laboració ja no té places lliures per a noves preassignacions.');
+        }
+    }
+}

--- a/app/Application/Colaboracion/ColaboracionService.php
+++ b/app/Application/Colaboracion/ColaboracionService.php
@@ -12,7 +12,10 @@ use Intranet\Entities\Colaboracion;
  */
 class ColaboracionService
 {
-    public function __construct(private readonly ColaboracionQueryService $queryService)
+    public function __construct(
+        private readonly ColaboracionQueryService $queryService,
+        private readonly ColaboracionPreasignacionService $preasignacionService
+    )
     {
     }
 
@@ -32,10 +35,12 @@ class ColaboracionService
             $meves->concat($relacionades)->values()
         );
 
-        return $this->queryService
+        $panel = $this->queryService
             ->attachRelatedAndContacts($meves, $relacionades, $activitiesByColab)
             ->sortBy(static fn ($item) => $item->empresa)
             ->values();
+
+        return $this->preasignacionService->hydrateForPanel($panel, $dni);
     }
 
     /**

--- a/app/Entities/Alumno.php
+++ b/app/Entities/Alumno.php
@@ -82,6 +82,14 @@ class Alumno extends Authenticatable
         return $this->hasMany(AlumnoFct::class, 'idAlumno', 'nia');
     }
 
+    /**
+     * Retorna les preassignacions provisionals d'este alumne.
+     */
+    public function Preasignaciones(): HasMany
+    {
+        return $this->hasMany(ColaboracionPreasignacion::class, 'idAlumno', 'nia');
+    }
+
     public function FctsColaboracion(int $colaboracion): BelongsToMany
     {
         return $this->Fcts()->wherePivot('idColaboracion', $colaboracion);

--- a/app/Entities/Colaboracion.php
+++ b/app/Entities/Colaboracion.php
@@ -3,6 +3,7 @@
 namespace Intranet\Entities;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Intranet\Application\Grupo\GrupoService;
 use Intranet\Entities\Poll\VoteAnt;
 use Intranet\Events\ActivityReport;
@@ -57,6 +58,14 @@ class Colaboracion extends Model
     public function Propietario()
     {
         return $this->belongsTo(Profesor::class, 'tutor', 'dni');
+    }
+
+    /**
+     * Retorna les preassignacions provisionals d'alumnat per a esta col·laboració.
+     */
+    public function Preasignaciones(): HasMany
+    {
+        return $this->hasMany(ColaboracionPreasignacion::class, 'idColaboracion', 'id');
     }
     public function votes()
     {

--- a/app/Entities/ColaboracionPreasignacion.php
+++ b/app/Entities/ColaboracionPreasignacion.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Intranet\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Reserva o preassignació provisional d'un alumne sobre una col·laboració.
+ *
+ * Esta entitat no substituïx la FCT real; només representa el pas previ de
+ * proposta o reserva dins del flux del tutor.
+ */
+class ColaboracionPreasignacion extends Model
+{
+    /**
+     * Estats que compten com a reserva activa de capacitat.
+     *
+     * @var array<int, string>
+     */
+    public const ACTIVE_STATES = ['proposta', 'reservada'];
+
+    /**
+     * Estats disponibles en el primer tall funcional.
+     *
+     * @var array<int, string>
+     */
+    public const STATES = ['proposta', 'reservada', 'descartada', 'convertida'];
+
+    protected $table = 'colaboracion_preasignaciones';
+
+    protected $fillable = [
+        'idColaboracion',
+        'idAlumno',
+        'idProfesor',
+        'estado',
+        'observaciones',
+    ];
+
+    /**
+     * Retorna la col·laboració vinculada.
+     */
+    public function Colaboracion(): BelongsTo
+    {
+        return $this->belongsTo(Colaboracion::class, 'idColaboracion', 'id');
+    }
+
+    /**
+     * Retorna l'alumne preassignat.
+     */
+    public function Alumno(): BelongsTo
+    {
+        return $this->belongsTo(Alumno::class, 'idAlumno', 'nia');
+    }
+
+    /**
+     * Retorna el professor que crea o manté la reserva.
+     */
+    public function Profesor(): BelongsTo
+    {
+        return $this->belongsTo(Profesor::class, 'idProfesor', 'dni');
+    }
+
+    /**
+     * Indica si la preassignació ocupa una plaça de la col·laboració.
+     */
+    public function isActive(): bool
+    {
+        return in_array((string) $this->estado, self::ACTIVE_STATES, true);
+    }
+}

--- a/app/Http/Controllers/PanelColaboracionController.php
+++ b/app/Http/Controllers/PanelColaboracionController.php
@@ -3,6 +3,7 @@
 namespace Intranet\Http\Controllers;
 
 use Intranet\Application\Colaboracion\ColaboracionService;
+use Intranet\Application\Colaboracion\ColaboracionPreasignacionService;
 use Intranet\Application\Grupo\GrupoService;
 use Intranet\Http\Controllers\Core\IntranetController;
 use Intranet\Http\Requests\ColaboracionRequest;
@@ -20,6 +21,7 @@ use Intranet\Presentation\Crud\ColaboracionCrudSchema;
 use Intranet\Http\Traits\Core\Panel;
 use Intranet\Services\UI\AppAlert as Alert;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 /**
  * Class PanelColaboracionController
@@ -31,6 +33,7 @@ class PanelColaboracionController extends IntranetController
 
     private ?GrupoService $grupoService = null;
     private ?ColaboracionService $colaboracionService = null;
+    private ?ColaboracionPreasignacionService $preasignacionService = null;
 
     const ROLES_ROL_TUTOR= 'roles.rol.tutor';
     const FCT_EMAILS_REQUEST = 'fctEmails.request';
@@ -45,11 +48,16 @@ class PanelColaboracionController extends IntranetController
 
     protected $parametresVista = ['modal' => ['contacto',  'seleccion']];
 
-    public function __construct(?GrupoService $grupoService = null, ?ColaboracionService $colaboracionService = null)
+    public function __construct(
+        ?GrupoService $grupoService = null,
+        ?ColaboracionService $colaboracionService = null,
+        ?ColaboracionPreasignacionService $preasignacionService = null
+    )
     {
         parent::__construct();
         $this->grupoService = $grupoService;
         $this->colaboracionService = $colaboracionService;
+        $this->preasignacionService = $preasignacionService;
     }
 
     private function grupos(): GrupoService
@@ -68,6 +76,15 @@ class PanelColaboracionController extends IntranetController
         }
 
         return $this->colaboracionService;
+    }
+
+    private function preasignaciones(): ColaboracionPreasignacionService
+    {
+        if ($this->preasignacionService === null) {
+            $this->preasignacionService = app(ColaboracionPreasignacionService::class);
+        }
+
+        return $this->preasignacionService;
     }
 
 
@@ -258,6 +275,76 @@ class PanelColaboracionController extends IntranetController
     private function showEmpresa($id)
     {
         return redirect()->route('empresa.detalle', ['empresa' => $id]);
+    }
+
+    /**
+     * Guarda una preassignació provisional d'alumnat per a una col·laboració.
+     *
+     * @param Request $request
+     * @param int $id
+     * @throws NotFoundDomainException
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function storePreasignacion(Request $request, int $id)
+    {
+        $colaboracion = $this->findModelOrFail(
+            Colaboracion::class,
+            $id,
+            'Col·laboració no trobada',
+            ['colaboracion_id' => $id]
+        );
+        $this->authorize('update', $colaboracion);
+
+        $this->validate($request, [
+            'idAlumno' => 'required|string',
+            'estado' => 'nullable|string',
+            'observaciones' => 'nullable|string',
+        ]);
+
+        try {
+            $this->preasignaciones()->create(
+                $colaboracion->id,
+                (string) $request->idAlumno,
+                (string) AuthUser()->dni,
+                (string) ($request->estado ?: 'proposta'),
+                $request->observaciones
+            );
+            Alert::success('Preassignació guardada correctament.');
+        } catch (RuntimeException $e) {
+            Alert::warning($e->getMessage());
+        }
+
+        Session::put('pestana', 3);
+        return back();
+    }
+
+    /**
+     * Descarta una preassignació existent des del panell del tutor.
+     *
+     * @param int $id
+     * @throws NotFoundDomainException
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function descartarPreasignacion(int $id)
+    {
+        $preasignacion = $this->wrapNotFound(
+            fn () => \Intranet\Entities\ColaboracionPreasignacion::query()
+                ->with('Colaboracion')
+                ->findOrFail($id),
+            'Preassignació no trobada',
+            ['preasignacion_id' => $id]
+        );
+        $this->authorize('update', $preasignacion->Colaboracion);
+
+        try {
+            $this->preasignaciones()->descartar($preasignacion->id);
+            Alert::success('Preassignació eliminada correctament.');
+        } catch (RuntimeException $e) {
+            Alert::warning($e->getMessage());
+        }
+
+        Session::put('pestana', 3);
+        return back();
     }
 
     /**

--- a/database/migrations/2026_03_20_120000_create_colaboracion_preasignaciones_table.php
+++ b/database/migrations/2026_03_20_120000_create_colaboracion_preasignaciones_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Crea la taula de preassignacions d'alumnat a col·laboracions.
+     */
+    public function up()
+    {
+        Schema::create('colaboracion_preasignaciones', function (Blueprint $table) {
+            $table->charset = 'utf8mb3';
+            $table->collation = 'utf8mb3_unicode_ci';
+            $table->id();
+            $table->unsignedInteger('idColaboracion');
+            $table->string('idAlumno', 8);
+            $table->string('idProfesor', 10);
+            $table->string('estado', 20)->default('proposta');
+            $table->text('observaciones')->nullable();
+            $table->timestamps();
+
+            $table->foreign('idColaboracion')
+                ->references('id')
+                ->on('colaboraciones')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+
+            $table->foreign('idAlumno')
+                ->references('nia')
+                ->on('alumnos')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+
+            $table->foreign('idProfesor')
+                ->references('dni')
+                ->on('profesores')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+
+            $table->index(['idColaboracion', 'estado'], 'col_preasig_colab_estado_idx');
+            $table->index(['idAlumno', 'estado'], 'col_preasig_alumno_estado_idx');
+        });
+    }
+
+    /**
+     * Elimina la taula de preassignacions.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('colaboracion_preasignaciones');
+    }
+};

--- a/docs/sprints/sprint-13-preasignacion-colaboraciones-plan.md
+++ b/docs/sprints/sprint-13-preasignacion-colaboraciones-plan.md
@@ -1,0 +1,138 @@
+# Sprint 13 - Preassignació d'alumnat a col·laboracions
+
+## Objectiu
+
+Permetre reservar o preassignar un o més alumnes a una col·laboració abans de crear la FCT definitiva, sense embrutar la taula `fcts` ni barrejar reserves amb pràctiques ja formalitzades.
+
+## Diagnòstic actual
+
+- [`Colaboracion`](/Users/igomis/Code/intranetBatoi/app/Entities/Colaboracion.php) representa la relació `centre + cicle`.
+- [`FctController@store`](/Users/igomis/Code/intranetBatoi/app/Http/Controllers/FctController.php) crea o reutilitza una `Fct` i després hi enganxa alumnat.
+- [`FctService`](/Users/igomis/Code/intranetBatoi/app/Application/Fct/FctService.php) treballa sempre sobre FCT real, no sobre un estat previ.
+- [`PanelColaboracionController`](/Users/igomis/Code/intranetBatoi/app/Http/Controllers/PanelColaboracionController.php) i les vistes de `misColaboraciones` ja són el punt natural per a mostrar reserves, perquè és on el tutor gestiona l’estat de cada col·laboració.
+- [`ColaboracionAlumnoController`](/Users/igomis/Code/intranetBatoi/app/Http/Controllers/ColaboracionAlumnoController.php) existeix, però és un panell legacy de consulta per a alumnat; no resol la necessitat de preassignació per al tutor.
+
+## Decisió d'arquitectura
+
+La preassignació ha de ser una capa nova i explícita.
+
+No farem:
+- esborranys en `fcts`
+- reutilitzar `AlumnoFct` com a reserva
+- guardar alumnat provisional dins de `colaboraciones`
+
+Sí farem:
+- una taula nova de reserves o preassignacions
+- un model propi
+- un flux separat de la FCT final
+
+## Model proposat
+
+Nom de treball recomanat:
+- `ColaboracionPreasignacion`
+
+Taula proposada:
+- `colaboracion_preasignaciones`
+
+Camps mínims:
+- `id`
+- `idColaboracion`
+- `idAlumno`
+- `idProfesor`
+- `estado`
+- `observaciones`
+- `created_at`
+- `updated_at`
+
+## Estats inicials
+
+Per al primer tall, millor pocs estats i clars:
+- `proposta`
+- `reservada`
+- `descartada`
+- `convertida`
+
+`confirmada` es podria afegir més avant si realment apareix una diferència funcional entre “reservada” i “ja acordada amb empresa”.
+
+## Regles funcionals
+
+- una col·laboració pot tindre zero, una o més preassignacions
+- no es pot duplicar el mateix alumne en la mateixa col·laboració
+- cal advertir si el mateix alumne ja està reservat en una altra col·laboració del mateix cicle
+- el sistema ha de respectar `puestos` com a límit tou
+  - primer tall: avisar i bloquejar si se supera
+- una preassignació `convertida` ja no s’edita com a reserva normal
+- les col·laboracions han d'estar com a col·labora per poder ser seleccionades 
+
+## Flux recomanat
+
+### Tall A - Base de dades i domini
+
+- crear migració `colaboracion_preasignaciones`
+- crear model [`ColaboracionPreasignacion`](/Users/igomis/Code/intranetBatoi/app/Entities)
+- afegir relació en [`Colaboracion`](/Users/igomis/Code/intranetBatoi/app/Entities/Colaboracion.php)
+- afegir relació mínima des d’`Alumno` o entitat equivalent
+
+### Tall B - Servei d’aplicació
+
+- crear servei nou, per exemple:
+  - `app/Application/Colaboracion/ColaboracionPreasignacionService.php`
+- responsabilitats:
+  - crear reserva
+  - llistar reserves d’una col·laboració
+  - descartar reserva
+  - convertir reserva a FCT
+  - validar conflictes per alumne/cicle
+
+### Tall C - UI tutor en col·laboracions
+
+- afegir botó `Preassignar alumnat` des de `misColaboraciones`
+- modal simple amb:
+  - selector d’alumne
+  - observacions
+  - estat inicial
+- en el detall de la col·laboració, mostrar:
+  - reserves actuals
+  - estat
+  - qui les ha fet
+
+Estat actual del Tall C:
+- el panell ja hidrata preassignacions i opcions d’alumnat des de backend
+- `misColaboraciones` ja mostra el llistat de preassignacions per col·laboració
+- el tutor ja pot crear i descartar preassignacions des del panell
+- pendent encara un tall curt de poliment/validació funcional sobre la UI
+
+### Tall D - Conversió a FCT
+
+En standBy: de moment no cal 
+
+- afegir acció `Convertir a FCT`
+- reutilitzar el flux d’`FctController`/`FctService`
+- quan es convertisca:
+  - crear o reutilitzar la FCT segons la signatura actual
+  - vincular alumnat
+  - marcar la preassignació com a `convertida`
+
+## Fora d’abast inicial
+
+- assignació múltiple massiva
+- Livewire nou per a tot el mòdul
+- sincronització automàtica amb `puestos` lliures/ocupats en temps real
+- dashboard d’estadístiques de reserves
+
+## Riscos
+
+- col·lisió conceptual amb el flux existent de creació de FCT
+- ús ambigu del camp `tutor` de `Colaboracion`
+- possibles duplicitats si un alumne ja té FCT real al mateix cicle
+
+## Primer tall recomanat
+
+Començar per `Tall A + Tall B`:
+- domini
+- migració
+- model
+- servei
+- proves unitàries de regles
+
+Després, quan això estiga estable, entrar a la UI del tutor.

--- a/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
+++ b/resources/views/intranet/partials/profile/partials/colaboracion.blade.php
@@ -13,8 +13,25 @@
     };
     $collapseId = 'colaboracion-detall-' . $elemento->id;
     $relatedCollapseId = 'colaboracion-relacionades-' . $elemento->id;
+    $preasignacionesCollapseId = 'colaboracion-preasignaciones-' . $elemento->id;
+    $preasignacionModalId = 'preasignacion_' . $elemento->id;
     $ultimContacte = $elemento->ultimaActividad ?? null;
     $relacionadas = $elemento->relacionadas ?? collect();
+    $preasignaciones = $elemento->preasignacionesPanel ?? collect();
+    $preasignacionAlumnoOptions = $elemento->preasignacionAlumnoOptions ?? collect();
+    $canPreassign = isset($pestana) && $pestana->getNombre() === 'colabora';
+    $activePreasignacionesCount = $preasignaciones
+        ->whereIn('estado', ['proposta', 'reservada'])
+        ->count();
+    $hasPreasignacionCapacity = $activePreasignacionesCount < max(1, (int) ($elemento->puestos ?? 1));
+    $preasignacionBadgeClass = static function (string $estado): string {
+        return match ($estado) {
+            'reservada' => 'bg-success',
+            'convertida' => 'bg-primary',
+            'descartada' => 'bg-danger',
+            default => 'bg-warning text-dark',
+        };
+    };
 @endphp
 <div class="col-md-4 col-sm-4 col-xs-12 profile_details">
     <div id="{{$elemento->id}}" class="well profile_view"
@@ -55,6 +72,13 @@
                             aria-controls="{{ $collapseId }}">
                         Més detall
                     </button>
+                    @if ($preasignaciones->isNotEmpty() || $canPreassign)
+                        <button class="btn btn-default btn-xs" type="button" data-bs-toggle="collapse"
+                                data-bs-target="#{{ $preasignacionesCollapseId }}" aria-expanded="false"
+                                aria-controls="{{ $preasignacionesCollapseId }}">
+                            Reserves ({{ $activePreasignacionesCount }}/{{ max(1, (int) ($elemento->puestos ?? 1)) }})
+                        </button>
+                    @endif
                     @if($relacionadas->isNotEmpty())
                         <button class="btn btn-default btn-xs" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#{{ $relatedCollapseId }}" aria-expanded="false"
@@ -86,6 +110,50 @@
                         <li><em class="fa fa-envelope"></em> {{$elemento->Centro->Empresa->email}}</li>
                 @endisset
                     </ul>
+                </div>
+
+                <div class="collapse" id="{{ $preasignacionesCollapseId }}">
+                    @if ($preasignaciones->isEmpty())
+                        <p class="small text-muted">Encara no hi ha cap alumne preassignat.</p>
+                    @else
+                        <ul class="list-unstyled">
+                            @foreach ($preasignaciones as $preasignacion)
+                                <li class="preasignacion-item" style="margin-bottom:.5rem">
+                                    <div class="d-flex justify-content-between align-items-start gap-2">
+                                        <div>
+                                            <strong>{{ optional($preasignacion->Alumno)->fullName ?? $preasignacion->idAlumno }}</strong>
+                                            <span class="badge {{ $preasignacionBadgeClass((string) $preasignacion->estado) }}">
+                                                {{ ucfirst((string) $preasignacion->estado) }}
+                                            </span>
+                                            <div class="text-muted">
+                                                {{ data_get($preasignacion, 'Alumno.Grupo.0.codigo', 'Sense grup') }}
+                                                ·
+                                                {{ optional($preasignacion->Profesor)->shortName ?? $preasignacion->idProfesor }}
+                                            </div>
+                                            @if (optional($preasignacion->Alumno)->nia)
+                                                <div>
+                                                    <a href="{{ route('alumno.days', ['id' => $preasignacion->Alumno->nia]) }}"
+                                                       class="preasignacion-horari-link">
+                                                        <em class="fa fa-calendar"></em> Horari
+                                                    </a>
+                                                </div>
+                                            @endif
+                                            @if (!empty($preasignacion->observaciones))
+                                                <div>{{ $preasignacion->observaciones }}</div>
+                                            @endif
+                                        </div>
+                                        @if (in_array((string) $preasignacion->estado, ['proposta', 'reservada'], true))
+                                            <a href="{{ route('colaboracion.preasignacion.descartar', ['id' => $preasignacion->id]) }}"
+                                               class="btn btn-default btn-xs"
+                                               onclick="return confirm('Segur que vols descartar esta preassignació?');">
+                                                <em class="fa fa-times"></em>
+                                            </a>
+                                        @endif
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
                 </div>
             </div>
 
@@ -148,6 +216,17 @@
             <div class="col-xs-12 emphasis">
                 @isset (authUser()->emailItaca)
                     <div class="d-flex flex-wrap justify-content-center gap-1">
+                        @if ($canPreassign)
+                            <button type="button"
+                                    class="btn btn-info btn-xs"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#{{ $preasignacionModalId }}"
+                                    @disabled($preasignacionAlumnoOptions->isEmpty() || !$hasPreasignacionCapacity)
+                                    title="{{ !$hasPreasignacionCapacity ? 'Ja no queden llocs lliures en esta col·laboració' : ($preasignacionAlumnoOptions->isEmpty() ? 'No hi ha alumnat disponible per a este cicle' : 'Reservar alumnat') }}"
+                                    style="{{ $hasPreasignacionCapacity ? '' : 'display:none;' }}">
+                                <em class="fa fa-user-plus"></em> Reservar
+                            </button>
+                        @endif
                         <x-botones :panel="$panel" tipo="profile" :elemento="$elemento ?? null" :centrado="false" />
                         <x-botones :panel="$panel" tipo="nofct" :elemento="$elemento ?? null" :centrado="false" />
                     </div>
@@ -156,3 +235,36 @@
         </div>
     </div>
 </div>
+
+@if ($canPreassign)
+    <x-modal name="{{ $preasignacionModalId }}"
+             title="Reservar alumnat"
+             action="{{ route('colaboracion.preasignacion.store', ['colaboracion' => $elemento->id]) }}"
+             message="{{ $preasignacionAlumnoOptions->isEmpty() || !$hasPreasignacionCapacity ? '' : 'Guardar' }}">
+        <input type="hidden" name="estado" value="proposta">
+
+        @if (!$hasPreasignacionCapacity)
+            <p class="text-muted mb-0">Ja no queden llocs lliures per a reservar més alumnat.</p>
+        @elseif ($preasignacionAlumnoOptions->isEmpty())
+            <p class="text-muted mb-0">No hi ha alumnat disponible del teu grup de tutoria per a este cicle.</p>
+        @else
+            <div class="form-group">
+                <label for="preasignacion-alumno-{{ $elemento->id }}">Alumne</label>
+                <select id="preasignacion-alumno-{{ $elemento->id }}" name="idAlumno" class="form-control" required>
+                    <option value="">Selecciona alumnat del teu grup</option>
+                    @foreach ($preasignacionAlumnoOptions as $nia => $label)
+                        <option value="{{ $nia }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label for="preasignacion-observaciones-{{ $elemento->id }}">Observacions</label>
+                <textarea id="preasignacion-observaciones-{{ $elemento->id }}"
+                          name="observaciones"
+                          class="form-control"
+                          rows="3"></textarea>
+            </div>
+        @endif
+    </x-modal>
+@endif

--- a/routes/profesor.php
+++ b/routes/profesor.php
@@ -284,6 +284,8 @@ Route::get('/colaboracion/{colaboracion}/edit', [
 Route::get('/colaboracion/{colaboracion}/copy', ['as' => 'colaboracion.copy', 'uses' => 'PanelColaboracionController@copy']);
 Route::post('/colaboracion/create', ['as' => 'colaboracion.store', 'uses' => 'PanelColaboracionController@store']);
 Route::get('/colaboracion/{colaboracion}/delete', ['as' => 'colaboracion.destroy', 'uses' => 'PanelColaboracionController@destroy']);
+Route::post('/colaboracion/{colaboracion}/preasignacion', ['as' => 'colaboracion.preasignacion.store', 'uses' => 'PanelColaboracionController@storePreasignacion']);
+Route::get('/colaboracion/preasignacion/{id}/descartar', ['as' => 'colaboracion.preasignacion.descartar', 'uses' => 'PanelColaboracionController@descartarPreasignacion']);
 
 
 Route::resource('/fct', 'FctController', ['except' => ['destroy', 'update', 'show','index']]);

--- a/tests/Feature/ComisionDireccionPanelTest.php
+++ b/tests/Feature/ComisionDireccionPanelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Intranet\Entities\Profesor;
@@ -150,6 +151,9 @@ class ComisionDireccionPanelTest extends TestCase
 
     public function test_editar_i_guardar_edicio_actualitza_la_comissio_des_del_component(): void
     {
+        $desde = Carbon::tomorrow()->addDay()->setTime(9, 30);
+        $hasta = (clone $desde)->setTime(11, 45);
+
         $component = Livewire::actingAs($this->direccionUser(), 'profesor')
             ->test(ComisionDireccionPanel::class);
 
@@ -157,8 +161,8 @@ class ComisionDireccionPanelTest extends TestCase
             ->assertSet('editComisionId', 1)
             ->assertSet('editProfessorName', 'Maria Garcia Lopez');
 
-        $component->set('editDesde', '2026-03-20T09:30')
-            ->set('editHasta', '2026-03-20T11:45')
+        $component->set('editDesde', $desde->format('Y-m-d\\TH:i'))
+            ->set('editHasta', $hasta->format('Y-m-d\\TH:i'))
             ->set('editServicio', 'Servei editat')
             ->set('editGastos', '18.50')
             ->set('editKilometraje', '25')
@@ -172,8 +176,8 @@ class ComisionDireccionPanelTest extends TestCase
 
         $updated = DB::connection('sqlite')->table('comisiones')->where('id', 1)->first();
         $this->assertSame('Servei editat', $updated->servicio);
-        $this->assertSame('2026-03-20 09:30', $updated->desde);
-        $this->assertSame('2026-03-20 11:45', $updated->hasta);
+        $this->assertSame($desde->format('Y-m-d H:i'), $updated->desde);
+        $this->assertSame($hasta->format('Y-m-d H:i'), $updated->hasta);
         $this->assertSame('Seat', $updated->marca);
         $this->assertSame('1234ABC', $updated->matricula);
         $this->assertSame('Alcoi - València', $updated->itinerario);

--- a/tests/Unit/Application/Colaboracion/ColaboracionPreasignacionServiceTest.php
+++ b/tests/Unit/Application/Colaboracion/ColaboracionPreasignacionServiceTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Colaboracion;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Intranet\Application\Colaboracion\ColaboracionPreasignacionService;
+use Intranet\Entities\ColaboracionPreasignacion;
+use RuntimeException;
+use Tests\TestCase;
+
+class ColaboracionPreasignacionServiceTest extends TestCase
+{
+    private string $sqlitePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sqlitePath = storage_path('colaboracion_preasignacion_service_testing.sqlite');
+        if (file_exists($this->sqlitePath)) {
+            @unlink($this->sqlitePath);
+        }
+
+        touch($this->sqlitePath);
+        config(['database.default' => 'sqlite']);
+        config(['database.connections.sqlite.database' => $this->sqlitePath]);
+
+        DB::setDefaultConnection('sqlite');
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createSchema();
+        $this->seedBaseData();
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::connection('sqlite')->dropIfExists('colaboracion_preasignaciones');
+        Schema::connection('sqlite')->dropIfExists('alumnos_grupos');
+        Schema::connection('sqlite')->dropIfExists('grupos');
+        Schema::connection('sqlite')->dropIfExists('colaboraciones');
+        Schema::connection('sqlite')->dropIfExists('alumnos');
+        Schema::connection('sqlite')->dropIfExists('profesores');
+
+        if (file_exists($this->sqlitePath)) {
+            @unlink($this->sqlitePath);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Crea una proposta vàlida i la deixa vinculada a alumne, professor i col·laboració.
+     */
+    public function test_create_crea_una_preasignacio_valida(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $preasignacion = $service->create(1, 'ALU001', 'PROF001', 'proposta', 'Primera proposta');
+
+        $this->assertInstanceOf(ColaboracionPreasignacion::class, $preasignacion);
+        $this->assertSame('ALU001', $preasignacion->idAlumno);
+        $this->assertSame('PROF001', $preasignacion->idProfesor);
+        $this->assertSame('proposta', $preasignacion->estado);
+        $this->assertSame(1, DB::connection('sqlite')->table('colaboracion_preasignaciones')->count());
+    }
+
+    /**
+     * Evita repetir una reserva activa del mateix alumne en la mateixa col·laboració.
+     */
+    public function test_create_rebutja_duplicat_en_la_mateixa_colaboracio(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $service->create(1, 'ALU001', 'PROF001');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('L\'alumne ja està preassignat en esta col·laboració.');
+
+        $service->create(1, 'ALU001', 'PROF001');
+    }
+
+    /**
+     * Evita ocupar més places de les que oferix la col·laboració.
+     */
+    public function test_create_rebutja_quan_no_queden_places_lliures(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $service->create(1, 'ALU001', 'PROF001');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('La col·laboració ja no té places lliures per a noves preassignacions.');
+
+        $service->create(1, 'ALU002', 'PROF001');
+    }
+
+    /**
+     * Evita reservar simultàniament el mateix alumne en un altre centre del mateix cicle.
+     */
+    public function test_create_rebutja_conflicte_del_mateix_alumne_en_el_mateix_cicle(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $service->create(1, 'ALU001', 'PROF001');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('L\'alumne ja té una altra preassignació activa en este cicle.');
+
+        $service->create(2, 'ALU001', 'PROF001');
+    }
+
+    /**
+     * Eliminar una reserva allibera la plaça i permet tornar a crear-la.
+     */
+    public function test_descartar_elimina_la_reserva_i_permet_tornar_a_crear(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $preasignacion = $service->create(1, 'ALU001', 'PROF001');
+        $service->descartar($preasignacion->id);
+
+        $nova = $service->create(1, 'ALU001', 'PROF001', 'proposta', 'Nova proposta');
+
+        $this->assertSame('proposta', $nova->estado);
+        $this->assertSame(1, DB::connection('sqlite')->table('colaboracion_preasignaciones')->count());
+    }
+
+    /**
+     * Hidrata el panell amb reserves existents i opcions d'alumnat del cicle.
+     */
+    public function test_hydrate_for_panel_adjunta_preasignaciones_i_opcions_per_cicle(): void
+    {
+        $service = new ColaboracionPreasignacionService();
+
+        $service->create(1, 'ALU001', 'PROF001', 'proposta', 'Primera proposta');
+
+        $panel = $service->hydrateForPanel(collect([
+            \Intranet\Entities\Colaboracion::query()->findOrFail(1),
+        ]));
+
+        /** @var \Intranet\Entities\Colaboracion $colaboracion */
+        $colaboracion = $panel->first();
+
+        $this->assertCount(1, $colaboracion->preasignacionesPanel);
+        $this->assertSame('ALU001', $colaboracion->preasignacionesPanel->first()->idAlumno);
+        $this->assertSame(
+            ['ALU002'],
+            $colaboracion->preasignacionAlumnoOptions->keys()->all()
+        );
+    }
+
+    /**
+     * Crea l'esquema mínim per a provar el servici sobre sqlite.
+     */
+    private function createSchema(): void
+    {
+        Schema::connection('sqlite')->create('profesores', function (Blueprint $table): void {
+            $table->string('dni')->primary();
+            $table->string('nombre')->nullable();
+            $table->string('apellido1')->nullable();
+            $table->string('apellido2')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('sqlite')->create('alumnos', function (Blueprint $table): void {
+            $table->string('nia')->primary();
+            $table->string('nombre')->nullable();
+            $table->string('apellido1')->nullable();
+            $table->string('apellido2')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('sqlite')->create('grupos', function (Blueprint $table): void {
+            $table->string('codigo')->primary();
+            $table->unsignedInteger('idCiclo');
+            $table->timestamps();
+        });
+
+        Schema::connection('sqlite')->create('alumnos_grupos', function (Blueprint $table): void {
+            $table->string('idAlumno');
+            $table->string('idGrupo');
+        });
+
+        Schema::connection('sqlite')->create('colaboraciones', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idCentro')->nullable();
+            $table->unsignedInteger('idCiclo');
+            $table->string('contacto')->nullable();
+            $table->string('telefono')->nullable();
+            $table->string('email')->nullable();
+            $table->unsignedInteger('puestos')->default(1);
+            $table->string('tutor')->nullable();
+            $table->unsignedInteger('estado')->default(1);
+            $table->timestamps();
+        });
+
+        Schema::connection('sqlite')->create('colaboracion_preasignaciones', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idColaboracion');
+            $table->string('idAlumno');
+            $table->string('idProfesor');
+            $table->string('estado', 20)->default('proposta');
+            $table->text('observaciones')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Carrega dades mínimes per a les proves de regles de preassignació.
+     */
+    private function seedBaseData(): void
+    {
+        DB::connection('sqlite')->table('profesores')->insert([
+            'dni' => 'PROF001',
+            'nombre' => 'Tutor',
+            'apellido1' => 'Prova',
+            'apellido2' => 'Un',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('sqlite')->table('alumnos')->insert([
+            [
+                'nia' => 'ALU001',
+                'nombre' => 'Alumne',
+                'apellido1' => 'Primer',
+                'apellido2' => 'Prova',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'nia' => 'ALU002',
+                'nombre' => 'Alumne',
+                'apellido1' => 'Segon',
+                'apellido2' => 'Prova',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::connection('sqlite')->table('grupos')->insert([
+            'codigo' => 'GRP100',
+            'idCiclo' => 100,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('sqlite')->table('alumnos_grupos')->insert([
+            ['idAlumno' => 'ALU001', 'idGrupo' => 'GRP100'],
+            ['idAlumno' => 'ALU002', 'idGrupo' => 'GRP100'],
+        ]);
+
+        DB::connection('sqlite')->table('colaboraciones')->insert([
+            [
+                'id' => 1,
+                'idCentro' => 10,
+                'idCiclo' => 100,
+                'puestos' => 1,
+                'tutor' => 'PROF001',
+                'estado' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => 2,
+                'idCentro' => 11,
+                'idCiclo' => 100,
+                'puestos' => 2,
+                'tutor' => 'PROF001',
+                'estado' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Resum

Afig el primer flux de reserves d'alumnat sobre col·laboracions abans de crear la FCT definitiva.

## Canvis principals

- crea la taula 
- afig el model 
- incorpora  amb regles de capacitat i conflicte
- integra les reserves en 
- mostra reserves amb alumne, grup i professor
- limita el selector a alumnat del tutor i exclou alumnat ja reservat en el cicle
- elimina reserves des del panell i torna a la pestanya 
- actualitza el test temporal de  per a evitar dates caducades

## Verificació

- 
   PASS  Tests\Unit\Application\Colaboracion\ColaboracionPreasignacionServiceTest
  ✓ create crea una preasignacio valida                                  0.29s  
  ✓ create rebutja duplicat en la mateixa colaboracio                    0.10s  
  ✓ create rebutja quan no queden places lliures                         0.10s  
  ✓ create rebutja conflicte del mateix alumne en el mateix cicle        0.10s  
  ✓ descartar elimina la reserva i permet tornar a crear                 0.12s  
  ✓ hydrate for panel adjunta preasignaciones i opcions per cicle        0.11s  

  Tests:    6 passed (16 assertions)
  Duration: 1.18s
- 
   PASS  Tests\Feature\ComisionDireccionPanelTest
  ✓ renderitza llistat i textos clau                                     0.34s  
  ✓ filtra per professor i estat                                         0.11s  
  ✓ acceptar i desautoritzar actualitzen estat                           0.15s  
  ✓ autoritzar pendents en bloc actualitza estats sense controller lega… 0.12s  
  ✓ no es pot esborrar una comissio cobrada                              0.10s  
  ✓ mostrar carrega la comissio seleccionada                             0.10s  
  ✓ editar i guardar edicio actualitza la comissio des del component     0.18s  
  ✓ imprimir pagaments seleccionats marca professor i redirigeix         0.13s  
  ✓ imprimir autoritzades usa ruta propia del pilot                      0.10s  

  Tests:    9 passed (46 assertions)
  Duration: 1.60s
