### PR TITLE
[FIX] Robust fallback for last signed PDF page

### DIFF
--- a/app/Http/Controllers/PanelSignaturaController.php
+++ b/app/Http/Controllers/PanelSignaturaController.php
@@ -122,13 +122,15 @@ class PanelSignaturaController extends BaseController
                             );
                             $x = config("signatures.files.{$effectiveTipus}.director.x");
                             $y = config("signatures.files.{$effectiveTipus}.director.y");
+                            $page = config("signatures.files.{$effectiveTipus}.director.page");
                             DigitalSignatureService::sign(
                                 $fileToSign,
                                 $fileToSign,
                                 $x,
                                 $y,
                                 $file,
-                                $passCert
+                                $passCert,
+                                is_numeric($page) ? (int) $page : null
                             );
                             $signatura->signed += 3;
                             $signatura->save();

--- a/app/Sao/Documents/A2DocumentService.php
+++ b/app/Sao/Documents/A2DocumentService.php
@@ -54,6 +54,7 @@ class A2DocumentService
         $saveFile = $fctAl->routeFile($annexe);
         $x = config('signatures.files.' . $annexe . '.owner.x');
         $y = config('signatures.files.' . $annexe . '.owner.y');
+        $page = config('signatures.files.' . $annexe . '.owner.page');
         $ad = (string) config('sao.urls.generate_pdf', 'https://foremp.edu.gva.es/inc/ajax/generar_pdf.php')
             . '?doc=' . $annexeNum . '&centro=59&idFct=' . $fctAl->idSao;
 
@@ -78,7 +79,8 @@ class A2DocumentService
                         $x,
                         $y,
                         $certPath,
-                        $certPassword
+                        $certPassword,
+                        is_numeric($page) ? (int) $page : null
                     );
                     Firma::saveIfNotExists($annexe, $fctAl->idSao, 2);
                 } else {

--- a/app/Sao/Documents/A5DocumentService.php
+++ b/app/Sao/Documents/A5DocumentService.php
@@ -56,6 +56,7 @@ class A5DocumentService
         $saveFile = $fctAl->routeFile($annexe);
         $x = config('signatures.files.' . $annexe . '.owner.x');
         $y = config('signatures.files.' . $annexe . '.owner.y');
+        $page = config('signatures.files.' . $annexe . '.owner.page');
         $error = false;
         $fctUrlBase = (string) config('sao.urls.fct', 'https://foremp.edu.gva.es/index.php?accion=7&idFct=');
 
@@ -117,7 +118,8 @@ class A5DocumentService
                         $x,
                         $y,
                         $certPath,
-                        $certPassword
+                        $certPassword,
+                        is_numeric($page) ? (int) $page : null
                     );
                     Firma::saveIfNotExists($annexe, $fctAl->idSao, 2);
                 } else {

--- a/app/Services/Document/DocumentService.php
+++ b/app/Services/Document/DocumentService.php
@@ -234,6 +234,7 @@ class DocumentService
             try {
                 $x = config("signatures.files.".$this->document->route.".owner.x");
                 $y = config("signatures.files.".$this->document->route.".owner.y");
+                $page = config("signatures.files.".$this->document->route.".owner.page");
                 $file = DigitalSignatureService::decryptCertificateUser(
                     $this->finder->getRequest()->decrypt,
                     authUser()
@@ -247,7 +248,8 @@ class DocumentService
                     $x,
                     $y,
                     $file,
-                    $passCert
+                    $passCert,
+                    is_numeric($page) ? (int) $page : null
                 );
 
                 return response()->file(storage_path('tmp/auttutor_'.authUser()->dni.'signed.pdf'));

--- a/app/Services/Signature/DigitalSignatureService.php
+++ b/app/Services/Signature/DigitalSignatureService.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
 use setasign\Fpdi\Fpdi;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Throwable;
 
 class DigitalSignatureService
@@ -185,16 +186,38 @@ class DigitalSignatureService
     }
 
 
-    public static function sign($file, $newFile, $coordx, $coordy, $certPath, $certPassword): void
+    /**
+     * Signa un PDF amb signatura visible.
+     *
+     * @param string $file
+     * @param string $newFile
+     * @param float|int|null $coordx
+     * @param float|int|null $coordy
+     * @param string $certPath
+     * @param string $certPassword
+     * @param int|null $page
+     */
+    public static function sign($file, $newFile, $coordx, $coordy, $certPath, $certPassword, ?int $page = null): void
     {
-        (new self())->signDocument($file, $newFile, $coordx, $coordy, $certPath, $certPassword);
+        (new self())->signDocument($file, $newFile, $coordx, $coordy, $certPath, $certPassword, $page);
     }
 
-    public function signDocument($file, $newFile, $coordx, $coordy, $certPath, $certPassword): void
+    /**
+     * Signa un PDF amb signatura visible.
+     *
+     * @param string $file
+     * @param string $newFile
+     * @param float|int|null $coordx
+     * @param float|int|null $coordy
+     * @param string $certPath
+     * @param string $certPassword
+     * @param int|null $page
+     */
+    public function signDocument($file, $newFile, $coordx, $coordy, $certPath, $certPassword, ?int $page = null): void
     {
         try {
             // 1️⃣ Primer intent normal
-            $this->signWithJSignPdf($file, $newFile, $coordx, $coordy, $certPath, $certPassword);
+            $this->signWithJSignPdf($file, $newFile, $coordx, $coordy, $certPath, $certPassword, $page);
             return;
 
         } catch (Throwable $th) {
@@ -212,7 +235,7 @@ class DigitalSignatureService
                 try {
                     // Normalitzem el PDF i tornem a intentar
                     $normalized = $this->normalizePdf($file);
-                    $this->signWithJSignPdf($normalized, $newFile, $coordx, $coordy, $certPath, $certPassword);
+                    $this->signWithJSignPdf($normalized, $newFile, $coordx, $coordy, $certPath, $certPassword, $page);
                     return;
 
                 } catch (Throwable $e2) {
@@ -251,7 +274,18 @@ class DigitalSignatureService
         }
     }
 
-    private function signWithJSignPdf($file, $newFile, $coordx, $coordy, $certPath, $certPassword): void
+    /**
+     * Executa la firma visible via JSignPdf.
+     *
+     * @param string $file
+     * @param string $newFile
+     * @param float|int|null $coordx
+     * @param float|int|null $coordy
+     * @param string $certPath
+     * @param string $certPassword
+     * @param int|null $page
+     */
+    private function signWithJSignPdf($file, $newFile, $coordx, $coordy, $certPath, $certPassword, ?int $page = null): void
     {
         if (!is_string($file) || $file === '' || !file_exists($file)) {
             throw new IntranetException("No s'ha trobat el PDF d'entrada per a signar.");
@@ -275,7 +309,7 @@ class DigitalSignatureService
         $coordy = (float) ($coordy ?? 50);
         $width = (float) ($config['width'] ?? 200);
         $height = (float) ($config['height'] ?? 70);
-        $page = $this->getLastPageNumber($file, (int) ($config['page'] ?? 1));
+        $page = $this->resolveSignaturePage($file, $page, (int) ($config['page'] ?? 1));
         $append = (bool) ($config['append'] ?? true);
         $timeout = (int) ($config['timeout'] ?? 60);
         $visibleText = $this->buildVisibleSignatureText($certPath, $certPassword);
@@ -387,6 +421,22 @@ class DigitalSignatureService
             'page' => $page,
             'append' => $append,
         ]);
+    }
+
+    /**
+     * Determina la pàgina visible de la signatura.
+     *
+     * Si hi ha una pàgina configurada explícitament, té prioritat. En cas
+     * contrari s'intenta usar l'última pàgina del PDF i, si falla, es recorre
+     * al valor de reserva.
+     */
+    public function resolveSignaturePage(string $inputFile, ?int $configuredPage = null, int $fallback = 1): int
+    {
+        if ($configuredPage !== null && $configuredPage > 0) {
+            return $configuredPage;
+        }
+
+        return $this->getLastPageNumber($inputFile, $fallback);
     }
 
     private function buildJSignPdfCommand(
@@ -605,7 +655,43 @@ class DigitalSignatureService
                 'pdfPath' => $inputFile,
                 'error' => $th->getMessage(),
             ]);
-            return max(1, $fallback);
+        }
+
+        $pageCount = $this->getLastPageNumberFromPdfInfo($inputFile);
+        if ($pageCount !== null) {
+            return $pageCount;
+        }
+
+        return max(1, $fallback);
+    }
+
+    /**
+     * Intenta obtindre el nombre de pàgines amb `pdfinfo` quan FPDI no pot
+     * llegir un PDF incrementalment signat.
+     */
+    private function getLastPageNumberFromPdfInfo(string $inputFile): ?int
+    {
+        $pdfInfo = trim((string) shell_exec('command -v pdfinfo 2>/dev/null'));
+        if ($pdfInfo === '' || !file_exists($inputFile)) {
+            return null;
+        }
+
+        try {
+            $process = new Process([$pdfInfo, $inputFile]);
+            $process->setTimeout(10);
+            $process->mustRun();
+
+            if (preg_match('/^Pages:\s+(\d+)$/mi', $process->getOutput(), $matches) !== 1) {
+                return null;
+            }
+
+            return max(1, (int) $matches[1]);
+        } catch (ProcessFailedException|Throwable $th) {
+            Log::channel('certificate')->warning("No s'ha pogut calcular l'última pàgina amb pdfinfo.", [
+                'pdfPath' => $inputFile,
+                'error' => $th->getMessage(),
+            ]);
+            return null;
         }
     }
 

--- a/tests/Unit/Services/Signature/DigitalSignatureServiceTest.php
+++ b/tests/Unit/Services/Signature/DigitalSignatureServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Signature;
+
+use Intranet\Services\Signature\DigitalSignatureService;
+use Tests\TestCase;
+
+/**
+ * Tests de regressió del càlcul de pàgina visible de la signatura.
+ */
+class DigitalSignatureServiceTest extends TestCase
+{
+    /**
+     * Comprova que la pàgina configurada té prioritat.
+     */
+    public function testResolveSignaturePageUsesConfiguredPageWhenProvided(): void
+    {
+        $service = new DigitalSignatureService();
+
+        $page = $service->resolveSignaturePage('/tmp/non-existent.pdf', 2, 1);
+
+        $this->assertSame(2, $page);
+    }
+
+    /**
+     * Comprova que, si no es pot llegir el PDF, s'usa el valor de reserva.
+     */
+    public function testResolveSignaturePageFallsBackWhenPdfCannotBeRead(): void
+    {
+        $service = new DigitalSignatureService();
+
+        $page = $service->resolveSignaturePage('/tmp/non-existent.pdf', null, 3);
+
+        $this->assertSame(3, $page);
+    }
+
+    /**
+     * Comprova que la configuració no fixa una pàgina concreta per a A2DUAL.
+     */
+    public function testA2DualDirectorPageIsNotForcedInConfig(): void
+    {
+        $this->assertNull(config('signatures.files.A2DUAL.director.page'));
+    }
+}


### PR DESCRIPTION
## Resum

Fa més robust el càlcul de l'última pàgina en la signatura visible dels PDFs quan FPDI no pot llegir correctament un document ja signat o amb estructura incremental.

## Canvis

- afegeix un fallback amb `pdfinfo` per obtindre el nombre de pàgines
- manté el comportament actual de signar en l'última pàgina
- admet una pàgina configurada explícitament sense forçar-la en `A2DUAL`
- cobreix la regressió amb proves unitàries

## Validació

- `vendor/bin/phpunit --filter DigitalSignatureServiceTest`

Closes #183