### PR TITLE
[ADD] Evita el modal de selecció en annexos signats

### DIFF
--- a/app/Http/Controllers/SignaturaController.php
+++ b/app/Http/Controllers/SignaturaController.php
@@ -159,6 +159,7 @@ class SignaturaController extends ModalController
                     'text' => "Envia Documentació a l'Instructor",
                     'class' => 'btn-info seleccion',
                     'data-url' => '/api/documentacionFCT/Signed',
+                    'data-skip-selection-option' => 'instructor-annexes',
                     'id' => '/signatura/All/send',
                     'roles' => config(self::ROLES_ROL_TUTOR)
                 ]

--- a/public/js/selDoc.js
+++ b/public/js/selDoc.js
@@ -42,8 +42,132 @@
         return Promise.reject(new Error('intranetApiAuth.apiGet no disponible'));
     }
 
-    function handleSeleccionClick(button, event) {
+    function storageKey(button) {
+        return 'signatura.skipSelection.' + (button.getAttribute('data-skip-selection-option') || 'default');
+    }
+
+    function readStorage(key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function writeStorage(key, value) {
+        try {
+            window.localStorage.setItem(key, value);
+        } catch (error) {
+            return;
+        }
+    }
+
+    function createSkipSelectionOption(button) {
+        if (!button || !button.hasAttribute('data-skip-selection-option')) {
+            return;
+        }
+
+        var id = 'skipSelection' + button.getAttribute('data-skip-selection-option');
+        if (document.getElementById(id)) {
+            return;
+        }
+
+        var wrapper = document.createElement('label');
+        wrapper.className = 'checkbox-inline signatura-skip-selection-option';
+        wrapper.style.marginLeft = '8px';
+
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = id;
+        checkbox.setAttribute('data-skip-selection-for', button.getAttribute('data-skip-selection-option'));
+        checkbox.checked = readStorage(storageKey(button)) === '1';
+
+        checkbox.addEventListener('change', function () {
+            writeStorage(storageKey(button), checkbox.checked ? '1' : '0');
+        });
+
+        wrapper.appendChild(checkbox);
+        wrapper.appendChild(document.createTextNode(' Enviar sense finestra de selecció'));
+        button.insertAdjacentElement('afterend', wrapper);
+    }
+
+    function skipSelectionIsEnabled(button) {
+        var option = button.getAttribute('data-skip-selection-option');
+        var checkbox = option ? document.querySelector('[data-skip-selection-for="' + option + '"]') : null;
+
+        return checkbox ? checkbox.checked : false;
+    }
+
+    function csrfToken(form) {
+        var input = form ? form.querySelector('input[name="_token"]') : null;
+        if (input) {
+            return input.value;
+        }
+
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        return meta ? meta.getAttribute('content') : '';
+    }
+
+    function directSubmit(route, token, elements) {
+        var form = document.createElement('form');
+        form.method = 'POST';
+        form.action = route;
+        form.style.display = 'none';
+
+        var tokenInput = document.createElement('input');
+        tokenInput.type = 'hidden';
+        tokenInput.name = '_token';
+        tokenInput.value = token;
+        form.appendChild(tokenInput);
+
+        elements.forEach(function (element) {
+            var input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = element.id;
+            input.value = 'on';
+            form.appendChild(input);
+        });
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+    function selectedByDefault(elements) {
+        return elements.filter(function (element) {
+            return element.marked || element.marked == null;
+        });
+    }
+
+    function sendWithoutSelection(button) {
+        var url = button.getAttribute('data-url') || '';
+        var route = button.getAttribute('id') || '';
+        var form = document.getElementById('formA3A');
+
+        apiGet(url)
+            .then(function (result) {
+                var elements = selectedByDefault(result.data || []);
+                if (elements.length === 0) {
+                    handleSeleccionClick(button, { preventDefault: function () {} }, true);
+                    return;
+                }
+
+                button.classList.add('disabled');
+                button.setAttribute('aria-disabled', 'true');
+                directSubmit(route, csrfToken(form), elements);
+            })
+            .catch(function () {
+                console.log('La sol·licitud no s\'ha pogut completar.');
+                handleSeleccionClick(button, { preventDefault: function () {} }, true);
+            });
+    }
+
+    function handleSeleccionClick(button, event, forceModal) {
         event.preventDefault();
+        if (!forceModal && skipSelectionIsEnabled(button)) {
+            sendWithoutSelection(button);
+            return;
+        }
+
         setModalAttrs(button, 'A3A');
         openModal('A3A');
 
@@ -85,6 +209,7 @@
 
     document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('.seleccion').forEach(function (button) {
+            createSkipSelectionOption(button);
             button.addEventListener('click', function (event) {
                 handleSeleccionClick(button, event);
             });


### PR DESCRIPTION
## Resum
- Afig una opció per enviar documentació signada a l'instructor sense obrir la finestra modal de selecció.
- Manté el comportament actual per defecte si el check no està activat.
- Reutilitza la mateixa API de selecció i envia directament els elements marcats per defecte.

## Validació
- php artisan test --filter='BotonesTest|SignaturaTest|SignaturaPolicyTest|SignaturaStatusServiceTest|EmailPostSendServiceTest'
- php artisan test --filter='RouteNameContractTest|GridTableComponentTest'
- node --check public/js/selDoc.js

Closes #218
Closes #219