### PR TITLE
[FIX] Sincronitza hores SAO en FCT aptes

### DIFF
--- a/app/Console/Commands/SaoConnect.php
+++ b/app/Console/Commands/SaoConnect.php
@@ -11,6 +11,9 @@ use Intranet\Services\Automation\SeleniumService;
 use Intranet\Sao\SaoSyncAction;
 use Intranet\Services\UI\AlertLogger;
 
+/**
+ * Comanda per sincronitzar dades de FCT amb SAO.
+ */
 class SaoConnect extends Command
 {
     protected $signature = 'sao:connect';
@@ -30,10 +33,10 @@ class SaoConnect extends Command
             );
 
             (new SaoSyncAction())->execute($driver,function () {
-                return AlumnoFct::whereNotNull('idSao')
+                return AlumnoFct::query()
                     ->noHaAcabado()
                     ->haEmpezado()
-                    ->activa();
+                    ->pendentSincronitzacioSao();
             });
 
             return Command::SUCCESS;

--- a/app/Entities/AlumnoFct.php
+++ b/app/Entities/AlumnoFct.php
@@ -198,9 +198,45 @@ class AlumnoFct extends Model
         return $query->whereNotIn('idFct', $fcts);
     }
 
+    /**
+     * Filtra FCT actives pendents de completar i sense qualificació.
+     */
     public function scopeActiva($query)
     {
        return $query->whereNull('calificacion')->where('correoAlumno', 0)->whereColumn('horas', '>', 'realizadas');
+    }
+
+    /**
+     * Filtra FCT amb hores pendents que han de consultar-se en SAO.
+     */
+    public function scopePendentSincronitzacioSao($query)
+    {
+        return $query
+            ->whereNotNull('idSao')
+            ->whereColumn('horas', '>', 'realizadas')
+            ->where(function ($query): void {
+                $query->where(function ($query): void {
+                    $query->whereNull('calificacion')
+                        ->where('correoAlumno', 0);
+                })
+                    ->orWhere('calificacion', 1);
+            });
+    }
+
+    /**
+     * Indica les hores SAO pendents de sincronitzar.
+     */
+    public function getHoresPendentsSaoAttribute(): int
+    {
+        return max(0, (int) $this->horas - (int) $this->realizadas);
+    }
+
+    /**
+     * Indica si cal confirmar l'aprovat perquè queden hores pendents.
+     */
+    public function getRequereixConfirmacioApteAttribute(): bool
+    {
+        return $this->hores_pendents_sao > 0;
     }
 
     public function scopeHaEmpezado($query)

--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -148,6 +148,8 @@ class PanelFctAvalController extends IntranetController
             $fct->setAttribute('proyecto_requerido', $requiresProject ? 1 : 0);
             $fct->setAttribute('grupo_codigo', $grupo?->codigo);
             $fct->setAttribute('grupo_nombre', $grupo?->nombre);
+            $fct->setAttribute('hores_pendents_sao', $fct->hores_pendents_sao);
+            $fct->setAttribute('requereix_confirmacio_apte', $fct->requereix_confirmacio_apte ? 1 : 0);
 
             return $fct;
         });
@@ -308,10 +310,28 @@ class PanelFctAvalController extends IntranetController
                 'fct.apte',
                 [
                     'img' => 'fa-hand-o-up',
+                    'title' => 'Marcar com a apte',
                     'where' => [
                         'calificacion', '!=', '1',
                         'actas', '==', 0,
-                        'asociacion', '<>', 2
+                        'asociacion', '<>', 2,
+                        'requereix_confirmacio_apte', '==', 0
+                    ]
+                ]
+            ));
+        $this->panel->setBoton(
+            'grid',
+            new BotonImg(
+                'fct.apte',
+                [
+                    'img' => 'fa-hand-o-up',
+                    'title' => 'Marcar com a apte amb hores pendents',
+                    'onclick' => "if (!confirm('Aquesta FCT encara té hores pendents de sincronitzar amb SAO. Vols marcar-la com a apta igualment?')) { return false; } this.href += (this.href.indexOf('?') === -1 ? '?' : '&') + 'confirmar_hores=1'; return true;",
+                    'where' => [
+                        'calificacion', '!=', '1',
+                        'actas', '==', 0,
+                        'asociacion', '<>', 2,
+                        'requereix_confirmacio_apte', '==', 1
                     ]
                 ]
             ));
@@ -424,6 +444,16 @@ class PanelFctAvalController extends IntranetController
     protected function apte($id)
     {
         Gate::authorize('manageAval', Fct::class);
+        $fct = $this->alumnoFcts()->findOrFail((int) $id);
+        if ($fct->requereix_confirmacio_apte && request('confirmar_hores') !== '1') {
+            Alert::message(
+                "Aquesta FCT encara té {$fct->hores_pendents_sao} hores pendents de sincronitzar amb SAO. Confirma explícitament l'aprovat per continuar.",
+                'warning'
+            );
+
+            return back();
+        }
+
         $this->avals()->apte((int) $id);
 
         return back();

--- a/app/Sao/SaoSyncAction.php
+++ b/app/Sao/SaoSyncAction.php
@@ -86,13 +86,16 @@ class SaoSyncAction
         AlertLogger::info('Fcts sincronitzades: ' . implode(', ', $alumnesActualitzats));
     }
 
+    /**
+     * Recupera les FCT candidates a sincronitzar amb SAO.
+     */
     private function getValidFcts()
     {
         if ($this->queryCallback) {
             return call_user_func($this->queryCallback)->get();
         }
 
-        return AlumnoFct::realFcts()->haEmpezado()->activa()->get();
+        return AlumnoFct::realFcts()->haEmpezado()->pendentSincronitzacioSao()->get();
     }
 
     private function obtenirHoresFct($idSao): ?int

--- a/app/UI/Botones/BotonImg.php
+++ b/app/UI/Botones/BotonImg.php
@@ -36,6 +36,7 @@ class BotonImg extends BotonElemento
             'rel' => $this->rel,
             'ariaLabel' => $this->ariaLabel,
             'title' => $this->title,
+            'onclick' => $this->onclick,
             'img' => $this->img??config("iconos.$this->accion"),
             'text' => $this->text,
             'badge' => $this->badge

--- a/resources/views/components/buttons/img.blade.php
+++ b/resources/views/components/buttons/img.blade.php
@@ -4,6 +4,7 @@
    @isset($rel) rel="{{$rel}}" @endisset
    @isset($ariaLabel) aria-label="{{$ariaLabel}}" @endisset
    @isset($title) title="{{$title}}" @endisset
+   @isset($onclick) onclick="{{$onclick}}" @endisset
    {!! $disabled !!}>
     @isset($img)
         <em class='fa {{$img}}' alt="{{$text}}" title="{{$text}}"></em>

--- a/tests/Unit/Entities/AlumnoFctScopeTest.php
+++ b/tests/Unit/Entities/AlumnoFctScopeTest.php
@@ -72,6 +72,23 @@ class AlumnoFctScopeTest extends TestCase
         $this->assertSame([30], $ids);
     }
 
+    public function test_scope_pendent_sincronitzacio_sao_inclou_aptes_amb_hores_pendents(): void
+    {
+        DB::table('alumno_fcts')->insert([
+            ['id' => 34, 'idFct' => 1, 'idSao' => 1001, 'calificacion' => null, 'correoAlumno' => 0, 'horas' => 120, 'realizadas' => 60],
+            ['id' => 35, 'idFct' => 1, 'idSao' => 1002, 'calificacion' => 1, 'correoAlumno' => 0, 'horas' => 120, 'realizadas' => 60],
+            ['id' => 36, 'idFct' => 1, 'idSao' => 1003, 'calificacion' => 1, 'correoAlumno' => 0, 'horas' => 120, 'realizadas' => 120],
+            ['id' => 37, 'idFct' => 1, 'idSao' => 1004, 'calificacion' => 0, 'correoAlumno' => 0, 'horas' => 120, 'realizadas' => 60],
+            ['id' => 38, 'idFct' => 1, 'idSao' => null, 'calificacion' => 1, 'correoAlumno' => 0, 'horas' => 120, 'realizadas' => 60],
+            ['id' => 39, 'idFct' => 1, 'idSao' => 1005, 'calificacion' => 1, 'correoAlumno' => 1, 'horas' => 120, 'realizadas' => 60],
+            ['id' => 40, 'idFct' => 1, 'idSao' => 1006, 'calificacion' => null, 'correoAlumno' => 1, 'horas' => 120, 'realizadas' => 60],
+        ]);
+
+        $ids = AlumnoFct::query()->pendentSincronitzacioSao()->pluck('id')->all();
+
+        $this->assertSame([34, 35, 39], $ids);
+    }
+
     public function test_scope_mis_fcts_inclou_professor_i_substituit(): void
     {
         DB::table('profesores')->insert([
@@ -229,6 +246,7 @@ class AlumnoFctScopeTest extends TestCase
         $schema->create('alumno_fcts', function (Blueprint $table): void {
             $table->increments('id');
             $table->unsignedInteger('idFct');
+            $table->unsignedInteger('idSao')->nullable();
             $table->string('idProfesor', 10)->nullable();
             $table->unsignedInteger('calificacion')->nullable();
             $table->unsignedTinyInteger('correoAlumno')->default(0);


### PR DESCRIPTION
## Resum
- Permet que la sincronització SAO revise FCT aptes amb hores pendents.
- Afig confirmació explícita abans de marcar com a apta una FCT amb hores pendents.
- Afig regressió del scope de sincronització SAO.

Closes #216

## Tests
- php artisan test --filter=AlumnoFctScopeTest
- php artisan test --filter=PanelFctAvalControllerTest
- php -l app/Entities/AlumnoFct.php
- php -l app/Http/Controllers/PanelFctAvalController.php
- php -l app/Sao/SaoSyncAction.php
- php -l app/Console/Commands/SaoConnect.php
- php -l app/UI/Botones/BotonImg.php
- git diff --check