### PR TITLE
[FIX] Usa el coordinador real en activitats #190

### DIFF
--- a/app/Livewire/ActividadDireccionPanel.php
+++ b/app/Livewire/ActividadDireccionPanel.php
@@ -287,12 +287,14 @@ class ActividadDireccionPanel extends Component
                 return [
                     'dni' => (string) $profesor->dni,
                     'nom' => $label,
+                    'coordinador' => (bool) ($profesor->pivot->coordinador ?? false),
                     'teHorariDocent' => $grupsAfectats !== [],
                     'grupsAfectats' => $grupsAfectats,
                 ];
             })
             ->filter(fn (array $profesor): bool => $profesor['nom'] !== '')
             ->values();
+        $coordinador = $profesores->firstWhere('coordinador', true);
         $grups = $actividad->grupos
             ->map(fn ($grup) => (string) ($grup->nombre ?? $grup->codigo ?? ''))
             ->filter()
@@ -311,7 +313,7 @@ class ActividadDireccionPanel extends Component
             'tipoActividad' => (string) ($actividad->tipoActividad->vliteral ?? '-'),
             'justificacioRa' => (string) ($actividad->tipoActividad->justificacio ?? ''),
             'departamento' => (string) ($actividad->tipoActividad->departamento ?? 'CENTRE'),
-            'coordinador' => $profesores->first()['nom'] ?? 'Sense assignar',
+            'coordinador' => $coordinador['nom'] ?? 'Sense assignar',
             'profesores' => $profesores->pluck('nom')->all(),
             'participants' => $profesores->all(),
             'grups' => $grups->all(),

--- a/tests/Feature/ActividadDireccionPanelTest.php
+++ b/tests/Feature/ActividadDireccionPanelTest.php
@@ -155,6 +155,49 @@ class ActividadDireccionPanelTest extends TestCase
         $this->assertSame(['1r CFGM Estètica'], $selected['grups']);
     }
 
+    public function test_mostrar_usa_el_pivot_per_a_identificar_el_coordinador(): void
+    {
+        DB::connection('sqlite')->table('profesores')->insert([
+            'dni' => 'ACT050',
+            'nombre' => 'Marta',
+            'apellido1' => 'Andreu',
+            'apellido2' => 'Gil',
+            'email' => 'act050@test.local',
+            'rol' => config('roles.rol.profesor'),
+            'activo' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('sqlite')->table('actividades')->insert([
+            'id' => 5,
+            'name' => 'Taller valorat',
+            'tipo_actividad_id' => 7,
+            'descripcion' => 'Activitat amb diversos participants',
+            'extraescolar' => 1,
+            'desde' => '2026-03-25 09:00:00',
+            'hasta' => '2026-03-25 12:00:00',
+            'complementaria' => 0,
+            'fueraCentro' => 1,
+            'transport' => 0,
+            'objetivos' => null,
+            'idDocumento' => null,
+            'estado' => 4,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('sqlite')->table('actividad_profesor')->insert([
+            ['idActividad' => 5, 'idProfesor' => 'ACT050', 'coordinador' => 0],
+            ['idActividad' => 5, 'idProfesor' => 'ACT200', 'coordinador' => 1],
+        ]);
+
+        Livewire::actingAs($this->direccionUser(), 'profesor')
+            ->test(ActividadDireccionPanel::class)
+            ->call('mostrar', 5)
+            ->assertSet('selectedActividad.coordinador', 'Anna Soler Lopez');
+    }
+
     private function direccionUser(): Profesor
     {
         return Profesor::on('sqlite')->findOrFail('DIR001');


### PR DESCRIPTION
## Resum

- El panell de direcció d’activitats identifica el coordinador amb el pivot `actividad_profesor.coordinador`.
- Es deixa de mostrar el primer participant com a coordinador quan no correspon.
- S’afegeix una regressió Livewire amb diversos participants i coordinador no situat en primer lloc.

## Causa

El modal de l’ull en direcció construïa el camp `coordinador` amb el primer professor carregat, ignorant el pivot que marca el responsable real.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=ActividadDireccionPanelTest`
- `git diff --check`

Closes #190