### PR TITLE
[FIX] Mostrar botó Demanar Acta per a cicles LOGSE

### DIFF
--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -552,7 +552,7 @@ class PanelFctAvalController extends IntranetController
      */
     private function setActaB(): void
     {
-        if ($this->elementos()->where('normativa', 'LOE')->isEmpty()) {
+        if ($this->elementos()->whereIn('normativa', ['LOE', 'LOGSE'])->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
## Problema

Seguiment de #161

El botó **"Demanar Acta"** no apareixia per als professors amb alumnes de cicles **LOGSE**. El mètode `setActaB()` tenia la condició:

```php
if ($this->elementos()->where('normativa', 'LOE')->isEmpty()) {
    return;
}
```

Com que LOGSE no és LOE, el mètode retornava sense mostrar el botó.

## Solució

Ampliar la condició per incloure LOGSE:

```php
if ($this->elementos()->whereIn('normativa', ['LOE', 'LOGSE'])->isEmpty()) {
    return;
}
```

## Test plan

- [ ] Professor amb alumnes LOGSE veu el botó "Demanar Acta" una vegada qualificades les FCTs
- [ ] Professor amb alumnes LOE segueix veient el botó correctament
- [ ] Professor amb alumnes LFP no veu el botó (comportament no canviat)