### PR TITLE
[MOD] Coherència Tetris: configs IA-agnòstiques + plantilla d'issues

### DIFF
--- a/.claude/commands/ia-review.md
+++ b/.claude/commands/ia-review.md
@@ -1,20 +1,15 @@
 # /ia-review — Revisió com a agent revisor independent
 
+> **Adaptador de Claude Code.** Font canònica dels criteris: [`docs/agents/ia-review-pipeline.md`](../../../docs/agents/ia-review-pipeline.md). Este fitxer només afig el *glue* de Claude (trigger slash + `$ARGUMENTS`).
+
 Actua com a **agent revisor** del codi actual. Has sigut escollit perquè ets diferent de l'agent que ha generat el codi.
 
 ## Instruccions per a l'agent
 
-1. Llegeix `AGENTS.md` i `specs/$ARGUMENTS.md` (si s'ha indicat el domini; si no, detecta'l pel diff).
+1. Llig `AGENTS.md` i `specs/$ARGUMENTS.md` (si s'ha indicat el domini; si no, detecta'l pel diff).
 2. Executa `git diff HEAD~1` per obtenir els canvis recents (o usa el diff proporcionat).
-3. Revisa **únicament** els criteris de [`docs/agents/ia-review-pipeline.md`](../../../docs/agents/ia-review-pipeline.md):
-   - Correcció funcional respecte a la spec
-   - Camps llegats modificats sense migració
-   - Autorització en accions sensibles
-   - Abast (res fora de la spec)
-   - Cobertura de tests
-   - Convencions (PSR-12, PHPDoc, Valencià)
-   - Seguretat (SQL cru, XSS, secrets)
-4. Per a cada problema: fitxer:línia, tipus, descripció i fragment de codi.
+3. Revisa **únicament** els criteris de [`docs/agents/ia-review-pipeline.md`](../../../docs/agents/ia-review-pipeline.md) § «Què ha de cobrir la revisió» (correcció funcional, camps llegats, autorització, abast, tests, convencions, seguretat).
+4. Per a cada problema: `fitxer:línia`, tipus, descripció i fragment de codi.
 5. Si no hi ha problemes: `✅ Cap problema detectat.`
 
 **No reescrius codi. No proposes millores fora dels criteris. Només reportes.**

--- a/.claude/commands/opsx-apply.md
+++ b/.claude/commands/opsx-apply.md
@@ -1,26 +1,7 @@
 # /opsx-apply — Implementa la spec aprovada
 
-**Pas 2 del flux OpenSpec.** Implementa estrictament la spec aprovada. No afegeix res fora del que descriu la spec.
+> **Adaptador de Claude Code.** Font canònica del flux: [`docs/agents/openspec.md`](../../../docs/agents/openspec.md) § **Pas 2 — apply**. Este fitxer només afig el *glue* de Claude.
 
-## Instruccions per a l'agent
+**Pas 2 del flux OpenSpec.** Segueix les instruccions de `docs/agents/openspec.md` § Pas 2.
 
-1. Llig `AGENTS.md` complet.
-2. Llig `specs/<domini>.md` (o l'esborrany aprovat per l'usuari).
-3. Verifica que la spec té `Status: approved` (o que l'usuari ha confirmat explícitament).
-4. Si no hi ha spec aprovada: retorna `Status: need_input — falta spec aprovada`.
-5. Implementa **únicament** el que descriu la spec:
-   - Crea/modifica els fitxers afectats llistats.
-   - Segueix les convencions de `docs/agents/conventions.md`.
-   - Afig PHPDoc a classes i mètodes nous.
-   - Text visible en Valencià.
-6. Crea o actualitza els tests que verifiquen els escenaris de la spec (`tests/Feature/` o `tests/Browser/`).
-7. **No refactoritzis** res fora de l'abast de la spec.
-8. Al final, llista els fitxers modificats i escriu `Status: ready_for_review`.
-
-## Verificació prèvia
-
-Abans d'escriure codi comprova:
-- [ ] Spec aprovada per l'usuari
-- [ ] Bounded context identificat
-- [ ] Cap camp llegat modificat sense migració explícita
-- [ ] Tests nous cobreixen tots els escenaris de la spec
+Recordatori del contracte: verifica que hi ha una spec aprovada (si no, `Status: need_input — falta spec aprovada`); implementa **únicament** el que descriu la spec, amb tests per a cada escenari; **no refactoritzes** res fora d'abast; acabes amb `Status: ready_for_review`.

--- a/.claude/commands/opsx-archive.md
+++ b/.claude/commands/opsx-archive.md
@@ -1,41 +1,7 @@
 # /opsx-archive — Tanca i arxiva la implementació
 
-**Pas 3 del flux OpenSpec.** Valida que tot és correcte, actualitza la spec permanent i prepara el commit.
+> **Adaptador de Claude Code.** Font canònica del flux: [`docs/agents/openspec.md`](../../../docs/agents/openspec.md) § **Pas 3 — archive**. Este fitxer només afig el *glue* de Claude.
 
-## Instruccions per a l'agent
+**Pas 3 del flux OpenSpec.** Segueix les instruccions de `docs/agents/openspec.md` § Pas 3.
 
-1. Comprova que els tests passen:
-   - `php artisan test --filter=<NomTest>` (o comanda Docker equivalent).
-   - Si fallen: reporta quins i atura't (`Status: tests_failing`).
-2. Actualitza `specs/<domini>.md` amb els escenaris nous/modificats (si no hi eren ja).
-3. Marca els escenaris implementats amb `✅` al fitxer de spec.
-4. Comprova que `AGENTS.md` i `docs/agents/` no necessiten actualització per als canvis introduïts.
-5. Llista tots els fitxers modificats i escriu `Status: ready_to_commit`.
-6. **No fa el commit.** L'usuari revisa i confirma.
-
-## Checklist de tancament
-
-- [ ] Tests en verd (PHPUnit + Dusk si aplica)
-- [ ] `specs/<domini>.md` actualitzat
-- [ ] Cap fitxer no relacionat modificat
-- [ ] Missatge de commit preparat amb prefix `[ADD]`/`[MOD]`/`[FIX]` i referència `#issue`
-
-## Format de resposta
-
-```
-## Resum de la implementació
-
-### Fitxers modificats
-- `ruta/fitxer.php` — descripció del canvi
-
-### Tests
-- `tests/Feature/NomTest.php::test_nom` ✅
-
-### Spec actualitzada
-- `specs/<domini>.md` — escenaris N, M marcats ✅
-
-### Missatge de commit suggerit
-[ADD] <descripció> #<issue>
-
-Status: ready_to_commit
-```
+Recordatori del contracte: comprova que els tests passen (si fallen, `Status: tests_failing` i atura't); actualitza `specs/<domini>.md` marcant escenaris amb `✅`; suggereix el missatge de commit amb prefix `[ADD]`/`[MOD]`/`[FIX]` i referència `#issue`; **no fas el commit**; acabes amb `Status: ready_to_commit`.

--- a/.claude/commands/opsx-propose.md
+++ b/.claude/commands/opsx-propose.md
@@ -1,39 +1,11 @@
 # /opsx-propose — Analitza i proposa una especificació
 
-**Pas 1 del flux OpenSpec.** Analitza el requeriment, genera un esborrany de spec i s'atura per a aprovació humana. **No escriu cap línia de codi.**
+> **Adaptador de Claude Code.** Font canònica del flux: [`docs/agents/openspec.md`](../../../docs/agents/openspec.md) § **Pas 1 — propose**. Este fitxer només afig el *glue* de Claude (trigger slash + `$ARGUMENTS`).
 
-## Instruccions per a l'agent
-
-1. Llig `AGENTS.md` i el doc de domini corresponent de `docs/agents/`.
-2. Identifica el bounded context afectat.
-3. Si ja existeix `specs/<domini>.md`, llegeix-lo per a no duplicar escenaris.
-4. Analitza el requeriment $ARGUMENTS i genera:
-   - **Llistat d'escenaris** BDD en format Given/When/Then (mínim 3, màxim 8).
-   - **Regles de negoci invariants** que l'escenari introdueix o modifica.
-   - **Fitxers afectats** (controladors, entitats, vistes, tests) sense tocar-los.
-   - **Riscos detectats** (efectes col·laterals, camps llegats, dependències).
-5. Mostra el resultat i escriu `Status: awaiting_approval`.
-6. **Atura't.** No implementes fins que l'usuari aprove la spec.
-
-## Format de resposta
+**Pas 1 del flux OpenSpec.** Segueix les instruccions de `docs/agents/openspec.md` § Pas 1, aplicades al requeriment:
 
 ```
-## Spec proposada: <títol>
-
-### Escenaris
-**Escenari N: <títol>**
-Given ...
-When ...
-Then ...
-
-### Regles de negoci
-- ...
-
-### Fitxers afectats
-- `ruta/fitxer.php` — motiu
-
-### Riscos
-- ...
-
-Status: awaiting_approval
+$ARGUMENTS
 ```
+
+Recordatori del contracte: analitza i genera escenaris BDD, regles de negoci, fitxers afectats i riscos; **no escrius cap línia de codi**; acabes amb `Status: awaiting_approval` i t'atures fins que l'usuari aprove la spec.

--- a/.codex/skills/intranet-batoi-activitats/agents/openai.yaml
+++ b/.codex/skills/intranet-batoi-activitats/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Intranet Batoi Activitats"
+  short_description: "Activitats complementàries i extraescolars."
+  default_prompt: "Usa este skill per a canvis en activitats: tipus, ubicació, transport, coordinador o PDFs."

--- a/.codex/skills/openspec/SKILL.md
+++ b/.codex/skills/openspec/SKILL.md
@@ -1,45 +1,16 @@
 ---
 name: openspec
-description: Flux OpenSpec de tres passos per a implementar funcionalitats amb aprovació humana. Usa quan l'usuari demana un nou feature, modificació de comportament existent, o quan cal escriure una spec BDD (Given/When/Then) abans d'implementar. Els tres passos són: propose (analitza i proposa spec), apply (implementa la spec aprovada), archive (valida tests i tanca).
+description: Flux OpenSpec de tres passos per a implementar funcionalitats amb aprovació humana. Usa quan l'usuari demana un nou feature, modificació de comportament existent, o quan cal escriure una spec BDD (Given/When/Then) abans d'implementar. Els tres passos són propose (analitza i proposa spec), apply (implementa la spec aprovada) i archive (valida tests i tanca).
 ---
 
-# OpenSpec — Flux d'implementació amb aprovació humana
+# OpenSpec — adaptador per a Codex
 
-Tres passos que obliguen l'agent a parar i esperar confirmació humana abans de passar al següent.
+> **Adaptador prim.** Esta skill només és el punt d'entrada de Codex al flux. Les instruccions completes i autoritzades viuen a la **font canònica agnòstica**: [`docs/agents/openspec.md`](../../../docs/agents/openspec.md). Llig-la i segueix-la.
 
-## Pas 1: propose
+Tres passos que obliguen a parar i esperar confirmació humana abans del següent:
 
-**Trigger**: `opsx-propose <descripció del requeriment>`
+1. **propose** (`opsx-propose <requeriment>`) — analitza, genera escenaris BDD + regles + fitxers + riscos, escriu `Status: awaiting_approval` i s'atura. **No escriu codi.**
+2. **apply** (`opsx-apply`) — implementa **únicament** la spec aprovada amb tests, escriu `Status: ready_for_review` i s'atura.
+3. **archive** (`opsx-archive`) — valida tests, marca escenaris `✅`, suggereix el commit (`#issue`), escriu `Status: ready_to_commit`. **No fa el commit.**
 
-1. Llig `AGENTS.md` i el doc de domini de `docs/agents/`.
-2. Analitza el requeriment.
-3. Genera escenaris BDD (Given/When/Then), regles de negoci, fitxers afectats i riscos.
-4. Escriu `Status: awaiting_approval` i s'atura.
-
-**No escriu codi.**
-
-## Pas 2: apply
-
-**Trigger**: `opsx-apply` (després que l'usuari aprove la spec)
-
-1. Verifica que hi ha una spec aprovada.
-2. Implementa **únicament** el que descriu la spec.
-3. Crea tests per a cada escenari de la spec.
-4. Escriu `Status: ready_for_review` i s'atura.
-
-## Pas 3: archive
-
-**Trigger**: `opsx-archive` (després de revisar el codi)
-
-1. Executa els tests; si fallen, para amb `Status: tests_failing`.
-2. Actualitza `specs/<domini>.md` marcant escenaris amb `✅`.
-3. Suggereix el missatge de commit (amb prefix i `#issue`).
-4. Escriu `Status: ready_to_commit` i s'atura.
-
-**No fa el commit.** L'usuari confirma.
-
-## Referències
-
-- Documentació completa: [`docs/agents/openspec.md`](../../../docs/agents/openspec.md)
-- Specs de domini: [`specs/`](../../../specs/)
-- Plantilles de prompt: [`prompts/`](../../../prompts/)
+El detall de cada pas, els formats d'eixida i les regles del flux estan a [`docs/agents/openspec.md`](../../../docs/agents/openspec.md). Specs de domini: [`specs/`](../../../specs/). Plantilles de prompt: [`prompts/`](../../../prompts/).

--- a/.codex/skills/openspec/agents/openai.yaml
+++ b/.codex/skills/openspec/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OpenSpec"
+  short_description: "Flux de 3 passos amb aprovació humana."
+  default_prompt: "Usa este skill per a implementar amb el flux OpenSpec: propose → apply → archive."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# Les plantilles són opcionals: es pot continuar obrint issues en blanc.
+blank_issues_enabled: true
+contact_links:
+  - name: Com treballem amb agents (Filosofia Tetris)
+    url: https://github.com/cipfpbatoi/intranetBatoi/blob/Laravel13/docs/agents/tetris.md
+    about: Llig com està organitzat el repo per a agents abans d'obrir una issue de workflow.

--- a/.github/ISSUE_TEMPLATE/tetris-workflow.md
+++ b/.github/ISSUE_TEMPLATE/tetris-workflow.md
@@ -1,0 +1,47 @@
+---
+name: "Issue de workflow (Filosofia Tetris)"
+about: "Issue paraigua amb checklist per a feines que toquen prompts, AGENTS.md, docs/agents, specs/tests o configs d'IA. Opcional."
+title: "[ADD] "
+labels: ["enhancement"]
+---
+
+> Plantilla **opcional**. Per a canvis normals (bug, feature concret) pots obrir una issue en blanc.
+> Context del model de treball: [`docs/agents/tetris.md`](../../docs/agents/tetris.md).
+
+## Objectiu
+
+<!-- Què vols aconseguir i per què. Una o dues frases. -->
+
+## Peça(es) Tetris afectada(es)
+
+Marca les que toques (vegeu `docs/agents/tetris.md`):
+
+- [ ] **Prompt (SISO)** — plantilles a `prompts/`
+- [ ] **Router** — `AGENTS.md`
+- [ ] **Docs vives** — `docs/agents/`
+- [ ] **Specs + Tests** — `specs/` i `tests/`
+- [ ] **Config d'IA** — `.claude/commands/`, `.codex/skills/` (recorda: adaptador prim sobre font canònica)
+
+## Domini
+
+<!-- FCT, Activitats, Comissions, Guàrdies, Horaris, transversal… -->
+
+## Checklist de tasques
+
+<!-- Desglossa en passos verificables. Cada commit ha de referenciar esta issue (#N). -->
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Criteris d'acceptació
+
+<!-- Com sabrem que està feta. Si hi ha spec, enllaça els escenaris Given/When/Then. -->
+
+- [ ] 
+
+## Notes
+
+- Llig `AGENTS.md` i el doc de domini abans de començar.
+- Si falta una peça (spec/convenció/camp), **òmpli-la**; no supòsits (Regla Zero).
+- Commits amb prefix `[ADD]`/`[MOD]`/`[DEL]`/`[FIX]` i referència `#issue`; sense atribució d'IA.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Repository Guidelines
 
 > **Font autoritzada compartida.** Aquest fitxer és la guia única per a qualsevol agent (Codex, Claude, Cursor, etc.). El coneixement de domini i les referències detallades viuen a [`docs/agents/`](docs/agents/) i s'enllacen al final.
+>
+> **Com està organitzat el repo per a agents:** [`docs/agents/tetris.md`](docs/agents/tetris.md) (les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA).
 
 ## Pre-flight Checklist
 
@@ -119,6 +121,7 @@ Namespace: `Intranet\Http\Controllers\API`. Auth via Sanctum. Intercanvi de toke
 
 Coneixement de domini compartit per a tots els agents. Llig el fitxer rellevant abans de tocar el seu àrea. Índex complet: [`docs/agents/README.md`](docs/agents/README.md).
 
+- [`docs/agents/tetris.md`](docs/agents/tetris.md) — mapa del repo: les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA.
 - [`docs/agents/conventions.md`](docs/agents/conventions.md) — convencions generals del repo (resum operatiu).
 - [`docs/agents/testing-docker.md`](docs/agents/testing-docker.md) — execució de tests, scripts Composer, Selenium/Docker.
 - **FCT** (annexos, signatures, SAO):
@@ -149,4 +152,10 @@ La IA que genera el codi no el revisa. Usar agents de motors diferents com a rev
 
 Plantilles per a tasques repetides (regla de les 3 vegades). Índex: [`prompts/README.md`](prompts/README.md).
 
-> Per a Codex, les fonts de domini s'invoquen via les skills de `.codex/skills/` (`intranet-batoi-general`, `intranet-batoi-fct`, `intranet-batoi-activitats`). Altres agents (Claude, Cursor, etc.) poden llegir-los directament.
+## Configuracions específiques per motor
+
+Les instruccions (fluxos, criteris, coneixement) viuen **una sola vegada** en una font canònica agnòstica (`docs/`, `specs/`, `prompts/`). Els fitxers de cada motor són **adaptadors prims** que només afigen el seu *glue* i apunten a eixa font. Detall i taula: [`docs/agents/tetris.md`](docs/agents/tetris.md) § «regla de l'adaptador prim».
+
+- **Codex**: skills a `.codex/skills/` (`intranet-batoi-general`, `intranet-batoi-fct`, `intranet-batoi-activitats`, `openspec`).
+- **Claude Code**: slash commands a `.claude/commands/` (`opsx-propose`, `opsx-apply`, `opsx-archive`, `ia-review`).
+- **Altres** (Cursor, etc.): poden llegir les fonts canòniques directament.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -4,6 +4,8 @@ Documents vius per a agents d'IA. Cada fitxer té **alta cohesió** (tot el que 
 
 Quan la IA es comporta malament en un domini, **refines el fitxer** corresponent; no el prompt.
 
+> **Comença ací si véns de nou:** [`tetris.md`](tetris.md) explica com està organitzat el repo per a treballar amb agents (les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA).
+
 ## Convencions generals
 
 | Fitxer | Contingut |

--- a/docs/agents/openspec.md
+++ b/docs/agents/openspec.md
@@ -1,54 +1,145 @@
 # Flux OpenSpec
 
-Procediment de tres passos que obliga l'agent a demanar aprovació humana abans d'implementar. Garanteix disseny iteratiu i control de qualitat.
+**Font canònica i agnòstica** del flux de tres passos que obliga l'agent a demanar aprovació humana abans d'implementar. Garanteix disseny iteratiu i control de qualitat.
+
+Qualsevol motor (Claude Code, Codex, Cursor…) segueix **estes** instruccions. Els fitxers específics de motor (`.claude/commands/opsx-*.md`, `.codex/skills/openspec/`) són adaptadors prims que només afigen el seu *glue* i apunten ací (vegeu [`tetris.md`](tetris.md) § adaptador prim).
 
 ```
 Requeriment inicial
        │
        ▼
- /opsx-propose          ← Agent analitza, genera spec, s'atura
+ propose                ← Agent analitza, genera spec, s'atura
        │
   [Revisió humana]      ← Tu aproves, rebutges o ajustes la spec
        │
        ▼
- /opsx-apply            ← Agent implementa estrictament la spec aprovada
+ apply                  ← Agent implementa estrictament la spec aprovada
        │
   [Revisió humana]      ← Tu revises el codi generat
        │
        ▼
- /opsx-archive          ← Agent valida tests, actualitza spec, suggereix commit
+ archive                ← Agent valida tests, actualitza spec, suggereix commit
        │
   [Commit humà]         ← Tu fas el commit i el push
 ```
 
-## Com usar-lo
+## Pas 1 — propose (analitza i proposa una spec)
 
-### Amb Claude Code (CLI)
+Analitza el requeriment, genera un esborrany de spec i s'atura per a aprovació humana. **No escriu cap línia de codi.**
+
+1. Llig `AGENTS.md` i el doc de domini corresponent de `docs/agents/`.
+2. Identifica el bounded context afectat.
+3. Si ja existeix `specs/<domini>.md`, llig-lo per a no duplicar escenaris.
+4. Analitza el requeriment i genera:
+   - **Escenaris** BDD Given/When/Then (mínim 3, màxim 8).
+   - **Regles de negoci invariants** que l'escenari introdueix o modifica.
+   - **Fitxers afectats** (controladors, entitats, vistes, tests) sense tocar-los.
+   - **Riscos detectats** (efectes col·laterals, camps llegats, dependències).
+5. Mostra el resultat i escriu `Status: awaiting_approval`.
+6. **Atura't.** No implementes fins que l'usuari aprove la spec.
+
+Format d'eixida:
+
 ```
-/opsx-propose Afegir exportació CSV a la llista d'empreses FCT
-/opsx-apply
-/opsx-archive
+## Spec proposada: <títol>
+
+### Escenaris
+**Escenari N: <títol>**
+Given ...
+When ...
+Then ...
+
+### Regles de negoci
+- ...
+
+### Fitxers afectats
+- `ruta/fitxer.php` — motiu
+
+### Riscos
+- ...
+
+Status: awaiting_approval
 ```
 
-Els slash commands estan definits a `.claude/commands/`.
+## Pas 2 — apply (implementa la spec aprovada)
 
-### Amb Codex
-Activar la skill `openspec` i demanar cada pas explícitament.
+Implementa **estrictament** la spec aprovada. No afig res fora del que descriu.
 
-### Manual (qualsevol agent)
-Copia les instruccions del pas corresponent de `.claude/commands/opsx-*.md` i envia-les com a prompt.
+1. Llig `AGENTS.md` complet.
+2. Llig `specs/<domini>.md` (o l'esborrany aprovat per l'usuari).
+3. Verifica que la spec té `Status: approved` (o confirmació explícita de l'usuari). Si no: retorna `Status: need_input — falta spec aprovada`.
+4. Implementa **únicament** el que descriu la spec:
+   - Crea/modifica els fitxers afectats llistats.
+   - Segueix `docs/agents/conventions.md`; afig PHPDoc a classes/mètodes nous; text visible en Valencià.
+5. Crea o actualitza els tests que verifiquen els escenaris (`tests/Feature/` o `tests/Browser/`).
+6. **No refactoritzes** res fora de l'abast de la spec.
+7. Llista els fitxers modificats i escriu `Status: ready_for_review`.
+
+Verificació prèvia (abans d'escriure codi):
+
+- [ ] Spec aprovada per l'usuari
+- [ ] Bounded context identificat
+- [ ] Cap camp llegat modificat sense migració explícita
+- [ ] Tests nous cobreixen tots els escenaris de la spec
+
+## Pas 3 — archive (valida i tanca)
+
+Valida que tot és correcte, actualitza la spec permanent i prepara el commit.
+
+1. Comprova que els tests passen (`php artisan test --filter=<NomTest>` o equivalent Docker). Si fallen: reporta quins i atura't amb `Status: tests_failing`.
+2. Actualitza `specs/<domini>.md` amb els escenaris nous/modificats i marca'ls amb `✅`.
+3. Comprova que `AGENTS.md` i `docs/agents/` no necessiten actualització pels canvis.
+4. Llista tots els fitxers modificats i escriu `Status: ready_to_commit`.
+5. **No fa el commit.** L'usuari revisa i confirma.
+
+Checklist de tancament:
+
+- [ ] Tests en verd (PHPUnit + Dusk si aplica)
+- [ ] `specs/<domini>.md` actualitzat (escenaris marcats `✅`)
+- [ ] Cap fitxer no relacionat modificat
+- [ ] Missatge de commit preparat amb prefix `[ADD]`/`[MOD]`/`[FIX]` i referència `#issue`
+
+Format d'eixida:
+
+```
+## Resum de la implementació
+
+### Fitxers modificats
+- `ruta/fitxer.php` — descripció del canvi
+
+### Tests
+- `tests/Feature/NomTest.php::test_nom` ✅
+
+### Spec actualitzada
+- `specs/<domini>.md` — escenaris N, M marcats ✅
+
+### Missatge de commit suggerit
+[ADD] <descripció> #<issue>
+
+Status: ready_to_commit
+```
 
 ## Regles del flux
 
 - **propose** no escriu mai codi. Si l'agent escriu codi sense aprovació, el pas és incorrecte.
-- **apply** no afegeix res fora de la spec. Si l'agent "millora" coses no sol·licitades, cal revertir-ho.
+- **apply** no afig res fora de la spec. Si l'agent "millora" coses no sol·licitades, cal revertir-ho.
 - **archive** no fa el commit. El commit el fa sempre un humà.
 - Si els tests fallen en `archive`, el flux torna a `apply` (no s'arxiva codi trencat).
+
+## Com invocar-lo per motor (adaptadors prims)
+
+- **Claude Code (CLI)**: `/opsx-propose <requeriment>` → `/opsx-apply` → `/opsx-archive` (`.claude/commands/opsx-*.md`).
+- **Codex**: activa la skill `openspec` i demana cada pas (`.codex/skills/openspec/`).
+- **Qualsevol altre agent (manual)**: copia el pas corresponent **d'este document** i envia'l com a prompt. No cal cap fitxer específic de motor.
 
 ## On viuen les specs
 
 Les especificacions aprovades i implementades es guarden a [`specs/`](../../specs/):
+
 - [`specs/fct.md`](../../specs/fct.md)
 - [`specs/activitats.md`](../../specs/activitats.md)
+- [`specs/comisions.md`](../../specs/comisions.md)
+- [`specs/guardies.md`](../../specs/guardies.md)
+- [`specs/horaris.md`](../../specs/horaris.md)
 
-Quan `opsx-archive` completa un escenari, el marca amb `✅` al fitxer de spec corresponent.
+Quan `archive` completa un escenari, el marca amb `✅` al fitxer de spec corresponent.

--- a/docs/agents/tetris.md
+++ b/docs/agents/tetris.md
@@ -1,0 +1,58 @@
+# Filosofia Tetris (IA) — mapa del repositori
+
+Document d'entrada. Explica **com està organitzat este repo per a treballar amb agents d'IA** i a quin artefacte correspon cada peça. Si véns de nou (humà o IA), llig açò primer i després el fitxer concret que necessites.
+
+## Regla Zero: programació predictible
+
+El codi i la documentació han de ser **avorrits i predictibles**: cada peça encaixa sense buits. **Zero buits = zero suposicions.** Quan un agent ha de suposar, és que falta una peça (una spec, una convenció, un camp documentat). La resposta correcta no és que l'agent endevine, sinó **omplir el buit** al fitxer que toca.
+
+Conseqüència pràctica (a `AGENTS.md` § Execution Rules):
+
+- Si l'stack o el requeriment és ambigu → **una sola pregunta concreta**, no suposes.
+- **Menys és més**: dona a l'agent la informació mínima vital, no tot el context.
+- **Res fora d'abast**: sense refactors ni funcionalitats no sol·licitades.
+
+## Les 4 peces
+
+Cada peça té una **font canònica única** i un lloc físic al repo. Quan l'agent es comporta malament, **refines la peça**, no el prompt puntual.
+
+| Peça | Què és | On viu | Quan la refines |
+|---|---|---|---|
+| **1. Prompt (SISO)** | Entrada estructurada → eixida estructurada. Plantilles reutilitzables amb buits `{{...}}`. | [`prompts/`](../../prompts/) | Quan repeteixes el mateix encàrrec >3 vegades. |
+| **2. Router (`AGENTS.md`)** | Guia única i autoritzada per a **qualsevol** agent. Pre-flight, regles d'execució i índex cap a la resta. | [`AGENTS.md`](../../AGENTS.md) | Quan una norma apareix en >3 prompts (regla de les 3 vegades). |
+| **3. Docs vives** | Coneixement de domini amb alta cohesió i baix acoblament. | [`docs/agents/`](README.md) | Quan l'IA s'equivoca en un domini concret. |
+| **4. Specs + Tests** | Veritat immutable del **què** (no del com), en BDD Given/When/Then, agnòstica de tecnologia. | [`specs/`](../../specs/) + `tests/` | Quan canvia el comportament esperat. |
+
+```
+        Prompt (SISO)
+            │  entrada estructurada
+            ▼
+   AGENTS.md (router) ──► docs/agents/ (com es fa ací)
+            │
+            ▼
+   specs/ + tests/ (què ha de passar = veritat)
+```
+
+## Configuracions d'IA: regla de l'adaptador prim
+
+Cada motor (Claude Code, Codex, Cursor…) té el seu mecanisme propi per a invocar instruccions: slash commands a `.claude/commands/`, skills a `.codex/skills/`, etc. Eixos mecanismes són **inevitablement específics del motor**, però el seu **contingut no ha de ser-ho**.
+
+> **Regla**: el *contingut* (passos d'un flux, criteris de revisió, coneixement de domini) viu **una sola vegada** en una font canònica agnòstica (`docs/`, `specs/` o `prompts/`). El fitxer de cada motor és un **adaptador prim**: només afig el *glue* específic del motor i apunta a la font canònica.
+
+| Mecanisme (específic del motor) | Glue que pot contindre | Font canònica (agnòstica) |
+|---|---|---|
+| `.claude/commands/opsx-*.md` | trigger slash, `$ARGUMENTS`, contracte d'eixida `Status:` | [`docs/agents/openspec.md`](openspec.md) |
+| `.codex/skills/openspec/` | `name`/`description` (YAML), `agents/openai.yaml` | [`docs/agents/openspec.md`](openspec.md) |
+| `.claude/commands/ia-review.md` | trigger slash, `$ARGUMENTS` | [`docs/agents/ia-review-pipeline.md`](ia-review-pipeline.md) |
+| `.codex/skills/intranet-batoi-*` | metadades d'activació de la skill | `docs/agents/**` (conventions, fct, activitats) |
+
+Així, afegir un motor nou (p. ex. Cursor) és escriure un adaptador prim nou; **mai** reescriure el flux. I corregir un flux és editar un sol fitxer canònic, no N còpies.
+
+## Fluxos que segueixen este model
+
+- **OpenSpec** (`propose → apply → archive`, amb aprovació humana entre passos): font canònica [`openspec.md`](openspec.md).
+- **IA revisora ≠ IA generadora** (qui escriu no revisa): font canònica [`ia-review-pipeline.md`](ia-review-pipeline.md).
+
+## Responsabilitat
+
+L'IA ajuda i actua, però **tu eres el responsable**. Cada commit porta la teua firma, no la de l'agent (per això no s'afig atribució d'IA als commits).


### PR DESCRIPTION
Continuació de la Filosofia Tetris (#197). Tanca #199.

## Resum

1. **Especificació coherent de la filosofia** — nou `docs/agents/tetris.md`: document d'entrada que nomena la filosofia i mapeja el repo a les 4 peces (Prompt/SISO, AGENTS.md router, docs vives, specs+tests) + Regla Zero. Enllaçat des d'`AGENTS.md` i `docs/agents/README.md`.
2. **Configs d'IA agnòstiques** — s'elimina la duplicació del flux OpenSpec i dels criteris de revisió. `docs/agents/openspec.md` passa a ser la **font canònica autosuficient**; els fitxers de cada motor (`.claude/commands/*`, `.codex/skills/openspec/`) queden com a **adaptadors prims** que només afigen el seu glue i apunten a la font. S'inverteix la dependència que abans anava de la doc cap a `.claude/commands`. S'homogeneïtzen els `agents/openai.yaml` que faltaven (`openspec`, `activitats`).
3. **Plantilla d'issues opcional** — `.github/ISSUE_TEMPLATE/` amb una plantilla paraigua d'estil Tetris/workflow i `config.yml` amb `blank_issues_enabled: true` (continua sent opcional).

## Principi aplicat

Una sola font canònica agnòstica per flux (a `docs/`/`specs/`/`prompts/`); cada motor és un adaptador prim. Afegir un motor nou (p. ex. Cursor) és escriure un adaptador, mai reescriure el flux.

## Test plan

- [ ] Revisar que els enllaços relatius de `docs/agents/tetris.md`, `openspec.md` i la plantilla resolen correctament.
- [ ] Comprovar a GitHub que la plantilla apareix com a opció i que es poden seguir obrint issues en blanc.
- [ ] Verificar que `/opsx-propose|apply|archive` i `/ia-review` segueixen sent utilitzables apuntant a la font canònica.