### PR TITLE
[FIX] Avoid DataTables placeholder rows in empty grids #194

### DIFF
--- a/resources/views/components/grid/table.blade.php
+++ b/resources/views/components/grid/table.blade.php
@@ -18,20 +18,9 @@
 
         @if($mostrarBody)
             <tbody>
-            @forelse($elementos as $elemento)
+            @foreach($elementos as $elemento)
                 <x-grid.row :elemento="$elemento" :panel="$panel" :pestana="$pestana" />
-            @empty
-                @php($cols = count($panel->getRejilla()) + 1)
-                <tr>
-                    @for ($i = 0; $i < $cols; $i++)
-                        @if ($i === 0)
-                            <td class="text-center">@lang('No hi ha dades disponibles')</td>
-                        @else
-                            <td></td>
-                        @endif
-                    @endfor
-                </tr>
-            @endforelse
+            @endforeach
             </tbody>
         @endif
 

--- a/tests/Feature/GridTableComponentTest.php
+++ b/tests/Feature/GridTableComponentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Blade;
+use Intranet\Presentation\Crud\TutoriaCrudSchema;
+use Intranet\UI\Panels\Panel;
+use Tests\TestCase;
+
+/**
+ * Proves de renderitzat de taules de grid compatibles amb DataTables.
+ */
+class GridTableComponentTest extends TestCase
+{
+    public function test_taula_buida_no_renderitza_fila_placeholder_en_tbody(): void
+    {
+        $panel = new Panel('Tutoria', TutoriaCrudSchema::GRID_FIELDS);
+        $pestana = $panel->getPestanas()[0];
+
+        $html = Blade::render(
+            '<x-grid.table :panel="$panel" :pestana="$pestana" :elementos="$elementos" />',
+            [
+                'panel' => $panel,
+                'pestana' => $pestana,
+                'elementos' => new Collection(),
+            ]
+        );
+
+        $document = new DOMDocument();
+        @$document->loadHTML($html);
+
+        $rows = (new DOMXPath($document))->query('//table[@id="datatable"]/tbody/tr');
+
+        $this->assertSame(0, $rows?->length);
+    }
+}


### PR DESCRIPTION
## Resum

Follow-up del desplegament de #194. El llistat `/tutoria` podia mostrar el warning de DataTables `Requested unknown parameter '1' for row 0, column 1` quan la graella no tenia registres.

## Causa

El component compartit de graella renderitzava una fila manual de placeholder dins del `<tbody>` quan no hi havia elements. DataTables pot interpretar eixa fila com una fila de dades i fallar si el recompte de columnes no quadra.

## Canvi

- El `<tbody>` queda buit quan no hi ha elements i DataTables gestiona el missatge de taula buida.
- S'afig un test del component per garantir que una taula buida no renderitza files placeholder.

## Validació

- `php -l tests/Feature/GridTableComponentTest.php`
- `php artisan test --filter=GridTableComponentTest`
- `php artisan test --filter=RouteNameContractTest`
- `php artisan route:clear`
- `php artisan route:cache`

Refs #194