### PR TITLE
[FIX] Clarify absence send step and Selenium docs #205 #206

### DIFF
--- a/app/Http/Controllers/FaltaController.php
+++ b/app/Http/Controllers/FaltaController.php
@@ -62,7 +62,11 @@ class FaltaController extends ModalController
         $this->panel->setBotonera(['create']);
         $this->panel->setBoton('grid', new BotonImg('falta.delete', ['where' => ['estado', '==', '0']]));
         $this->panel->setBoton('grid', new BotonImg('falta.edit', ['where' => ['estado', '<', '3']]));
-        $this->panel->setBoton('grid', new BotonImg('falta.init', ['where' => ['estado', '==', '0']]));
+        $this->panel->setBoton('grid', new BotonImg('falta.init', [
+            'where' => ['estado', '==', '0'],
+            'title' => 'Enviar a direcció',
+            'aria-label' => 'Enviar falta a direcció',
+        ]));
         $this->panel->setBoton('grid', new BotonImg('falta.document', ['where' => ['fichero', '!=', '']]));
     }
 
@@ -80,7 +84,16 @@ class FaltaController extends ModalController
         if (!$request->boolean('baja') && UserisAllow(config('roles.rol.direccion'))) {
             $this->faltas()->init($id);
         } elseif (!$request->boolean('baja')) {
-            return ConfirmAndSend::render($this->model, $id);
+            return ConfirmAndSend::render(
+                $this->model,
+                $id,
+                'Enviar falta a direcció',
+                null,
+                null,
+                'La falta s\'ha guardat, però direcció encara no la veurà. Prem "Enviar a direcció" per a completar el tràmit.',
+                'Enviar a direcció',
+                'Deixar pendent'
+            );
         }
 
         return $this->redirect();

--- a/app/Services/Notifications/ConfirmAndSend.php
+++ b/app/Services/Notifications/ConfirmAndSend.php
@@ -1,15 +1,47 @@
 <?php
 namespace Intranet\Services\Notifications;
 
+/**
+ * Renderitza la pantalla intermèdia de confirmació abans d'enviar un element.
+ */
 class ConfirmAndSend
 {
-    public static function render($model, $id, $message=null, $route=null, $back=null)
-    {
+    /**
+     * Mostra una confirmació explícita abans de canviar l'estat d'un element.
+     *
+     * @param string $model Nom curt del model.
+     * @param int|string $id Identificador de l'element.
+     * @param string|null $message Títol del pas de confirmació.
+     * @param string|null $route URL que confirma l'enviament.
+     * @param string|null $back URL de tornada sense enviar.
+     * @param string|null $notice Text explicatiu addicional.
+     * @param string $confirmText Text del botó de confirmació.
+     * @param string $cancelText Text del botó de cancel·lació.
+     * @return \Illuminate\Contracts\View\View
+     */
+    public static function render(
+        $model,
+        $id,
+        $message = null,
+        $route = null,
+        $back = null,
+        $notice = null,
+        $confirmText = 'SI',
+        $cancelText = 'NO'
+    ) {
         $class = 'Intranet\\Entities\\'.$model;
         $element = $class::find($id);
         $route = $route??"/".strtolower($model)."/$id/init/";
         $back = $back??"/".strtolower($model)."/";
         $message = $message ?? "Enviar $model a Direcció";
-        return view('intranet.confirm', compact('element', 'message', 'route', 'back'));
+        return view('intranet.confirm', compact(
+            'element',
+            'message',
+            'route',
+            'back',
+            'notice',
+            'confirmText',
+            'cancelText'
+        ));
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,4 @@ Intranet del CIP FP Batoi. Documentació organitzada per tipus (alta cohesió, b
 - [Setup i instal·lació](operations/setup.md)
 - [Esquema de la BD](architecture/bbdd-esquema.md)
 - [Desplegament Docker](operations/docker-prod.md)
+- [Selenium/SAO en producció](operations/selenium-sao-prod.md)

--- a/docs/operations/selenium-sao-prod.md
+++ b/docs/operations/selenium-sao-prod.md
@@ -1,0 +1,140 @@
+# Servei Selenium per a SAO en producció
+
+## Objectiu
+
+Selenium dona suport als fluxos que entren en SAO/ITACA des de la intranet, sobretot la descàrrega i signatura d'annexos FCT. En producció el servei corre com a contenidor separat i Laravel s'hi connecta per HTTP.
+
+Fitxers clau:
+
+- `docker-compose.prod.yml`: serveis `laravel.prod` i `selenium`, volum compartit `selenium-downloads`.
+- `app/Services/Automation/SeleniumService.php`: connexió amb Selenium i login SAO/ITACA.
+- `app/Sao/Support/SaoRunner.php`: obri driver, executa l'acció SAO i tanca sessió.
+- `app/Sao/Documents/*DocumentService.php`: descàrrega i processat d'annexos.
+- `config/sao.php` i `config/services.php`: URLs, esperes i directori de descàrrega.
+
+## Serveis i volums
+
+En producció, `docker-compose.prod.yml` defineix:
+
+```yaml
+laravel.prod:
+  volumes:
+    - selenium-downloads:/srv/documentsfct
+  depends_on:
+    - selenium
+
+selenium:
+  image: selenium/standalone-firefox:latest
+  ports:
+    - '${FORWARD_SELENIUM_PORT:-4444}:4444'
+    - '127.0.0.1:${FORWARD_SELENIUM_VNC_PORT:-7900}:7900'
+  volumes:
+    - selenium-downloads:/home/seluser/Downloads
+```
+
+El navegador descarrega en `/home/seluser/Downloads` dins del contenidor Selenium. Laravel veu el mateix volum en `/srv/documentsfct`.
+
+Variables recomanades en `.env`:
+
+```env
+SELENIUM_URL=selenium:4444
+SELENIUM_URL_SAO=https://foremp.edu.gva.es/index.php
+SELENIUM_URL_ITACA=https://acces.edu.gva.es/sso/login.xhtml?callbackUrl=https://acces.edu.gva.es/escriptori/
+SAO_DOWNLOAD_DIR=/srv/documentsfct
+SAO_DOWNLOAD_WAIT_SECONDS=10
+SAO_NAVIGATION_SLEEP_SECONDS=1
+```
+
+No publiques el port VNC fora de localhost. En producció el patró recomanat és `127.0.0.1:7900:7900` i accés per túnel SSH si cal veure el navegador.
+
+## Arrancada
+
+Des del directori de desplegament:
+
+```bash
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d selenium laravel.prod
+docker compose -f docker-compose.prod.yml ps
+```
+
+Comprovacions mínimes:
+
+```bash
+docker compose -f docker-compose.prod.yml exec laravel.prod php artisan config:clear
+docker compose -f docker-compose.prod.yml exec laravel.prod php artisan tinker
+```
+
+En `tinker`, comprova que Laravel resol el host de Selenium:
+
+```php
+config('services.selenium.url'); // selenium:4444
+config('sao.download.directory'); // /srv/documentsfct
+```
+
+## Flux de depuració
+
+1. Revisa estat dels contenidors:
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --tail=100 selenium
+docker compose -f docker-compose.prod.yml logs --tail=100 laravel.prod
+```
+
+2. Revisa logs SAO de Laravel:
+
+```bash
+docker compose -f docker-compose.prod.yml exec laravel.prod tail -n 200 storage/logs/sao.log
+docker compose -f docker-compose.prod.yml exec laravel.prod tail -n 200 storage/logs/laravel.log
+```
+
+3. Comprova el volum compartit:
+
+```bash
+docker compose -f docker-compose.prod.yml exec selenium ls -lah /home/seluser/Downloads
+docker compose -f docker-compose.prod.yml exec laravel.prod ls -lah /srv/documentsfct
+```
+
+Si el fitxer apareix en Selenium però no en Laravel, el problema és el muntatge del volum. Si no apareix en Selenium, el problema és navegació, credencials, selector o descàrrega bloquejada.
+
+4. Mira el navegador amb VNC només si cal:
+
+```bash
+ssh -L 7900:127.0.0.1:7900 usuari@servidor
+```
+
+Després obri `http://127.0.0.1:7900` des del teu equip. No deixes este port exposat públicament.
+
+## Errors habituals
+
+- `No s'ha pogut connectar al servidor de Selenium`: `SELENIUM_URL` no apunta a `selenium:4444`, el servei no està alçat o no comparteix xarxa Docker amb Laravel.
+- `Password no vàlid`: credencial SAO/ITACA incorrecta o portal extern rebutjant l'accés.
+- Descàrrega no trobada: revisa `SAO_DOWNLOAD_DIR`, permisos del volum i `SAO_DOWNLOAD_WAIT_SECONDS`.
+- Procés penjat: comprova VNC, logs de `sao.log` i canvis en selectors del portal SAO.
+- `storage/logs/sao.log` buit: l'acció pot estar fallant abans d'entrar en el flux SAO; revisa `laravel.log`.
+
+## Reinici controlat
+
+Per reiniciar només Selenium:
+
+```bash
+docker compose -f docker-compose.prod.yml restart selenium
+```
+
+Per actualitzar la imatge i conservar volums:
+
+```bash
+docker compose -f docker-compose.prod.yml pull selenium
+docker compose -f docker-compose.prod.yml up -d selenium
+```
+
+No esborres el volum `selenium-downloads` durant una incidència si encara necessites inspeccionar fitxers descarregats.
+
+## Checklist postcanvi
+
+- `docker compose -f docker-compose.prod.yml ps` mostra `selenium` i `laravel.prod` en estat saludable.
+- Laravel resol `SELENIUM_URL=selenium:4444`.
+- `SAO_DOWNLOAD_DIR` apunta a `/srv/documentsfct`.
+- El volum `selenium-downloads` està muntat en els dos serveis.
+- El port VNC només està exposat en `127.0.0.1`.
+- S'han revisat `storage/logs/sao.log` i `storage/logs/laravel.log` després d'una prova real.

--- a/resources/views/intranet/confirm.blade.php
+++ b/resources/views/intranet/confirm.blade.php
@@ -1,6 +1,11 @@
 <x-layouts.app :title="$message">
     <x-modal name="dialogo" title='{{$message}}'
-             message='SI'  cancel="NO" dismiss='0' >
+             message="{{ $confirmText ?? 'SI' }}"  cancel="{{ $cancelText ?? 'NO' }}" dismiss='0' >
+        @if (!empty($notice))
+            <div class="alert alert-warning" role="alert">
+                {{ $notice }}
+            </div>
+        @endif
         @include('intranet.partials.components.showFields',['fields' => $element->showConfirm()])
     </x-modal>
     @push('scripts')

--- a/tests/Feature/FaltaControllerFeatureTest.php
+++ b/tests/Feature/FaltaControllerFeatureTest.php
@@ -37,7 +37,11 @@ class FaltaControllerFeatureTest extends TestCase
     protected function tearDown(): void
     {
         Schema::connection('sqlite')->dropIfExists('activities');
+        Schema::connection('sqlite')->dropIfExists('departamentos');
         Schema::connection('sqlite')->dropIfExists('faltas');
+        Schema::connection('sqlite')->dropIfExists('faltas_profesores');
+        Schema::connection('sqlite')->dropIfExists('menus');
+        Schema::connection('sqlite')->dropIfExists('notifications');
         Schema::connection('sqlite')->dropIfExists('profesores');
 
         if (file_exists($this->sqlitePath)) {
@@ -88,6 +92,32 @@ class FaltaControllerFeatureTest extends TestCase
         $this->assertNull(DB::table('profesores')->where('dni', 'PF03')->value('fecha_baja'));
     }
 
+    public function test_store_professor_mostra_avis_d_enviament_pendent(): void
+    {
+        $this->insertProfesor('PF04', config('roles.rol.profesor'));
+
+        $usuario = Profesor::on('sqlite')->findOrFail('PF04');
+        $response = $this
+            ->actingAs($usuario, 'profesor')
+            ->post(route('falta.store'), [
+                'idProfesor' => 'PF04',
+                'desde' => '2026-02-10',
+                'hasta' => '2026-02-10',
+                'dia_completo' => '1',
+                'motivos' => '1',
+                'observaciones' => 'Falta pendent de confirmar',
+            ], ['referer' => '/falta']);
+
+        $response->assertOk();
+        $response->assertSee('La falta s&#039;ha guardat, però direcció encara no la veurà.', false);
+        $response->assertSee('Enviar a direcció');
+        $response->assertSee('Deixar pendent');
+
+        $falta = DB::table('faltas')->where('observaciones', 'Falta pendent de confirmar')->first();
+        $this->assertNotNull($falta);
+        $this->assertSame(0, (int) $falta->estado);
+    }
+
     private function createSchema(): void
     {
         if (!Schema::connection('sqlite')->hasTable('profesores')) {
@@ -98,11 +128,26 @@ class FaltaControllerFeatureTest extends TestCase
                 $table->string('apellido2')->nullable();
                 $table->string('email')->nullable();
                 $table->unsignedInteger('rol')->default(3);
+                $table->unsignedInteger('departamento')->nullable();
                 $table->boolean('activo')->default(true);
                 $table->date('fecha_baja')->nullable();
                 $table->string('sustituye_a', 10)->nullable();
                 $table->timestamps();
             });
+        }
+
+        if (!Schema::connection('sqlite')->hasTable('departamentos')) {
+            Schema::connection('sqlite')->create('departamentos', function (Blueprint $table): void {
+                $table->unsignedInteger('id')->primary();
+                $table->string('codigo')->nullable();
+                $table->string('nombre')->nullable();
+            });
+
+            DB::connection('sqlite')->table('departamentos')->insert([
+                'id' => 99,
+                'codigo' => '99',
+                'nombre' => 'Desconegut',
+            ]);
         }
 
         if (!Schema::connection('sqlite')->hasTable('faltas')) {
@@ -123,6 +168,17 @@ class FaltaControllerFeatureTest extends TestCase
             });
         }
 
+        if (!Schema::connection('sqlite')->hasTable('faltas_profesores')) {
+            Schema::connection('sqlite')->create('faltas_profesores', function (Blueprint $table): void {
+                $table->id();
+                $table->string('idProfesor', 10);
+                $table->date('dia')->nullable();
+                $table->time('entrada')->nullable();
+                $table->time('salida')->nullable();
+                $table->timestamps();
+            });
+        }
+
         if (!Schema::connection('sqlite')->hasTable('activities')) {
             Schema::connection('sqlite')->create('activities', function (Blueprint $table): void {
                 $table->increments('id');
@@ -132,6 +188,34 @@ class FaltaControllerFeatureTest extends TestCase
                 $table->string('model_class')->nullable();
                 $table->unsignedBigInteger('model_id')->nullable();
                 $table->string('author_id')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        if (!Schema::connection('sqlite')->hasTable('menus')) {
+            Schema::connection('sqlite')->create('menus', function (Blueprint $table): void {
+                $table->increments('id');
+                $table->string('nombre')->nullable();
+                $table->string('url')->nullable();
+                $table->string('class')->nullable();
+                $table->unsignedInteger('rol')->default(3);
+                $table->string('menu')->default('general');
+                $table->string('submenu')->default('');
+                $table->boolean('activo')->default(true);
+                $table->unsignedInteger('orden')->default(0);
+                $table->string('img')->nullable();
+                $table->string('ajuda')->nullable();
+            });
+        }
+
+        if (!Schema::connection('sqlite')->hasTable('notifications')) {
+            Schema::connection('sqlite')->create('notifications', function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->string('type');
+                $table->string('notifiable_type');
+                $table->string('notifiable_id');
+                $table->text('data');
+                $table->timestamp('read_at')->nullable();
                 $table->timestamps();
             });
         }
@@ -146,6 +230,7 @@ class FaltaControllerFeatureTest extends TestCase
             'apellido2' => 'Feature',
             'email' => strtolower($dni) . '@test.local',
             'rol' => $rol,
+            'departamento' => 99,
             'activo' => 1,
             'fecha_baja' => '2026-02-10',
             'sustituye_a' => null,
@@ -169,4 +254,3 @@ class FaltaControllerFeatureTest extends TestCase
         ]);
     }
 }
-


### PR DESCRIPTION
Closes #205 #206 
This pull request introduces several improvements to the confirmation flow for sending "falta" (absence) records to management, enhances user feedback, and expands test coverage. It also adds new documentation for Selenium/SAO production setup and improves the test database schema for more comprehensive feature tests.

**User Experience Improvements:**

* The confirmation dialog for sending a "falta" to management now displays a custom title, explanatory notice, and configurable button texts, providing clearer guidance to users about the process. [[1]](diffhunk://#diff-8713dda8fbc352f7da1af6ba939c8d63bc7ea0c39f1a49abcff120a2f0d11e8cL83-R96) [[2]](diffhunk://#diff-48d65c2cb7ce6e7e5014c3cec85f374f6f0cc5d77bde1f7f30a09613c289e30bL3-R8) [[3]](diffhunk://#diff-31f732da936cd3e3434313b38494ff270d0fb31ba784215bf4e59f3702a1cb23R4-R45) [[4]](diffhunk://#diff-8713dda8fbc352f7da1af6ba939c8d63bc7ea0c39f1a49abcff120a2f0d11e8cL65-R69)

**Testing Enhancements:**

* The test suite for `FaltaController` has been expanded with a new feature test that verifies the presence of the new confirmation message and button labels when a professor submits a "falta" pending approval.
* The SQLite test schema was extended to include additional tables (`departamentos`, `faltas_profesores`, `menus`, `notifications`) and data needed for realistic feature testing. [[1]](diffhunk://#diff-488d8de65a72425bacd633181abaf0fd2c13957b70603c9f9ff446e187463824R40-R44) [[2]](diffhunk://#diff-488d8de65a72425bacd633181abaf0fd2c13957b70603c9f9ff446e187463824R131-R152) [[3]](diffhunk://#diff-488d8de65a72425bacd633181abaf0fd2c13957b70603c9f9ff446e187463824R171-R181) [[4]](diffhunk://#diff-488d8de65a72425bacd633181abaf0fd2c13957b70603c9f9ff446e187463824R194-R221) [[5]](diffhunk://#diff-488d8de65a72425bacd633181abaf0fd2c13957b70603c9f9ff446e187463824R233)

**Documentation Updates:**

* Added a detailed guide for running Selenium/SAO in production, including configuration, debugging, and best practices for secure deployment. [[1]](diffhunk://#diff-b61551dd38fa2f6018d560e9989170a96a23d0e01f704fe4958b4628182d29c9R1-R140) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R26)