### PR TITLE
[FIX] Codificació accents informes instructor

### DIFF
--- a/app/Services/Document/PdfFormService.php
+++ b/app/Services/Document/PdfFormService.php
@@ -149,9 +149,9 @@ class PdfFormService
                 continue;
             }
 
-            $fieldName = $this->escapeFdfString((string) $name);
-            $fieldValue = $this->escapeFdfString((string) ($value ?? ''));
-            $fieldEntries[] = "<< /T ({$fieldName}) /V ({$fieldValue}) >>";
+            $fieldName = $this->formatFdfString((string) $name);
+            $fieldValue = $this->formatFdfString((string) ($value ?? ''));
+            $fieldEntries[] = "<< /T {$fieldName} /V {$fieldValue} >>";
         }
 
         $fdf = "%FDF-1.2\n";
@@ -180,6 +180,21 @@ class PdfFormService
         $value = str_replace('\\', '\\\\', $value);
         $value = str_replace('(', '\\(', $value);
         return str_replace(')', '\\)', $value);
+    }
+
+    /**
+     * Formata una cadena FDF preservant accents i caràcters no ASCII.
+     *
+     * @param string $value
+     * @return string
+     */
+    private function formatFdfString(string $value): string
+    {
+        if (preg_match('/^[\x20-\x7E]*$/', $value) === 1) {
+            return '(' . $this->escapeFdfString($value) . ')';
+        }
+
+        return '<FEFF' . strtoupper(bin2hex(mb_convert_encoding($value, 'UTF-16BE', 'UTF-8'))) . '>';
     }
 
     /**

--- a/tests/Unit/Services/PdfFormServiceTest.php
+++ b/tests/Unit/Services/PdfFormServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Intranet\Services\Document\PdfFormService;
+use ReflectionClass;
+use Tests\TestCase;
+
+class PdfFormServiceTest extends TestCase
+{
+    /**
+     * Verifica que els camps FDF amb accents s'escriuen com a Unicode PDF.
+     */
+    public function test_create_temp_fdf_codifica_accents_com_unicode(): void
+    {
+        $service = new PdfFormService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('createTempFdf');
+        $method->setAccessible(true);
+
+        $path = $method->invoke($service, [
+            'INSTRUCT' => 'José Pérez',
+            'POBLACIÓN' => 'Alcoi',
+        ]);
+
+        try {
+            $content = file_get_contents($path);
+
+            $this->assertIsString($content);
+            $this->assertStringContainsString('(INSTRUCT)', $content);
+            $this->assertStringContainsString('<FEFF004A006F007300E90020005000E900720065007A>', $content);
+            $this->assertStringContainsString('<FEFF0050004F0042004C00410043004900D3004E>', $content);
+            $this->assertStringNotContainsString('José Pérez', $content);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Canvis

- Codifica les cadenes FDF no ASCII com a Unicode PDF (UTF-16BE amb BOM en format hex).
- Manté les cadenes ASCII com a literals FDF escapades.
- Afig una prova de regressió amb nom d'instructor i camp amb accent.

## Impacte

Els informes/certificats FCT basats en formularis PDF preserven accents i caràcters especials en noms d'instructors i altres camps textuals.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=PdfFormServiceTest`
- `docker compose exec -T laravel.test php artisan test --filter=DocumentServiceTest`
- `docker compose exec -T laravel.test php -l app/Services/Document/PdfFormService.php`
- `docker compose exec -T laravel.test php -l tests/Unit/Services/PdfFormServiceTest.php`
- `git diff --check`

Closes #233