### PR TITLE
[ADD] Reconstruir caché de rutes i vistes durant l'actualització #212

### DIFF
--- a/app/Http/Controllers/ActualizacionController.php
+++ b/app/Http/Controllers/ActualizacionController.php
@@ -46,6 +46,14 @@ class ActualizacionController extends Controller
         Alert::info('config:cache executat');
         Log::info('config:cache executat durant /actualizacion.');
 
+        Artisan::call('route:cache');
+        Alert::info('route:cache executat');
+        Log::info('route:cache executat durant /actualizacion.');
+
+        Artisan::call('view:cache');
+        Alert::info('view:cache executat');
+        Log::info('view:cache executat durant /actualizacion.');
+
         Artisan::call('migrate', ['--force' => true]);
         Alert::info('migrate --force executat');
         Log::info('migrate --force executat durant /actualizacion.');


### PR DESCRIPTION
## Resum

- Afegeix `route:cache` i `view:cache` al flux de `ActualizacionController@actualizacion`, just després de `config:cache`.
- Tanca #212

## Motivació

Sense aquests passos, un desplegament que inclogués nous noms de ruta (com el recent #194) o canvis Blade podia deixar l'aplicació servint versions antigues fins a intervenció manual.

## Ordre d'execució resultant

1. Elimina `composer.lock`
2. `git pull origin <branca>`
3. `config:cache`
4. **`route:cache`** ← nou
5. **`view:cache`** ← nou
6. `migrate --force`
7. Scripts d'actualització funcional per versió

## Tests

- Canvi mínim, sense lògica nova: un `Artisan::call` per comanda, mateix patró que `config:cache` ja existent.
- Verificació manual: executar l'acció i comprovar que les tres caches es reconstrueixen sense errors.