### PR TITLE
[MOD] Clarifica avís d'hores pendents FCT #243

### DIFF
--- a/app/Http/Controllers/PanelFctAvalController.php
+++ b/app/Http/Controllers/PanelFctAvalController.php
@@ -326,7 +326,7 @@ class PanelFctAvalController extends IntranetController
                 [
                     'img' => 'fa-hand-o-up',
                     'title' => 'Marcar com a apte amb hores pendents',
-                    'onclick' => "if (!confirm('Aquesta FCT encara té hores pendents de sincronitzar amb SAO. Vols marcar-la com a apta igualment?')) { return false; } this.href += (this.href.indexOf('?') === -1 ? '?' : '&') + 'confirmar_hores=1'; return true;",
+                    'onclick' => "if (!confirm(" . json_encode($this->aptePendingHoursConfirmMessage(), JSON_UNESCAPED_UNICODE) . ")) { return false; } this.href += (this.href.indexOf('?') === -1 ? '?' : '&') + 'confirmar_hores=1'; return true;",
                     'where' => [
                         'calificacion', '!=', '1',
                         'actas', '==', 0,
@@ -447,7 +447,7 @@ class PanelFctAvalController extends IntranetController
         $fct = $this->alumnoFcts()->findOrFail((int) $id);
         if ($fct->requereix_confirmacio_apte && request('confirmar_hores') !== '1') {
             Alert::message(
-                "Aquesta FCT encara té {$fct->hores_pendents_sao} hores pendents de sincronitzar amb SAO. Confirma explícitament l'aprovat per continuar.",
+                $this->aptePendingHoursAlertMessage($fct),
                 'warning'
             );
 
@@ -457,6 +457,31 @@ class PanelFctAvalController extends IntranetController
         $this->avals()->apte((int) $id);
 
         return back();
+    }
+
+    /**
+     * Missatge del diàleg per a FCT amb hores pendents de sincronitzar.
+     *
+     * @return string
+     */
+    private function aptePendingHoursConfirmMessage(): string
+    {
+        return "Aquesta FCT encara té hores pendents de sincronitzar. "
+            . "Si vols actualitzar-les abans, cancel·la i ves a l'opció de sincronització d'hores de la intranet. "
+            . "Si continues, marcaràs l'FCT com a apta amb les hores registrades ara mateix.";
+    }
+
+    /**
+     * Missatge de fallback quan es prova d'aprovar sense confirmació explícita.
+     *
+     * @param AlumnoFct $fct
+     * @return string
+     */
+    private function aptePendingHoursAlertMessage(AlumnoFct $fct): string
+    {
+        return "Aquesta FCT encara té {$fct->hores_pendents_sao} hores pendents de sincronitzar. "
+            . "Pots anar a l'opció de sincronització d'hores de la intranet abans d'aprovar-la. "
+            . "Si vols continuar igualment, confirma explícitament l'aprovat i es guardaran les hores registrades ara mateix.";
     }
 
     /**

--- a/tests/Unit/Controllers/PanelFctAvalControllerTest.php
+++ b/tests/Unit/Controllers/PanelFctAvalControllerTest.php
@@ -41,6 +41,34 @@ class PanelFctAvalControllerTest extends TestCase
         $this->assertSame('G2LFP', $grupo?->codigo);
     }
 
+    public function test_missatge_confirmacio_apte_amb_hores_pendents_orienta_sense_alarmar(): void
+    {
+        $controller = (new ReflectionClass(PanelFctAvalController::class))->newInstanceWithoutConstructor();
+
+        $message = $this->invokePrivate($controller, 'aptePendingHoursConfirmMessage');
+
+        $this->assertStringContainsString('hores pendents de sincronitzar', $message);
+        $this->assertStringContainsString("opció de sincronització d'hores de la intranet", $message);
+        $this->assertStringContainsString('cancel·la', $message);
+        $this->assertStringContainsString('Si continues', $message);
+        $this->assertStringContainsString('hores registrades ara mateix', $message);
+    }
+
+    public function test_missatge_fallback_apte_amb_hores_pendents_inclou_hores_i_opcio_sincronitzar(): void
+    {
+        $controller = (new ReflectionClass(PanelFctAvalController::class))->newInstanceWithoutConstructor();
+        $fct = new AlumnoFct();
+        $fct->horas = 20;
+        $fct->realizadas = 8;
+
+        $message = $this->invokePrivate($controller, 'aptePendingHoursAlertMessage', [$fct]);
+
+        $this->assertStringContainsString('12 hores pendents de sincronitzar', $message);
+        $this->assertStringContainsString("opció de sincronització d'hores de la intranet", $message);
+        $this->assertStringContainsString('confirma explícitament', $message);
+        $this->assertStringContainsString('hores registrades ara mateix', $message);
+    }
+
     private function makeAlumnoFctWithoutCicle(string $normativa): AlumnoFct
     {
         return $this->makeAlumnoFctWithGroups([


### PR DESCRIPTION
## Què canvia

Clarifica el diàleg que apareix quan el professorat intenta marcar una FCT com a apta amb hores pendents de sincronitzar.

El missatge ara diferencia entre cancel·lar per anar abans a l'opció de sincronització d'hores de la intranet i continuar aprovant amb les hores registrades actualment.

## Impacte

Només canvia el text/UX del diàleg i del missatge fallback del servidor. No modifica la sincronització SAO ni la lògica d'aprovació de FCT.

## Validació

- `php artisan test --filter=PanelFctAvalControllerTest`

Relacionada amb #243.