### PR TITLE
[FIX] Cicles LOGSE no mostren pestanyes d'avaluació FCT

### DIFF
--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -245,7 +245,9 @@ class PanelFctAvalController extends IntranetController
 
         $normativa = $fct->Fct?->Colaboracion?->Ciclo?->normativa;
         if (is_string($normativa) && trim($normativa) !== '') {
-            return strtoupper($normativa);
+            $normativa = strtoupper($normativa);
+            // LOGSE és la llei anterior a LOE; s'avalua de la mateixa manera
+            return $normativa === 'LOGSE' ? 'LOE' : $normativa;
         }
 
         if ($grupo && str_contains((string) $grupo->codigo, 'LFP')) {


### PR DESCRIPTION
## Problema

Tanca #161

En l'apartat `/avalFCT`, els professors amb alumnes de cicles **LOGSE** únicament veien la pestanya **Resum**, sense poder accedir a les pestanyes d'avaluació de les FCTs.

## Causa

El mètode `resolveNormativa()` retornava directament el valor del camp `normativa` del cicle (`'LOGSE'`), però `iniPestanas()` només comprova `'LOE'` i `'LFP'`. Com que `'LOGSE'` no coincidia amb cap, `$available` quedava buit i sols apareixia la pestanya "Resum".

## Solució

Mapejar `LOGSE` → `LOE` dins de `resolveNormativa()`, ja que LOGSE és la llei anterior a LOE i el procés d'avaluació FCT és equivalent.

```php
return $normativa === 'LOGSE' ? 'LOE' : $normativa;
```

## Fitxers modificats

- `app/Http/Controllers/PanelFctAvalController.php` — mètode `resolveNormativa()` (+3 línies)

## Test plan

- [ ] Accedir a `/avalFCT` com a professor tutor amb alumnes de cicles LOGSE
- [ ] Verificar que apareix la pestanya d'avaluació (LOE) a més de la pestanya Resum
- [ ] Verificar que cicles LOE i LFP segueixen funcionant correctament

🤖 Generated with [Claude Code](https://claude.com/claude-code)