### PR TITLE
[FIX] Permet esborrar empreses a cap de pràctiques i administració

### DIFF
--- a/app/Http/Controllers/EmpresaController.php
+++ b/app/Http/Controllers/EmpresaController.php
@@ -108,10 +108,7 @@ class EmpresaController extends IntranetController
         $this->panel->setBoton('index', new BotonBasico("empresa.create", ['roles' => config(self::ROLES_ROL_TUTOR)]));
         $this->panel->setBoton('grid', new BotonImg('empresa.detalle'));
         $this->panel->setBoton('grid', new BotonImg('empresa.delete', [
-            'roles' => [
-                config('roles.rol.administrador'),
-                config('roles.rol.direccion'),
-            ],
+            'roles' => config('roles.rol.jefe_practicas'),
         ]));
      }
 

--- a/app/Http/Controllers/EmpresaController.php
+++ b/app/Http/Controllers/EmpresaController.php
@@ -108,7 +108,10 @@ class EmpresaController extends IntranetController
         $this->panel->setBoton('index', new BotonBasico("empresa.create", ['roles' => config(self::ROLES_ROL_TUTOR)]));
         $this->panel->setBoton('grid', new BotonImg('empresa.detalle'));
         $this->panel->setBoton('grid', new BotonImg('empresa.delete', [
-            'roles' => config('roles.rol.jefe_practicas'),
+            'roles' => [
+                config('roles.rol.jefe_practicas'),
+                config('roles.rol.administrador'),
+            ],
         ]));
      }
 

--- a/app/Policies/EmpresaPolicy.php
+++ b/app/Policies/EmpresaPolicy.php
@@ -32,7 +32,7 @@ class EmpresaPolicy
     /**
      * Determina si l'usuari pot eliminar una empresa.
      *
-     * L'esborrat queda restringit al cap de pràctiques.
+     * L'esborrat queda restringit al cap de pràctiques i administració.
      *
      * @param mixed $user
      */
@@ -72,6 +72,7 @@ class EmpresaPolicy
 
         $rol = (int) $user->rol;
 
-        return $rol % (int) config('roles.rol.jefe_practicas') === 0;
+        return $rol % (int) config('roles.rol.jefe_practicas') === 0
+            || $rol % (int) config('roles.rol.administrador') === 0;
     }
 }

--- a/app/Policies/EmpresaPolicy.php
+++ b/app/Policies/EmpresaPolicy.php
@@ -32,7 +32,7 @@ class EmpresaPolicy
     /**
      * Determina si l'usuari pot eliminar una empresa.
      *
-     * L'esborrat queda restringit a administració i direcció.
+     * L'esborrat queda restringit al cap de pràctiques.
      *
      * @param mixed $user
      */
@@ -72,7 +72,6 @@ class EmpresaPolicy
 
         $rol = (int) $user->rol;
 
-        return $rol % (int) config('roles.rol.administrador') === 0
-            || $rol % (int) config('roles.rol.direccion') === 0;
+        return $rol % (int) config('roles.rol.jefe_practicas') === 0;
     }
 }

--- a/resources/views/empresa/show.blade.php
+++ b/resources/views/empresa/show.blade.php
@@ -57,7 +57,7 @@
         </ul>
         <a href="{{ route('empresa.edit', ['empresa' => $elemento->id]) }}" class="btn btn-success">
             <em class="fa fa-edit m-right-xs"></em>Editar</a>
-        @if (userIsAllow([config('roles.rol.administrador'), config('roles.rol.direccion')]))
+        @if (userIsAllow(config('roles.rol.jefe_practicas')))
             <a href="{{ route('empresa.destroy', ['empresa' => $elemento->id]) }}" id='Borrar' class="btn btn-danger">
                 <em class="fa fa-delete m-right-xs"></em>Esborrar</a>
         @endif

--- a/resources/views/empresa/show.blade.php
+++ b/resources/views/empresa/show.blade.php
@@ -57,7 +57,7 @@
         </ul>
         <a href="{{ route('empresa.edit', ['empresa' => $elemento->id]) }}" class="btn btn-success">
             <em class="fa fa-edit m-right-xs"></em>Editar</a>
-        @if (userIsAllow(config('roles.rol.jefe_practicas')))
+        @if (userIsAllow([config('roles.rol.jefe_practicas'), config('roles.rol.administrador')]))
             <a href="{{ route('empresa.destroy', ['empresa' => $elemento->id]) }}" id='Borrar' class="btn btn-danger">
                 <em class="fa fa-delete m-right-xs"></em>Esborrar</a>
         @endif

--- a/tests/Feature/EmpresaControllerFeatureTest.php
+++ b/tests/Feature/EmpresaControllerFeatureTest.php
@@ -103,6 +103,20 @@ class EmpresaControllerFeatureTest extends TestCase
         $this->assertNull(DB::table('empresas')->where('id', $empresaId)->first());
     }
 
+    public function test_destroy_esborra_empresa_com_administrador_si_no_te_fct_vinculades(): void
+    {
+        $this->insertProfesor('EMP04', $this->administradorRole());
+        $empresaId = $this->insertEmpresa('Empresa Admin');
+
+        $usuario = Profesor::on('sqlite')->findOrFail('EMP04');
+        $response = $this
+            ->actingAs($usuario, 'profesor')
+            ->get(route('empresa.destroy', ['empresa' => $empresaId]), ['referer' => '/home']);
+
+        $response->assertStatus(302);
+        $this->assertNull(DB::table('empresas')->where('id', $empresaId)->first());
+    }
+
     public function test_detall_empresa_te_controls_de_mapa_per_als_centres(): void
     {
         $showView = file_get_contents(resource_path('views/empresa/show.blade.php'));
@@ -113,7 +127,8 @@ class EmpresaControllerFeatureTest extends TestCase
 
         $this->assertStringNotContainsString("new BotonImg('empresa.edit')", $controller);
         $this->assertStringContainsString("config('roles.rol.jefe_practicas')", $controller);
-        $this->assertStringContainsString("userIsAllow(config('roles.rol.jefe_practicas'))", $showView);
+        $this->assertStringContainsString("config('roles.rol.administrador')", $controller);
+        $this->assertStringContainsString("userIsAllow([config('roles.rol.jefe_practicas'), config('roles.rol.administrador')])", $showView);
         $this->assertStringContainsString('class="mapa-centro"', $showView);
         $this->assertStringContainsString('data-fusion-url="{{ url(\'/api/centro/fusionar\') }}"', $showView);
         $this->assertStringContainsString("empresa.partials.modalMapaCentro", $showView);
@@ -235,13 +250,24 @@ class EmpresaControllerFeatureTest extends TestCase
 
     /**
      * Retorna el rol compost necessari per a passar el middleware de professor
-     * i la policy específica d'administració.
+     * i la policy específica de cap de pràctiques.
      *
      * @return int
      */
     private function capPractiquesRole(): int
     {
         return (int) config('roles.rol.profesor') * (int) config('roles.rol.jefe_practicas');
+    }
+
+    /**
+     * Retorna el rol compost necessari per a passar el middleware de professor
+     * i la policy específica d'administració.
+     *
+     * @return int
+     */
+    private function administradorRole(): int
+    {
+        return (int) config('roles.rol.profesor') * (int) config('roles.rol.administrador');
     }
 
     /**

--- a/tests/Feature/EmpresaControllerFeatureTest.php
+++ b/tests/Feature/EmpresaControllerFeatureTest.php
@@ -71,7 +71,7 @@ class EmpresaControllerFeatureTest extends TestCase
 
     public function test_destroy_bloca_empresa_amb_fct_vinculades_i_mostra_alerta(): void
     {
-        $this->insertProfesor('EMP02', $this->administradorRole());
+        $this->insertProfesor('EMP02', $this->capPractiquesRole());
         $empresaId = $this->insertEmpresa('Empresa Bloquejada');
         $centroId = $this->insertCentro($empresaId);
         $colaboracionId = $this->insertColaboracion($centroId);
@@ -91,7 +91,7 @@ class EmpresaControllerFeatureTest extends TestCase
 
     public function test_destroy_esborra_empresa_si_no_te_fct_vinculades(): void
     {
-        $this->insertProfesor('EMP03', $this->administradorRole());
+        $this->insertProfesor('EMP03', $this->capPractiquesRole());
         $empresaId = $this->insertEmpresa('Empresa Lliure');
 
         $usuario = Profesor::on('sqlite')->findOrFail('EMP03');
@@ -112,8 +112,8 @@ class EmpresaControllerFeatureTest extends TestCase
         $controller = file_get_contents(app_path('Http/Controllers/EmpresaController.php'));
 
         $this->assertStringNotContainsString("new BotonImg('empresa.edit')", $controller);
-        $this->assertStringContainsString("config('roles.rol.administrador')", $controller);
-        $this->assertStringContainsString("config('roles.rol.direccion')", $controller);
+        $this->assertStringContainsString("config('roles.rol.jefe_practicas')", $controller);
+        $this->assertStringContainsString("userIsAllow(config('roles.rol.jefe_practicas'))", $showView);
         $this->assertStringContainsString('class="mapa-centro"', $showView);
         $this->assertStringContainsString('data-fusion-url="{{ url(\'/api/centro/fusionar\') }}"', $showView);
         $this->assertStringContainsString("empresa.partials.modalMapaCentro", $showView);
@@ -239,9 +239,9 @@ class EmpresaControllerFeatureTest extends TestCase
      *
      * @return int
      */
-    private function administradorRole(): int
+    private function capPractiquesRole(): int
     {
-        return (int) config('roles.rol.profesor') * (int) config('roles.rol.administrador');
+        return (int) config('roles.rol.profesor') * (int) config('roles.rol.jefe_practicas');
     }
 
     /**

--- a/tests/Unit/Policies/EmpresaPolicyTest.php
+++ b/tests/Unit/Policies/EmpresaPolicyTest.php
@@ -49,12 +49,13 @@ class EmpresaPolicyTest extends TestCase
         $this->assertFalse($policy->update((object) ['rol' => (int) config('roles.rol.alumno')], $empresa));
     }
 
-    public function test_delete_només_permet_cap_de_practiques(): void
+    public function test_delete_permet_cap_de_practiques_i_administracio(): void
     {
         $policy = new EmpresaPolicy();
         $empresa = new Empresa();
 
         $this->assertTrue($policy->delete((object) ['rol' => (int) config('roles.rol.jefe_practicas')], $empresa));
+        $this->assertTrue($policy->delete((object) ['rol' => (int) config('roles.rol.administrador')], $empresa));
         $this->assertFalse($policy->delete((object) ['rol' => (int) config('roles.rol.tutor')], $empresa));
         $this->assertFalse($policy->delete((object) ['rol' => (int) config('roles.rol.direccion')], $empresa));
         $this->assertFalse($policy->delete((object) [], $empresa));


### PR DESCRIPTION
## Canvis

- Ajusta `EmpresaPolicy::delete()` perquè permeti esborrar empreses a `jefe_practicas` i `administrador`.
- Alinea la visibilitat dels botons d'esborrat d'empresa amb la policy.
- Actualitza tests de policy i controlador per cobrir els dos rols permesos.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=EmpresaPolicyTest`
- `docker compose exec -T laravel.test php artisan test --filter=EmpresaControllerFeatureTest`

Closes #225