### PR TITLE
[FIX] Permet demanar acta a LOE de grau mitjà #186

### DIFF
--- a/app/Entities/Grupo.php
+++ b/app/Entities/Grupo.php
@@ -172,6 +172,17 @@ class Grupo extends Model
             && (int) ($ciclo?->tipo ?? 0) === 2);
     }
 
+    /**
+     * Determina si el grup pot sol·licitar acta d'avaluació FCT.
+     */
+    public function getPuedeSolicitarActaAttribute(): bool
+    {
+        $normativa = strtoupper((string) ($this->Ciclo?->normativa ?? ''));
+
+        return (int) $this->curso === 2
+            && in_array($normativa, ['LOE', 'LOGSE'], true);
+    }
+
     public function getXcicloAttribute()
     {
         return $this->Ciclo->ciclo ?? $this->idCiclo;

--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -515,7 +515,7 @@ class PanelFctAvalController extends IntranetController
     }
 
     /**
-     * Demana acta d'avaluació per als grups LOE amb projecte.
+     * Demana acta d'avaluació per als grups LOE/LOGSE de segon curs.
      *
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -524,7 +524,7 @@ class PanelFctAvalController extends IntranetController
         Gate::authorize('requestActa', Fct::class);
         $grupos = $this->grupos()
             ->qTutor(AuthUser()->dni)
-            ->filter(static fn (Grupo $grupo): bool => (bool) $grupo->proyecto || $grupo->Ciclo?->normativa === 'LOGSE')
+            ->filter(static fn (Grupo $grupo): bool => (bool) $grupo->puede_solicitar_acta)
             ->values();
         if ($grupos->isEmpty()) {
             Alert::message('No tens grups per sol·licitar acta', 'warning');
@@ -550,7 +550,7 @@ class PanelFctAvalController extends IntranetController
     }
 
     /**
-     * Configura el botó d'acta per a grups LOE amb projecte.
+     * Configura el botó d'acta per a grups LOE/LOGSE de segon curs.
      *
      * @return void
      */
@@ -562,7 +562,7 @@ class PanelFctAvalController extends IntranetController
 
         $grupos = $this->grupos()->qTutor(AuthUser()->dni);
         $gruposConActa = $grupos->filter(
-            static fn (Grupo $grupo): bool => (bool) $grupo->proyecto || $grupo->Ciclo?->normativa === 'LOGSE'
+            static fn (Grupo $grupo): bool => (bool) $grupo->puede_solicitar_acta
         );
 
         if ($gruposConActa->isEmpty()) {

--- a/tests/Unit/Entities/GrupoTest.php
+++ b/tests/Unit/Entities/GrupoTest.php
@@ -202,6 +202,51 @@ class GrupoTest extends TestCase
         $this->assertFalse($grupo->proyecto);
     }
 
+    public function test_accessor_puede_solicitar_acta_retorna_true_per_loe_grau_mitja_de_segon(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 2;
+        $grupo->setRelation('Ciclo', (object) ['normativa' => 'LOE', 'tipo' => 1]);
+
+        $this->assertTrue($grupo->puede_solicitar_acta);
+    }
+
+    public function test_accessor_puede_solicitar_acta_retorna_true_per_loe_grau_superior_de_segon(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 2;
+        $grupo->setRelation('Ciclo', (object) ['normativa' => 'LOE', 'tipo' => 2]);
+
+        $this->assertTrue($grupo->puede_solicitar_acta);
+    }
+
+    public function test_accessor_puede_solicitar_acta_retorna_true_per_logse_de_segon(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 2;
+        $grupo->setRelation('Ciclo', (object) ['normativa' => 'LOGSE', 'tipo' => 1]);
+
+        $this->assertTrue($grupo->puede_solicitar_acta);
+    }
+
+    public function test_accessor_puede_solicitar_acta_retorna_false_per_lfp(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 2;
+        $grupo->setRelation('Ciclo', (object) ['normativa' => 'LFP', 'tipo' => 2]);
+
+        $this->assertFalse($grupo->puede_solicitar_acta);
+    }
+
+    public function test_accessor_puede_solicitar_acta_retorna_false_fora_de_segon_curs(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 1;
+        $grupo->setRelation('Ciclo', (object) ['normativa' => 'LOE', 'tipo' => 1]);
+
+        $this->assertFalse($grupo->puede_solicitar_acta);
+    }
+
     public function test_accessor_xtutor_retorna_buit_si_no_hi_ha_tutor(): void
     {
         $grupo = new Grupo();


### PR DESCRIPTION
## Resum

Este canvi permet que els grups **LOE de grau mitjà de 2n** també puguen veure i usar l'opció de **Demanar Acta** en el panell d'avaluació FCT.

## Què canvia

- es centralitza en `Grupo` la regla de si un grup pot sol·licitar acta
- `PanelFctAvalController` reutilitza eixa regla tant per al botó com per a la sol·licitud real
- s'afigen proves de regressió per a LOE grau mitjà, LOE grau superior, LOGSE, LFP i cursos fora de 2n

## Causa arrel

El controlador estava usant una condició massa restrictiva:

- permetia grups amb projecte
- permetia LOGSE per l'excepció de l'issue #161
- però deixava fora els **LOE de grau mitjà**, que no tenen projecte i sí han de poder demanar acta

El servei d'avaluació ja distingia correctament quan calia projecte i quan no; el problema estava abans, en el filtre d'elegibilitat del grup.

## Impacte

- `LOE` de 2n: poden demanar acta
- `LOGSE` de 2n: continuen podent demanar acta
- `LFP`: continua fora
- grups fora de 2n: continuen fora

## Validació

- `php artisan test tests/Unit/Entities/GrupoTest.php`
- `php artisan test tests/Unit/Policies/FctPolicyTest.php tests/Unit/GrupoRepositoryTest.php`

Closes #186