### PR TITLE
[ADD] Guia d'ús de la Filosofia Tetris + README visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Font autoritzada compartida.** Aquest fitxer és la guia única per a qualsevol agent (Codex, Claude, Cursor, etc.). El coneixement de domini i les referències detallades viuen a [`docs/agents/`](docs/agents/) i s'enllacen al final.
 >
-> **Com està organitzat el repo per a agents:** [`docs/agents/tetris.md`](docs/agents/tetris.md) (les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA).
+> **Com està organitzat el repo per a agents i com s'usa al dia a dia:** [`docs/agents/tetris.md`](docs/agents/tetris.md) (les 4 peces, la Regla Zero, receptes per escenari i la regla de l'adaptador prim per a configs d'IA).
 
 ## Pre-flight Checklist
 
@@ -121,7 +121,7 @@ Namespace: `Intranet\Http\Controllers\API`. Auth via Sanctum. Intercanvi de toke
 
 Coneixement de domini compartit per a tots els agents. Llig el fitxer rellevant abans de tocar el seu àrea. Índex complet: [`docs/agents/README.md`](docs/agents/README.md).
 
-- [`docs/agents/tetris.md`](docs/agents/tetris.md) — mapa del repo: les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA.
+- [`docs/agents/tetris.md`](docs/agents/tetris.md) — mapa del repo i **guia d'ús**: les 4 peces, la Regla Zero, receptes per escenari i la regla de l'adaptador prim per a configs d'IA.
 - [`docs/agents/conventions.md`](docs/agents/conventions.md) — convencions generals del repo (resum operatiu).
 - [`docs/agents/testing-docker.md`](docs/agents/testing-docker.md) — execució de tests, scripts Composer, Selenium/Docker.
 - **FCT** (annexos, signatures, SAO):

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Intranet CIP FP Batoi
+
+Aplicació de gestió interna del centre (Laravel, namespace `Intranet\`; Blade + Bootstrap 4/Gentelella + Vue 2 + Livewire 3). Rutes separades per rol, capes `app/Domain` i `app/Application`, tests amb PHPUnit i Dusk.
+
+## Com treballem amb IA: Filosofia Tetris
+
+Este repo està preparat perquè els agents d'IA (Claude Code, Codex, Cursor…) treballen de forma **predictible**: cada peça encaixa sense buits, i quan falta context **s'omple la peça** en lloc de suposar.
+
+> 📐 **Comença ací:** [`docs/agents/tetris.md`](docs/agents/tetris.md) — mapa de les 4 peces i **guia d'ús al dia a dia** (receptes, exemple complet del flux OpenSpec, antipatrons).
+
+| Vull… | Vés a… |
+|---|---|
+| Entendre com treballar i quina eina usar | [`docs/agents/tetris.md`](docs/agents/tetris.md) |
+| La guia autoritzada per a agents (router) | [`AGENTS.md`](AGENTS.md) |
+| Implementar amb aprovació humana (propose → apply → archive) | [`docs/agents/openspec.md`](docs/agents/openspec.md) |
+| Plantilles de prompt reutilitzables | [`prompts/`](prompts/) |
+| Especificacions de comportament (BDD) | [`specs/`](specs/) |
+| Coneixement de domini (FCT, Activitats…) | [`docs/agents/`](docs/agents/README.md) |
+
+## Documentació
+
+Índex complet de la documentació (arquitectura, operacions, manuals, governança): [`docs/README.md`](docs/README.md).
+
+- Setup i instal·lació: [`docs/operations/setup.md`](docs/operations/setup.md)
+- Tests, Docker i Dusk: [`docs/agents/testing-docker.md`](docs/agents/testing-docker.md)
+- Esquema de la BD: [`docs/architecture/bbdd-esquema.md`](docs/architecture/bbdd-esquema.md)
+
+## Contribuir
+
+- Llig `AGENTS.md` abans de tocar codi i completa el seu **Pre-flight Checklist**.
+- Commits amb prefix `[ADD]`/`[MOD]`/`[DEL]`/`[FIX]` i referència a la issue (`#NNN`); sense atribució d'IA.
+- Text d'usuari, comentaris i vistes en **Valencià**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Intranet del CIP FP Batoi. Documentació organitzada per tipus (alta cohesió, b
 
 ## Accés ràpid
 
+- 📐 [Filosofia Tetris: mapa i guia d'ús amb IA](agents/tetris.md) — com treballem amb agents (comença ací)
 - [Manual del Professor](manuals/manual-profe.md)
 - [Manual del Tutor de pràctiques](manuals/manual-fct.md)
 - [Preguntes freqüents](governance/faqs.md)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -4,7 +4,7 @@ Documents vius per a agents d'IA. Cada fitxer té **alta cohesió** (tot el que 
 
 Quan la IA es comporta malament en un domini, **refines el fitxer** corresponent; no el prompt.
 
-> **Comença ací si véns de nou:** [`tetris.md`](tetris.md) explica com està organitzat el repo per a treballar amb agents (les 4 peces, la Regla Zero i la regla de l'adaptador prim per a configs d'IA).
+> **Comença ací si véns de nou:** [`tetris.md`](tetris.md) — mapa de les 4 peces i **guia d'ús al dia a dia** (receptes per escenari, exemple complet del flux OpenSpec, antipatrons i la regla de l'adaptador prim per a configs d'IA).
 
 ## Convencions generals
 

--- a/docs/agents/tetris.md
+++ b/docs/agents/tetris.md
@@ -1,6 +1,9 @@
-# Filosofia Tetris (IA) — mapa del repositori
+# Filosofia Tetris (IA) — mapa i guia d'ús
 
-Document d'entrada. Explica **com està organitzat este repo per a treballar amb agents d'IA** i a quin artefacte correspon cada peça. Si véns de nou (humà o IA), llig açò primer i després el fitxer concret que necessites.
+Document d'entrada. Explica **com està organitzat este repo per a treballar amb agents d'IA** i **com usar-lo al dia a dia**. Si véns de nou (humà o IA), llig açò primer.
+
+- Tens pressa i només vols saber què fer? → [Com s'usa al dia a dia](#com-susa-al-dia-a-dia).
+- Vols entendre el perquè? → continua per [Regla Zero](#regla-zero-programació-predictible) i [Les 4 peces](#les-4-peces).
 
 ## Regla Zero: programació predictible
 
@@ -33,6 +36,117 @@ Cada peça té una **font canònica única** i un lloc físic al repo. Quan l'ag
    specs/ + tests/ (què ha de passar = veritat)
 ```
 
+## Com s'usa al dia a dia
+
+### Per on començar (arbre de decisió)
+
+| Tens... | Fes... | Peça / eina |
+|---|---|---|
+| Una **funcionalitat nova** o un **canvi de comportament** | Flux OpenSpec: `propose → apply → archive` | [Recepta 1](#recepta-1-funcionalitat-nova-o-canvi-de-comportament) |
+| Una **tasca que repeteixes** (nou controlador, entitat, test, vista…) | Copia una plantilla de `prompts/` | [Recepta 2](#recepta-2-una-tasca-que-repeteixes) |
+| L'**IA s'equivoca** sempre en un domini | Refina el doc de `docs/agents/` (no el prompt) | [Recepta 3](#recepta-3-lia-sequivoca-en-un-domini) |
+| Codi **generat per IA** a punt de revisar | Revisió creuada amb `ia-review` | [Recepta 4](#recepta-4-revisar-codi-generat-per-ia) |
+| Un **bug menut i clar**, sense canvi de comportament | Arregla'l directe + test de regressió. No cal spec nova. | `tests/` |
+
+> **Abans de res, sempre**: completa el [Pre-flight Checklist](../../AGENTS.md#pre-flight-checklist) d'`AGENTS.md` (llig AGENTS.md, identifica el domini i el seu doc, confirma el bounded context, llig la spec si existeix). Si falta una peça, l'agent ha de retornar `Status: need_input`, no suposar.
+
+### Recepta 1: Funcionalitat nova o canvi de comportament
+
+Usa el flux **OpenSpec** (font canònica: [`openspec.md`](openspec.md)). Tres passos amb **aprovació humana** entre cadascun:
+
+1. **propose** — l'agent analitza i proposa una spec BDD (escenaris Given/When/Then, regles, fitxers afectats, riscos). **No escriu codi.** Acaba en `Status: awaiting_approval`.
+2. *(tu revises i aproves la spec)*
+3. **apply** — l'agent implementa **únicament** la spec, amb tests. Acaba en `Status: ready_for_review`.
+4. *(tu revises el codi; opcionalment el passes per la [Recepta 4](#recepta-4-revisar-codi-generat-per-ia))*
+5. **archive** — l'agent valida tests, marca els escenaris `✅` a la spec i suggereix el commit. **No fa el commit.** Acaba en `Status: ready_to_commit`.
+6. *(tu fas el commit referenciant la issue)*
+
+Invocació segons el motor (vegeu la [taula d'eines](#quina-eina-per-a-quin-motor)).
+
+### Recepta 2: Una tasca que repeteixes
+
+Si una tasca apareix >3 vegades, ja té (o ha de tindre) una plantilla a [`prompts/`](../../prompts/). Copia-la, ompli els buits `{{...}}` i envia-la:
+
+| Vull… | Plantilla |
+|---|---|
+| Un controlador nou (CRUD o personalitzat) | `prompts/nou-controlador.md` |
+| Una entitat Eloquent + Policy + migració | `prompts/nova-entitat.md` |
+| Un test Feature PHPUnit | `prompts/nou-test-feature.md` |
+| Una vista Blade amb layout i parcials | `prompts/nova-vista-blade.md` |
+| Extraure lògica d'un controlador a un Service | `prompts/refactor-a-service.md` |
+| Una revisió de codi (vegeu Recepta 4) | `prompts/review-checklist.md` |
+
+Si la tasca encara no té plantilla i la repetiràs, **crea-la** (regla de les 3 vegades).
+
+### Recepta 3: L'IA s'equivoca en un domini
+
+No pegues pedaços al prompt cada vegada. **Refina el doc de domini** a `docs/agents/` perquè qualsevol agent encerte a la primera:
+
+- FCT → [`fct/fct-map.md`](fct/fct-map.md), [`fct/signatures.md`](fct/signatures.md), [`fct/sao-selenium.md`](fct/sao-selenium.md)
+- Activitats → [`activitats/activitats-map.md`](activitats/activitats-map.md)
+- Convencions transversals → [`conventions.md`](conventions.md)
+
+Si la norma és global (apareix en >3 prompts de qualsevol domini), va a `AGENTS.md`.
+
+### Recepta 4: Revisar codi generat per IA
+
+**Qui escriu no revisa.** Usa un motor diferent com a revisor independent (font canònica: [`ia-review-pipeline.md`](ia-review-pipeline.md)):
+
+- Amb Claude Code: `/ia-review [domini]`.
+- Sense segon motor a mà: copia [`prompts/review-checklist.md`](../../prompts/review-checklist.md).
+
+El revisor només **reporta** (correcció, camps llegats, autorització, abast, tests, convencions, seguretat); no reescriu.
+
+### Exemple complet (end-to-end)
+
+Requeriment: *«Afegir exportació CSV a la llista d'empreses FCT.»*
+
+```
+# 1. PROPOSE  (Claude: /opsx-propose  ·  Codex: skill openspec)
+/opsx-propose Afegir exportació CSV a la llista d'empreses FCT
+
+→ L'agent llig AGENTS.md + docs/agents/fct/fct-map.md, proposa:
+  Escenari 1: Given un professor FCT, When prem «Exporta CSV», Then es descarrega…
+  Regles, fitxers afectats (EmpresaController, ruta, vista), riscos.
+  Status: awaiting_approval
+                                   ← [tu aproves o ajustes la spec]
+
+# 2. APPLY
+/opsx-apply
+→ Implementa NOMÉS la spec + test a tests/Feature/. Sense extres.
+  Status: ready_for_review
+                                   ← [tu revises; opcional: /ia-review fct amb un altre motor]
+
+# 3. ARCHIVE
+/opsx-archive
+→ Executa tests, marca escenaris ✅ a specs/fct.md, suggereix:
+  [ADD] Exportació CSV d'empreses FCT #<issue>
+  Status: ready_to_commit
+                                   ← [tu fas el commit referenciant la issue]
+```
+
+### Quina eina per a quin motor
+
+El **contingut** (passos, criteris) és el mateix per a tots; només canvia com l'invoques.
+
+| Pas / acció | Claude Code | Codex | Manual (qualsevol agent) |
+|---|---|---|---|
+| OpenSpec | `/opsx-propose`, `/opsx-apply`, `/opsx-archive` | skill `openspec` | seguir [`openspec.md`](openspec.md) |
+| Revisió creuada | `/ia-review [domini]` | demanar revisió segons criteris | [`prompts/review-checklist.md`](../../prompts/review-checklist.md) |
+| Coneixement de domini | llegir `docs/agents/**` | skills `intranet-batoi-*` | llegir `docs/agents/**` |
+
+Els fitxers de cada motor (`.claude/commands/`, `.codex/skills/`) són **adaptadors prims**: només afigen el seu *glue* i apunten a la font canònica (vegeu [regla de l'adaptador prim](#configuracions-dia-regla-de-ladaptador-prim)).
+
+### Antipatrons (què NO fer)
+
+- ❌ Escriure codi en el pas **propose** (encara no hi ha spec aprovada).
+- ❌ «Millorar» coses no demanades durant **apply** (trenca la Regla Zero d'abast).
+- ❌ Que l'agent **endevine** quan falta context: ha de retornar `Status: need_input`.
+- ❌ Repetir la mateixa instrucció en cada prompt: si passa >3 vegades, va a `docs/agents/` o `AGENTS.md`.
+- ❌ Revisar amb **el mateix motor** que ha generat el codi.
+- ❌ Tocar **camps llegats** (`complementaria`, `extraescolar`, `sendTo`, `signed`…) sense migració explícita.
+- ❌ Fer el **commit** des de l'agent en `archive`: el commit el fa (i el firma) un humà.
+
 ## Configuracions d'IA: regla de l'adaptador prim
 
 Cada motor (Claude Code, Codex, Cursor…) té el seu mecanisme propi per a invocar instruccions: slash commands a `.claude/commands/`, skills a `.codex/skills/`, etc. Eixos mecanismes són **inevitablement específics del motor**, però el seu **contingut no ha de ser-ho**.
@@ -41,9 +155,9 @@ Cada motor (Claude Code, Codex, Cursor…) té el seu mecanisme propi per a invo
 
 | Mecanisme (específic del motor) | Glue que pot contindre | Font canònica (agnòstica) |
 |---|---|---|
-| `.claude/commands/opsx-*.md` | trigger slash, `$ARGUMENTS`, contracte d'eixida `Status:` | [`docs/agents/openspec.md`](openspec.md) |
-| `.codex/skills/openspec/` | `name`/`description` (YAML), `agents/openai.yaml` | [`docs/agents/openspec.md`](openspec.md) |
-| `.claude/commands/ia-review.md` | trigger slash, `$ARGUMENTS` | [`docs/agents/ia-review-pipeline.md`](ia-review-pipeline.md) |
+| `.claude/commands/opsx-*.md` | trigger slash, `$ARGUMENTS`, contracte d'eixida `Status:` | [`openspec.md`](openspec.md) |
+| `.codex/skills/openspec/` | `name`/`description` (YAML), `agents/openai.yaml` | [`openspec.md`](openspec.md) |
+| `.claude/commands/ia-review.md` | trigger slash, `$ARGUMENTS` | [`ia-review-pipeline.md`](ia-review-pipeline.md) |
 | `.codex/skills/intranet-batoi-*` | metadades d'activació de la skill | `docs/agents/**` (conventions, fct, activitats) |
 
 Així, afegir un motor nou (p. ex. Cursor) és escriure un adaptador prim nou; **mai** reescriure el flux. I corregir un flux és editar un sol fitxer canònic, no N còpies.


### PR DESCRIPTION
Material d'ús de la Filosofia Tetris i punt d'entrada visible. Tanca #201. Continuació de #197 i #199.

## Resum

- **`docs/agents/tetris.md`** passa de mapa conceptual a **mapa + guia d'ús al dia a dia**: arbre de decisió, receptes per escenari (OpenSpec, plantilles de `prompts/`, refinar docs de domini, revisió IA creuada), **exemple complet end-to-end** del flux `propose → apply → archive`, taula d'eines per motor i antipatrons.
- **`README.md` arrel** (abans inexistent): landing visible de GitHub que destaca la forma de treballar amb agents i enllaça AGENTS.md, tetris.md, openspec.md, prompts/, specs/ i docs/.
- Enllaços visibles afegits a `AGENTS.md`, `docs/README.md` i `docs/agents/README.md`.

Tota la documentació en Valencià, coherent amb la resta.

## Test plan

- [ ] Comprovar a GitHub que el README arrel es renderitza com a landing i que els enllaços resolen.
- [ ] Verificar les àncores internes de `tetris.md` (índex → seccions «Com s'usa», receptes, antipatrons).