### PR TITLE
[FIX] Aclara la justificació RA en activitats #193

### DIFF
--- a/resources/views/extraescolares/showValue.blade.php
+++ b/resources/views/extraescolares/showValue.blade.php
@@ -38,7 +38,10 @@
             </ul>
         </div>
         <div style="display: inline-block;width: 70%;margin-right:30px;float: right">
-            <strong>Descripció:</strong><br/><em style="font-size: smaller">{{$Actividad->descripcion}}</em><br/>
+            <strong>Descripció de l'activitat:</strong><br/><em style="font-size: smaller">{{$Actividad->descripcion}}</em><br/>
+            @if ($Actividad->complementaria)
+                <strong>Justificació RA:</strong><br/><em style="font-size: smaller">{{$Actividad->tipoActividad->justificacio ?? '-'}}</em><br/>
+            @endif
             <strong>Objectius:</strong><br/><em style="font-size: smaller">{{$Actividad->objetivos}}</em><br/>
             <strong>Comentaris:</strong><br/><em style="font-size: smaller">{{$Actividad->comentarios}}</em><br/>
         </div>

--- a/resources/views/pdf/extraescolars.blade.php
+++ b/resources/views/pdf/extraescolars.blade.php
@@ -10,7 +10,7 @@
             <tr>
                 <th style='width:2%'>N</th>
                 <th style='width:15%'>Activitat</th>
-                <th style='width:15%'>Descripció/Justificació</th>
+                <th style='width:15%'>Descripció</th>
                 <th style='width:10%'>Objectius</th>
                 <th style='width:10%'>Desde</th>
                 <th style='width:10%'>Fins</th>
@@ -62,4 +62,3 @@
     </div>
 </div>
 @endsection
-

--- a/specs/activitats.md
+++ b/specs/activitats.md
@@ -69,9 +69,25 @@ Especificació del comportament esperat per al domini Activitats. Tecnologia-agn
 **When** sol·licita el PDF  
 **Then** es genera un PDF usant `resources/views/pdf/extraescolars.blade.php` amb les dades correctes
 
+### Escenari 9: Mostrar justificació RA només en complementàries ✅
+
+**Given** que una activitat té un tipus amb `tipo_actividad.justificacio`
+**When** es mostra el detall o la valoració de l'activitat
+**Then**
+- La justificació RA prové de `tipo_actividad.justificacio`
+- Les activitats complementàries poden mostrar `Justificació RA`
+- Les activitats extraescolars no mostren `Justificació RA`
+
+### Escenari 10: Evitar etiquetes ambigües en PDFs d'activitats ✅
+
+**Given** que direcció genera el PDF/listat d'activitats extraescolars
+**When** es renderitza la columna de descripció
+**Then** la columna es mostra com `Descripció` i no com `Descripció/Justificació`
+
 ## Regles de negoci invariants
 
 - `complementaria` i `extraescolar` (llegat) no són el mateix camp; no intercanviar sense migració.
 - `transport = 1` és incoherent si `fueraCentro = 0`; normalitzar o rebutjar.
 - Les activitats complementàries mostren RA; les extraescolars, no.
+- La justificació RA és `tipo_actividad.justificacio`; `actividades.descripcion` és descripció general.
 - El coordinador sempre es determina per `actividad_profesor.coordinador = 1`, mai per posició.

--- a/tests/Feature/ActividadDireccionPanelTest.php
+++ b/tests/Feature/ActividadDireccionPanelTest.php
@@ -155,6 +155,15 @@ class ActividadDireccionPanelTest extends TestCase
         $this->assertSame(['1r CFGM Estètica'], $selected['grups']);
     }
 
+    public function test_mostrar_oculta_justificacio_ra_en_activitats_extraescolars(): void
+    {
+        Livewire::actingAs($this->direccionUser(), 'profesor')
+            ->test(ActividadDireccionPanel::class)
+            ->call('mostrar', 4)
+            ->assertSet('selectedActividad.tipo', 'No complementària')
+            ->assertDontSee('Justificació RA');
+    }
+
     public function test_mostrar_usa_el_pivot_per_a_identificar_el_coordinador(): void
     {
         DB::connection('sqlite')->table('profesores')->insert([

--- a/tests/Feature/ActividadPdfViewTest.php
+++ b/tests/Feature/ActividadPdfViewTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+/**
+ * Proves de renderitzat dels PDFs d'activitats.
+ */
+class ActividadPdfViewTest extends TestCase
+{
+    public function test_llistat_extraescolars_usa_etiqueta_descripcio_sense_justificacio_ra(): void
+    {
+        config(['signatures.llistats' => []]);
+
+        $profesor = new \stdClass();
+        $profesor->nombre = 'Anna';
+        $profesor->apellido1 = 'Soler';
+
+        $grupo = new \stdClass();
+        $grupo->nombre = '1r CFGM Estètica';
+
+        $actividad = new \stdClass();
+        $actividad->id = 1;
+        $actividad->name = 'Taller extraescolar';
+        $actividad->descripcion = 'Descripció general';
+        $actividad->objetivos = 'Objectius generals';
+        $actividad->desde = '10-06-2026 09:00';
+        $actividad->hasta = '10-06-2026 12:00';
+        $actividad->fueraCentro = 1;
+        $actividad->transport = 0;
+        $actividad->comentarios = '';
+        $actividad->profesores = new Collection([$profesor]);
+        $actividad->grupos = new Collection([$grupo]);
+
+        $html = view('pdf.extraescolars', [
+            'todos' => new Collection([$actividad]),
+            'datosInforme' => '10-06-2026',
+        ])->render();
+
+        $this->assertStringContainsString('Descripció</th>', $html);
+        $this->assertStringNotContainsString('Descripció/Justificació', $html);
+        $this->assertStringNotContainsString('Justificació RA', $html);
+    }
+}


### PR DESCRIPTION
## Resum

- Mostra `Justificació RA` en la valoració només quan l’activitat és complementària.
- Manté `Descripció de l’activitat` com a descripció general.
- El PDF/listat d’activitats canvia `Descripció/Justificació` per `Descripció` per evitar l’ambigüitat.
- Actualitza la spec d’activitats amb els escenaris de RA i PDF.
- Afig regressions per al panell Livewire i el PDF/listat.

## Causa

La UI barrejava el concepte de descripció general amb la justificació RA. La justificació RA pertany a `tipo_actividad.justificacio`, mentre que `actividades.descripcion` és la descripció de l’activitat.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=ActividadDireccionPanelTest`
- `docker compose exec -T laravel.test php artisan test --filter=ActividadPdfViewTest`
- `git diff --check`

Closes #193