### PR TITLE
[FIX] Agrupa resultats FCT per grup #188

### DIFF
--- a/app/Application/Poll/PollWorkflowService.php
+++ b/app/Application/Poll/PollWorkflowService.php
@@ -29,7 +29,7 @@ class PollWorkflowService
         }
 
         $modelo = $poll->modelo;
-        $quests = $modelo::loadPoll($this->loadPreviousVotes($poll, $user));
+        $quests = $modelo::loadPoll($this->loadPreviousVotes($poll, $user), $poll);
         $options = $this->surveyOptions($poll, $user);
 
         return [
@@ -47,7 +47,7 @@ class PollWorkflowService
         }
 
         $modelo = $poll->modelo;
-        $quests = $modelo::loadPoll($this->loadPreviousVotes($poll, $user));
+        $quests = $modelo::loadPoll($this->loadPreviousVotes($poll, $user), $poll);
         $options = $this->surveyOptions($poll, $user);
 
         foreach ($options as $question => $option) {
@@ -105,14 +105,14 @@ class PollWorkflowService
         $optionsNumeric = $options->filter(fn(Option $option): bool => $option->isNumericType());
         $optionsSelect = $options->filter(fn(Option $option): bool => $option->isSelectType());
 
-        $allVotes = Vote::allNumericVotes($id)->get();
+        $allVotes = $modelo::filterVotesForPoll(Vote::allNumericVotes($id)->get(), $poll);
         $option1 = $allVotes->groupBy(['idOption1', 'option_id']);
         $option2 = $allVotes->groupBy(['idOption2', 'option_id']);
 
         $votes = [];
         $this->initValues($votes, $optionsNumeric, $grupoService);
         $votes['all'] = $allVotes->groupBy('option_id');
-        $modelo::aggregate($votes, $option1, $option2);
+        $modelo::aggregate($votes, $option1, $option2, $poll);
 
         $stats = [
             'all' => [],
@@ -174,12 +174,13 @@ class PollWorkflowService
         ];
 
         if ($optionsSelect->isNotEmpty()) {
-            $allSelectVotes = Vote::allSelectVotes($id)->get();
+            $allSelectVotes = $modelo::filterVotesForPoll(Vote::allSelectVotes($id)->get(), $poll);
             $selectVotes['all'] = $allSelectVotes->groupBy('option_id');
             $modelo::aggregate(
                 $selectVotes,
                 $allSelectVotes->groupBy(['idOption1', 'option_id']),
-                $allSelectVotes->groupBy(['idOption2', 'option_id'])
+                $allSelectVotes->groupBy(['idOption2', 'option_id']),
+                $poll
             );
 
             foreach ($selectVotes['all'] as $optionId => $optionVote) {

--- a/app/Entities/Poll/Actividad.php
+++ b/app/Entities/Poll/Actividad.php
@@ -2,10 +2,13 @@
 
 namespace Intranet\Entities\Poll;
 
+/**
+ * Tipus d'enquesta vinculada a activitats dels grups de l'usuari.
+ */
 class Actividad extends ModelPoll
 {
 
-    public static function loadPoll($allVotes)
+    public static function loadPoll($allVotes, ?Poll $poll = null)
     {
         $actividades = collect();
         foreach (authUser()->Grupo as $grupo) {

--- a/app/Entities/Poll/Alumno.php
+++ b/app/Entities/Poll/Alumno.php
@@ -23,7 +23,7 @@ class Alumno extends ModelPoll
      * @param array<mixed> $votes
      * @return Collection<int, array{option1: object}>|null
      */
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {
         if (count($votes)) {
             return null;
@@ -87,7 +87,7 @@ class Alumno extends ModelPoll
      * @param iterable<mixed> $option2
      * @return void
      */
-    public static function aggregate(&$votes, $option1, $option2): void
+    public static function aggregate(&$votes, $option1, $option2, ?Poll $poll = null): void
     {
         foreach (AlumnoEntity::with(['Grupo.Ciclo'])->get() as $alumno) {
             $grupo = $alumno->Grupo->first();
@@ -120,7 +120,7 @@ class Alumno extends ModelPoll
     /**
      * Determina si l'alumne autenticat té context suficient per a respondre.
      */
-    public static function has()
+    public static function has(?Poll $poll = null)
     {
         $alumno = authUser();
 

--- a/app/Entities/Poll/AlumnoFct.php
+++ b/app/Entities/Poll/AlumnoFct.php
@@ -2,7 +2,9 @@
 
 namespace Intranet\Entities\Poll;
 
+use Illuminate\Support\Collection;
 use Intranet\Entities\Fct;
+use Intranet\Entities\Grupo;
 
 /**
  * Tipus d'enquesta de valoració FCT contestada per l'alumnat.
@@ -15,7 +17,7 @@ class AlumnoFct extends ModelPoll
      * @param array<mixed> $votes
      * @return \Illuminate\Support\Collection<int, array{option1: \Intranet\Entities\Fct}>|null
      */
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {
         $alumno = authUser();
         $fcts = collect();
@@ -25,6 +27,10 @@ class AlumnoFct extends ModelPoll
             ->whereNotIn('fcts.id', $votes)
             ->get();
         foreach ($alumnos as $fct) {
+            if (!self::matchesPollCourse($fct, $poll)) {
+                continue;
+            }
+
             $fcts->push(['option1'=>$fct]);
         }
         if (count($fcts)) {
@@ -67,7 +73,7 @@ class AlumnoFct extends ModelPoll
      * @param iterable<mixed> $option2
      * @return void
      */
-    public static function aggregate(&$votes, $option1, $option2)
+    public static function aggregate(&$votes, $option1, $option2, ?Poll $poll = null)
     {
         foreach ($option1 as $idFct => $vote) {
             $fct = Fct::with(['Colaboracion.Ciclo', 'Alumnos.Grupo'])->find($idFct);
@@ -105,23 +111,52 @@ class AlumnoFct extends ModelPoll
     }
 
     /**
-     * Construeix un mapa `nia|md5(nia) => codi de grup` per als alumnes de la FCT.
-     *
-     * @return array<string, string>
+     * Descarta els vots que no pertanyen al curs configurat en la poll.
      */
+    public static function filterVotesForPoll(Collection $votes, Poll $poll): Collection
+    {
+        if ($poll->curs === null) {
+            return $votes;
+        }
+
+        $course = (int) $poll->curs;
+        if (!in_array($course, [1, 2], true)) {
+            return $votes;
+        }
+
+        $fcts = Fct::with(['Colaboracion.Ciclo', 'Alumnos.Grupo'])
+            ->whereIn('id', $votes->pluck('idOption1')->filter()->unique()->values())
+            ->get()
+            ->keyBy('id');
+
+        return $votes
+            ->filter(function ($vote) use ($course, $fcts): bool {
+                $fct = $fcts->get($vote->idOption1);
+                $cicloId = $fct?->Colaboracion?->Ciclo?->id;
+                if (!$fct || $cicloId === null) {
+                    return false;
+                }
+
+                $group = self::groupByRespondent($fct, (int) $cicloId, (string) ($vote->user_id ?? ''));
+
+                return $group !== null && (int) $group->curso === $course;
+            })
+            ->values();
+    }
+
     private static function groupsByRespondent(Fct $fct, int $cicloId): array
     {
         $groups = [];
 
         foreach ($fct->Alumnos as $alumno) {
-            $groupCode = self::resolveStudentGroupCode($alumno, $cicloId);
-            if ($groupCode === null) {
+            $group = self::resolveStudentGroup($alumno, $cicloId);
+            if (!$group instanceof Grupo) {
                 continue;
             }
 
             $nia = (string) $alumno->nia;
-            $groups[$nia] = $groupCode;
-            $groups[md5($nia)] = $groupCode;
+            $groups[$nia] = (string) $group->codigo;
+            $groups[md5($nia)] = (string) $group->codigo;
         }
 
         return $groups;
@@ -130,12 +165,48 @@ class AlumnoFct extends ModelPoll
     /**
      * Resol el grup de l'alumne dins del mateix cicle que la FCT.
      */
-    private static function resolveStudentGroupCode(object $alumno, int $cicloId): ?string
+    private static function resolveStudentGroup(object $alumno, int $cicloId): ?Grupo
     {
         foreach ($alumno->Grupo ?? [] as $grupo) {
             if ((int) ($grupo->idCiclo ?? 0) === $cicloId) {
-                return (string) $grupo->codigo;
+                return $grupo;
             }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determina si la FCT correspon al curs configurat en la poll.
+     */
+    private static function matchesPollCourse(Fct $fct, ?Poll $poll): bool
+    {
+        if (!$poll || $poll->curs === null) {
+            return true;
+        }
+
+        $cicloId = $fct->Colaboracion?->Ciclo?->id;
+        if ($cicloId === null) {
+            return false;
+        }
+
+        $group = self::groupByRespondent($fct, (int) $cicloId, (string) authUser()->id);
+
+        return $group !== null && (int) $group->curso === (int) $poll->curs;
+    }
+
+    /**
+     * Retorna el grup del respondedor en la FCT, compatible amb polls anònimes.
+     */
+    private static function groupByRespondent(Fct $fct, int $cicloId, string $respondent): ?Grupo
+    {
+        foreach ($fct->Alumnos as $alumno) {
+            $nia = (string) $alumno->nia;
+            if (!in_array($respondent, [$nia, md5($nia)], true)) {
+                continue;
+            }
+
+            return self::resolveStudentGroup($alumno, $cicloId);
         }
 
         return null;
@@ -149,8 +220,12 @@ class AlumnoFct extends ModelPoll
     /**
      * Indica si l'usuari autenticat té FCT disponibles per contestar.
      */
-    public static function has()
+    public static function has(?Poll $poll = null)
     {
-        return count(authUser()->fcts);
+        if ($poll === null || $poll->curs === null) {
+            return count(authUser()->fcts);
+        }
+
+        return self::loadPoll([], $poll) !== null;
     }
 }

--- a/app/Entities/Poll/Fct.php
+++ b/app/Entities/Poll/Fct.php
@@ -4,9 +4,12 @@ namespace Intranet\Entities\Poll;
 
 use Intranet\Entities\Fct as realFct;
 
+/**
+ * Tipus d'enquesta FCT contestada pel professorat tutor.
+ */
 class Fct extends ModelPoll
 {
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {
         $fcts = collect();
         foreach (realFct::misFctsColaboracion()->esFct()->whereNotIn('id', $votes)->get() as $fct) {
@@ -39,19 +42,51 @@ class Fct extends ModelPoll
         return null;
     }
 
-    public static function aggregate(&$votes, $option1, $option2)
+    public static function aggregate(&$votes, $option1, $option2, ?Poll $poll = null)
     {
         foreach ($option1 as $idFct => $vote) {
-            $ciclo = realFct::find($idFct)->Colaboracion->Ciclo ?? null;
-            if ($ciclo) {
-                foreach ($vote as $key => $optionVotes) {
-                    foreach ($optionVotes as $optionVote) {
-                        $votes['cicle'][$ciclo->id][$key]->push($optionVote);
-                        $votes['departament'][$ciclo->departamento][$key]->push($optionVote);
+            $fct = realFct::with(['Colaboracion.Ciclo', 'Alumnos.Grupo'])->find($idFct);
+            $ciclo = $fct?->Colaboracion?->Ciclo;
+            if (!$fct || !$ciclo) {
+                continue;
+            }
+
+            $groupCodes = self::groupCodesForFct($fct, (int) $ciclo->id);
+
+            foreach ($vote as $key => $optionVotes) {
+                foreach ($optionVotes as $optionVote) {
+                    foreach ($groupCodes as $groupCode) {
+                        $votes['grup'][$groupCode][$key] ??= collect();
+                        $votes['grup'][$groupCode][$key]->push($optionVote);
                     }
+
+                    $votes['cicle'][$ciclo->id][$key]->push($optionVote);
+                    $votes['departament'][$ciclo->departamento][$key]->push($optionVote);
                 }
             }
         }
+    }
+
+    /**
+     * Retorna els codis de grup de l'alumnat associat a la FCT dins del cicle.
+     *
+     * @return array<int, string>
+     */
+    private static function groupCodesForFct(realFct $fct, int $cicloId): array
+    {
+        $groups = [];
+
+        foreach ($fct->Alumnos as $alumno) {
+            foreach ($alumno->Grupo ?? [] as $grupo) {
+                if ((int) ($grupo->idCiclo ?? 0) !== $cicloId) {
+                    continue;
+                }
+
+                $groups[] = (string) $grupo->codigo;
+            }
+        }
+
+        return array_values(array_unique($groups));
     }
 
     public static function loadGroupVotes($id)
@@ -59,7 +94,7 @@ class Fct extends ModelPoll
         return [];
     }
 
-    public static function has()
+    public static function has(?Poll $poll = null)
     {
         return realFct::misFctsColaboracion()->esFct()->count();
     }

--- a/app/Entities/Poll/ModelPoll.php
+++ b/app/Entities/Poll/ModelPoll.php
@@ -8,10 +8,14 @@
 
 namespace Intranet\Entities\Poll;
 
+use Illuminate\Support\Collection;
 
+/**
+ * Contracte base per als diferents tipus d'enquesta.
+ */
 abstract class ModelPoll
 {
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {}
     public static function loadVotes($id)
     {}
@@ -29,10 +33,18 @@ abstract class ModelPoll
     {
         return class_basename(static::class);
     }
-    public static function aggregate(&$votes, $option1, $option2)
+    public static function aggregate(&$votes, $option1, $option2, ?Poll $poll = null)
     {}
 
-    public static function has()
+    /**
+     * Permet al model descartar respostes que no corresponen al context de la poll.
+     */
+    public static function filterVotesForPoll(Collection $votes, Poll $poll): Collection
+    {
+        return $votes;
+    }
+
+    public static function has(?Poll $poll = null)
     {
         return true;
     }

--- a/app/Entities/Poll/Profesor.php
+++ b/app/Entities/Poll/Profesor.php
@@ -6,9 +6,12 @@ use Intranet\Application\Grupo\GrupoService;
 use Intranet\Entities\Departamento;
 use Intranet\Services\School\ModuloGrupoService;
 
+/**
+ * Tipus d'enquesta perquè l'alumnat valore professorat i mòduls.
+ */
 class Profesor extends ModelPoll
 {
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {
         if (count($votes)) {
             return null;
@@ -47,13 +50,13 @@ class Profesor extends ModelPoll
         return $myGroupsVotes;
     }
 
-    public static function aggregate(&$votes, $option1, $option2)
+    public static function aggregate(&$votes, $option1, $option2, ?Poll $poll = null)
     {
         self::aggregateGrupo($option1, $votes);
         self::aggregateDepartamento($option2, $votes);
     }
 
-    public static function has()
+    public static function has(?Poll $poll = null)
     {
         return count(authUser()->Grupo);
     }

--- a/app/Http/Controllers/PanelPollResponseController.php
+++ b/app/Http/Controllers/PanelPollResponseController.php
@@ -44,7 +44,7 @@ class PanelPollResponseController extends PollController
         $usuario = [];
         foreach ($activas as $activa) {
             $modelo = $activa->modelo;
-            if ($modelo::has() && $this->hasVisibleQuestionsForUser($activa, $mustFilterByCycle, $userCicleId)) {
+            if ($modelo::has($activa) && $this->hasVisibleQuestionsForUser($activa, $mustFilterByCycle, $userCicleId)) {
                 $usuario[] = $activa;
             }
         }

--- a/tests/Unit/Application/Poll/PollWorkflowServiceTest.php
+++ b/tests/Unit/Application/Poll/PollWorkflowServiceTest.php
@@ -523,6 +523,268 @@ class PollWorkflowServiceTest extends TestCase
         $this->assertSame(1, $result['stats']['grup']['1CAE'][40]['count']);
     }
 
+    public function test_all_votes_alumno_fct_filtra_resultats_pel_curs_de_la_poll(): void
+    {
+        DB::table('departamentos')->insert([
+            'id' => 1,
+            'cliteral' => 'Sanitat',
+            'vliteral' => 'Sanitat',
+        ]);
+
+        DB::table('ciclos')->insert([
+            'id' => 8,
+            'ciclo' => 'Cures auxiliars',
+            'departamento' => 1,
+        ]);
+
+        DB::table('grupos')->insert([
+            ['codigo' => '1CAE', 'nombre' => '1CAE', 'idCiclo' => 8, 'curso' => 1],
+            ['codigo' => '2CAE', 'nombre' => '2CAE', 'idCiclo' => 8, 'curso' => 2],
+        ]);
+
+        DB::table('alumnos')->insert([
+            [
+                'nia' => 'NIA10',
+                'dni' => 'DNI10',
+                'nombre' => 'Ada',
+                'apellido1' => 'Lovelace',
+                'apellido2' => 'Test',
+                'email' => 'ada@test.local',
+            ],
+            [
+                'nia' => 'NIA20',
+                'dni' => 'DNI20',
+                'nombre' => 'Grace',
+                'apellido1' => 'Hopper',
+                'apellido2' => 'Test',
+                'email' => 'grace@test.local',
+            ],
+        ]);
+
+        DB::table('alumnos_grupos')->insert([
+            ['idAlumno' => 'NIA10', 'idGrupo' => '1CAE'],
+            ['idAlumno' => 'NIA20', 'idGrupo' => '2CAE'],
+        ]);
+
+        DB::table('colaboraciones')->insert([
+            'id' => 100,
+            'idCiclo' => 8,
+        ]);
+
+        DB::table('fcts')->insert([
+            'id' => 200,
+            'idColaboracion' => 100,
+        ]);
+
+        DB::table('alumno_fcts')->insert([
+            ['idFct' => 200, 'idAlumno' => 'NIA10'],
+            ['idFct' => 200, 'idAlumno' => 'NIA20'],
+        ]);
+
+        $idPPoll = (int) DB::table('ppolls')->insertGetId([
+            'title' => 'Valoració FE alumnat',
+            'what' => 'AlumnoFct',
+            'anonymous' => 1,
+            'remains' => 0,
+        ]);
+
+        $idPoll = (int) DB::table('polls')->insertGetId([
+            'title' => 'Enquesta valoració FE Alumnat de 1er',
+            'desde' => '2026-03-01',
+            'hasta' => '2026-03-31',
+            'idPPoll' => $idPPoll,
+            'curs' => 1,
+        ]);
+
+        DB::table('options')->insert([
+            'id' => 41,
+            'question' => 'Valora l’empresa',
+            'scala' => 10,
+            'choices' => null,
+            'idCiclo' => null,
+            'ppoll_id' => $idPPoll,
+        ]);
+
+        DB::table('votes')->insert([
+            [
+                'idPoll' => $idPoll,
+                'user_id' => md5('NIA10'),
+                'option_id' => 41,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 9,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => md5('NIA20'),
+                'option_id' => 41,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 1,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $grupo1 = new Grupo();
+        $grupo1->codigo = '1CAE';
+        $grupo2 = new Grupo();
+        $grupo2->codigo = '2CAE';
+
+        $grupoService = $this->createMock(GrupoService::class);
+        $grupoService
+            ->method('all')
+            ->willReturn(new EloquentCollection([$grupo1, $grupo2]));
+
+        $service = new PollWorkflowService();
+        $result = $service->allVotes($idPoll, $grupoService);
+
+        $this->assertNotNull($result);
+        $this->assertSame(9.0, $result['stats']['all'][41]['avg']);
+        $this->assertSame(1, $result['stats']['all'][41]['count']);
+        $this->assertTrue($result['hasVotes']['grup']['1CAE']);
+        $this->assertFalse($result['hasVotes']['grup']['2CAE']);
+        $this->assertSame(9.0, $result['stats']['grup']['1CAE'][41]['avg']);
+        $this->assertSame(1, $result['stats']['grup']['1CAE'][41]['count']);
+        $this->assertSame(1, $result['stats']['cicle'][8][41]['count']);
+        $this->assertSame(1, $result['stats']['departament'][1][41]['count']);
+    }
+
+    public function test_all_votes_fct_de_tutor_agrupa_una_mateixa_poll_per_grups_de_primer_i_segon(): void
+    {
+        DB::table('departamentos')->insert([
+            'id' => 1,
+            'cliteral' => 'Sanitat',
+            'vliteral' => 'Sanitat',
+        ]);
+
+        DB::table('ciclos')->insert([
+            'id' => 8,
+            'ciclo' => 'Cures auxiliars',
+            'departamento' => 1,
+        ]);
+
+        DB::table('grupos')->insert([
+            ['codigo' => '1CAE', 'nombre' => '1CAE', 'idCiclo' => 8, 'curso' => 1],
+            ['codigo' => '2CAE', 'nombre' => '2CAE', 'idCiclo' => 8, 'curso' => 2],
+        ]);
+
+        DB::table('alumnos')->insert([
+            [
+                'nia' => 'NIA10',
+                'dni' => 'DNI10',
+                'nombre' => 'Ada',
+                'apellido1' => 'Lovelace',
+                'apellido2' => 'Test',
+                'email' => 'ada@test.local',
+            ],
+            [
+                'nia' => 'NIA20',
+                'dni' => 'DNI20',
+                'nombre' => 'Grace',
+                'apellido1' => 'Hopper',
+                'apellido2' => 'Test',
+                'email' => 'grace@test.local',
+            ],
+        ]);
+
+        DB::table('alumnos_grupos')->insert([
+            ['idAlumno' => 'NIA10', 'idGrupo' => '1CAE'],
+            ['idAlumno' => 'NIA20', 'idGrupo' => '2CAE'],
+        ]);
+
+        DB::table('colaboraciones')->insert([
+            'id' => 100,
+            'idCiclo' => 8,
+        ]);
+
+        DB::table('fcts')->insert([
+            ['id' => 200, 'idColaboracion' => 100],
+            ['id' => 201, 'idColaboracion' => 100],
+        ]);
+
+        DB::table('alumno_fcts')->insert([
+            ['idFct' => 200, 'idAlumno' => 'NIA10'],
+            ['idFct' => 201, 'idAlumno' => 'NIA20'],
+        ]);
+
+        $idPPoll = (int) DB::table('ppolls')->insertGetId([
+            'title' => 'Enquesta tutor avaluació FCT',
+            'what' => 'Fct',
+            'anonymous' => 0,
+            'remains' => 0,
+        ]);
+
+        $idPoll = (int) DB::table('polls')->insertGetId([
+            'title' => 'Enquesta Tutor Avaluació FE',
+            'desde' => '2026-03-01',
+            'hasta' => '2026-03-31',
+            'idPPoll' => $idPPoll,
+            'curs' => null,
+        ]);
+
+        DB::table('options')->insert([
+            'id' => 42,
+            'question' => 'Valora la FE',
+            'scala' => 10,
+            'choices' => null,
+            'idCiclo' => null,
+            'ppoll_id' => $idPPoll,
+        ]);
+
+        DB::table('votes')->insert([
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'PROF1',
+                'option_id' => 42,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 9,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'PROF2',
+                'option_id' => 42,
+                'idOption1' => 201,
+                'idOption2' => null,
+                'value' => 5,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $grupo1 = new Grupo();
+        $grupo1->codigo = '1CAE';
+        $grupo2 = new Grupo();
+        $grupo2->codigo = '2CAE';
+
+        $grupoService = $this->createMock(GrupoService::class);
+        $grupoService
+            ->method('all')
+            ->willReturn(new EloquentCollection([$grupo1, $grupo2]));
+
+        $service = new PollWorkflowService();
+        $result = $service->allVotes($idPoll, $grupoService);
+
+        $this->assertNotNull($result);
+        $this->assertSame(7.0, $result['stats']['all'][42]['avg']);
+        $this->assertSame(2, $result['stats']['all'][42]['count']);
+        $this->assertTrue($result['hasVotes']['grup']['1CAE']);
+        $this->assertTrue($result['hasVotes']['grup']['2CAE']);
+        $this->assertSame(9.0, $result['stats']['grup']['1CAE'][42]['avg']);
+        $this->assertSame(5.0, $result['stats']['grup']['2CAE'][42]['avg']);
+        $this->assertSame(1, $result['stats']['grup']['1CAE'][42]['count']);
+        $this->assertSame(1, $result['stats']['grup']['2CAE'][42]['count']);
+    }
+
     /**
      * Crea una plantilla d'enquesta mínima per als tests del workflow.
      *
@@ -570,6 +832,7 @@ class PollWorkflowServiceTest extends TestCase
             $table->string('title')->nullable();
             $table->date('desde')->nullable();
             $table->date('hasta')->nullable();
+            $table->unsignedTinyInteger('curs')->nullable();
             $table->unsignedInteger('idPPoll');
         });
 
@@ -673,7 +936,7 @@ class WorkflowTestModel extends ModelPoll
         return 'dni';
     }
 
-    public static function loadPoll($votes)
+    public static function loadPoll($votes, ?Poll $poll = null)
     {
         self::$lastVotesInput = is_array($votes) ? $votes : [];
 


### PR DESCRIPTION
## Canvis

- Passa el context de la poll als models d'enquesta per poder filtrar/agregar segons el tipus.
- Reconstrueix els grups de les respostes en enquestes FCT de tutor a partir de la FCT i l'alumnat associat.
- Manté el cas `AlumnoFct` compatible amb polls separades per curs quan `polls.curs` està informat.
- Afig regressions per a una mateixa poll FCT/FE amb alumnat de 1r i 2n.

## Causa

La poll de tutor usa el model `Fct`, però `Fct::aggregate()` només agregava per cicle i departament. Per això la fulla `Grups` podia quedar buida encara que `idOption1` apuntara correctament a la FCT.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=PollWorkflowServiceTest`
- 12 tests, 62 assertions.

Refs #188