### PR TITLE
[MOD] Automatitza build i publicació d'imatges Docker per a Laravel13 #150

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,10 +5,49 @@ on:
     workflows: ["PHP Tests"]
     branches:
       - main
+      - Laravel13
     types:
       - completed
 
 jobs:
+  build-dev:
+    name: Build dev image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push dev image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/8.3
+          file: ./docker/8.3/Dockerfile
+          push: true
+          tags: |
+            arturocandela/intranet:laravel13-dev
+            arturocandela/intranet:sha-${{ github.event.workflow_run.head_sha }}-dev
+          build-args: |
+            WWWUSER=1000
+            WWWGROUP=1000
+            NODE_VERSION=20
+            NPM_VERSION=11
+          cache-from: type=gha,scope=dev
+          cache-to: type=gha,mode=max,scope=dev
+
   build-prod:
     name: Build prod image
     runs-on: ubuntu-latest
@@ -37,10 +76,10 @@ jobs:
           file: ./docker/8.3/Dockerfile.prod
           push: true
           tags: |
-            arturocandela/intranet:latest-prod
-            arturocandela/intranet:sha-${{ github.event.workflow_run.head_sha }}
+            arturocandela/intranet:laravel13-prod
+            arturocandela/intranet:sha-${{ github.event.workflow_run.head_sha }}-prod
           build-args: |
             NODE_VERSION=20
             NPM_VERSION=11
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,mode=max,scope=prod


### PR DESCRIPTION
## Resum

- Afig `Laravel13` als triggers del workflow `docker-build.yml` (abans sols `main`)
- Nou job `build-dev` que construeix i publica `arturocandela/intranet:laravel13-dev` des de `docker/8.3/Dockerfile`
- Tags actualitzats a `laravel13-prod` (era `latest-prod`) per consistència entre entorns
- Scopes de cache GHA separats (`scope=dev` / `scope=prod`) per evitar col·lisions entre jobs

## Configuració necessària

Cal tenir configurats a GitHub els secrets:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Tags publicats a Docker Hub

| Entorn | Tag fix | Tag per SHA |
|--------|---------|-------------|
| Dev    | `arturocandela/intranet:laravel13-dev` | `arturocandela/intranet:sha-<SHA>-dev` |
| Prod   | `arturocandela/intranet:laravel13-prod` | `arturocandela/intranet:sha-<SHA>-prod` |

Els fitxers `docker-compose.yml` i `docker-compose.prod.yml` ja usen `IMAGE_TAG_DEV` i `IMAGE_TAG_PROD` com a variables d'entorn per seleccionar el tag, per tant no cal modificar-los.

## Tests executats

- `phpunit` (CI via `php-tests.yml`)
- `npm run production` no afecta (canvi sols en workflow)

Tanca #150