### PR TITLE
[FIX] Mostrar botó Demanar Acta per a cicles LOGSE

### DIFF
--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -520,10 +520,10 @@ class PanelFctAvalController extends IntranetController
         Gate::authorize('requestActa', Fct::class);
         $grupos = $this->grupos()
             ->qTutor(AuthUser()->dni)
-            ->filter(static fn (Grupo $grupo): bool => (bool) $grupo->proyecto)
+            ->filter(static fn (Grupo $grupo): bool => (bool) $grupo->proyecto || $grupo->Ciclo?->normativa === 'LOGSE')
             ->values();
         if ($grupos->isEmpty()) {
-            Alert::message('No tens grups amb projecte assignats', 'warning');
+            Alert::message('No tens grups per sol·licitar acta', 'warning');
             return back();
         }
 
@@ -557,13 +557,15 @@ class PanelFctAvalController extends IntranetController
         }
 
         $grupos = $this->grupos()->qTutor(AuthUser()->dni);
-        $grupoConProyecto = $grupos->first(static fn (Grupo $grupo): bool => (bool) $grupo->proyecto);
+        $gruposConActa = $grupos->filter(
+            static fn (Grupo $grupo): bool => (bool) $grupo->proyecto || $grupo->Ciclo?->normativa === 'LOGSE'
+        );
 
-        if (!$grupoConProyecto) {
+        if ($gruposConActa->isEmpty()) {
             return;
         }
 
-        $pendiente = $grupos->first(static fn (Grupo $grupo): bool => (bool) ($grupo->proyecto && $grupo->acta_pendiente));
+        $pendiente = $gruposConActa->first(static fn (Grupo $grupo): bool => (bool) $grupo->acta_pendiente);
         if ($pendiente) {
             Alert::message("L'acta pendent esta en procés", 'info');
             return;


### PR DESCRIPTION
## Problema

Seguiment de #161

El botó **"Demanar Acta"** no apareixia per als professors amb alumnes de cicles **LOGSE** malgrat el fix anterior (#164).

## Causa arrel

El mètode `setActaB()` filtra grups per `$grupo->proyecto`, que és un **accessor calculat** a `Grupo.php`:

```php
public function getProyectoAttribute()
{
    return ((int) $this->curso === 2
        && $ciclo?->normativa === 'LOE'   // ← mai true per a LOGSE
        && (int) ($ciclo?->tipo ?? 0) === 2);
}
```

Com que `proyecto` mai pot ser `true` per a un grup LOGSE, tant `setActaB()` com `demanarActa()` excloïen sempre aquests grups.

## Solució

S'afegeix `$grupo->Ciclo?->normativa === 'LOGSE'` com a condició alternativa als dos mètodes:

- **`setActaB()`**: mostra el botó si hi ha grups amb `proyecto` O grups LOGSE
- **`demanarActa()`**: processa grups amb `proyecto` O grups LOGSE

## Test plan

- [ ] Professor amb alumnes LOGSE veu el botó "Demanar Acta"
- [ ] En prémer el botó, s'envia la notificació a direcció correctament
- [ ] Professor amb alumnes LOE segueix funcionant igual
- [ ] Professor sense alumnes LOGSE/LOE no veu el botó