### PR TITLE
[FIX] Evita panel en controlador documental de projectes #237

### DIFF
--- a/app/Http/Controllers/ProjecteDocumentoController.php
+++ b/app/Http/Controllers/ProjecteDocumentoController.php
@@ -7,14 +7,13 @@ namespace Intranet\Http\Controllers;
 use Intranet\Application\Grupo\GrupoService;
 use Intranet\Application\Profesor\ProfesorService;
 use Intranet\Application\Projecte\ProjecteDocumentService;
-use Intranet\Http\Controllers\Core\IntranetController;
 use Intranet\Services\Document\PdfService;
 use Intranet\Entities\Projecte;
 
 /**
  * Gestiona fluxos documentals específics del domini de projectes.
  */
-class ProjecteDocumentoController extends IntranetController
+class ProjecteDocumentoController extends Controller
 {
     private ?GrupoService $grupoService = null;
     private ?ProfesorService $profesorService = null;

--- a/tests/Feature/RouteNameContractTest.php
+++ b/tests/Feature/RouteNameContractTest.php
@@ -54,4 +54,10 @@ class RouteNameContractTest extends TestCase
         $this->assertContains('POST', Route::getRoutes()->getByName('direccion.lote.store.rest')->methods());
         $this->assertContains('PUT', Route::getRoutes()->getByName('direccion.lote.update')->methods());
     }
+
+    public function test_route_list_de_lot_de_direccio_no_falla_per_controladors_documentals(): void
+    {
+        $this->artisan('route:list --name=direccion.lote -vvv')
+            ->assertExitCode(0);
+    }
 }


### PR DESCRIPTION
## Resum

Corregeix la regressio on `php artisan route:list --name=direccion.lote -vvv` fallava en recopilar middleware de totes les rutes perque Laravel instanciava `ProjecteDocumentoController`.

## Causa

`ProjecteDocumentoController` heretava de `IntranetController`, que inicialitza un `Panel` en el constructor i requereix `$model`. Aquest controlador nomes gestiona accions documentals de projectes i no defineix ni necessita cap model de graella.

## Canvis

- `ProjecteDocumentoController` passa a estendre el controlador base `Controller`, conservant `authorize()` i evitant la inicialitzacio de `Panel`.
- S'afegeix una prova de regressio en `RouteNameContractTest` per garantir que `route:list --name=direccion.lote -vvv` no torna a fallar.

## Validacio

- `php -l app/Http/Controllers/ProjecteDocumentoController.php`
- `php artisan route:list --name=direccion.lote -vvv`
- `php artisan test --filter=RouteNameContractTest`
- `php artisan route:list --name=projectes -vvv`
- `git diff --check`

Closes #237