### PR TITLE
[MOD] Revisió de docs/: repara enllaços, actualitza contingut i dona estil

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Com treballem amb agents (Filosofia Tetris)
-    url: https://github.com/cipfpbatoi/intranetBatoi/blob/Laravel13/docs/agents/tetris.md
+    url: https://github.com/cipfpbatoi/intranetBatoi/blob/main/docs/agents/tetris.md
     about: Llig com està organitzat el repo per a agents abans d'obrir una issue de workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ Namespace: `Intranet\Http\Controllers\API`. Autenticació via Sanctum. Intercanv
 
 ### Frontend
 
-- Laravel Mix (`webpack.mix.js`): `resources/assets/js` + `resources/assets/sass` → `public/`.
-- Bootstrap 4 + tema admin Gentelella + Vue 2 (widgets datepicker/select) + Livewire 3.
+- Vite (`vite.config.mjs`, plugin `laravel-vite-plugin`): entrades a `resources/assets/js` (`app.js`, `legacy-app.js`, `fichar-app.js`, `ppIntranet.js`) i `resources/assets/sass/app.scss`.
+- Bootstrap 5 + Vue 3 + Livewire 3.
 - Vistes Blade: `resources/views/`; layouts: `resources/views/layouts`; partials: `resources/views/intranet/partials`.
 
 ## Ordres de compilació, test i desenvolupament
 
 - `composer install` per a dependències PHP (copia `.env.example`, executa `php artisan key:generate` després de clonar).
-- Frontend: `npm install`; `npm run dev` compila una vegada, `npm run watch` recompila en cada canvi, `npm run production` genera bundles minificats (`NODE_OPTIONS=--openssl-legacy-provider`).
+- Frontend: `npm install`; `npm run dev` arranca el servidor Vite amb HMR, `npm run build` (o `npm run production`) genera els bundles de producció.
 - `php artisan serve` arrenca l'app; `php artisan migrate --seed` prepara la BD.
 - Tests amb `phpunit` o `php artisan test`; usa `--filter` per a apuntar casos concrets.
 - Scripts Composer: `composer test:focus`, `composer test:quick` (Expediente|Empresa|Comision), `composer test:full`, `composer test:auth-migration`, `composer dusk:local`.
@@ -98,7 +98,7 @@ Namespace: `Intranet\Http\Controllers\API`. Autenticació via Sanctum. Intercanv
 - PSR-12: indentació de 4 espais, noms de mètode clars; sufixa les classes amb `Controller`, `Job`, `Event`, `Policy` on escaiga.
 - Tota classe modificada o nova ha d'incloure/actualitzar blocs `phpDoc` (`/** ... */`) per a la classe i els mètodes/propietats rellevants.
 - Prefereix layouts/components Blade a `resources/views/layouts` i `resources/views/components`; manté les cadenes de text a `resources/lang`.
-- Mantén JS/SCSS modular dins `resources/assets`; alinea els noms de classe amb el marcat Blade i afig nous punts d'entrada a `webpack.mix.js` quan calga.
+- Mantén JS/SCSS modular dins `resources/assets`; alinea els noms de classe amb el marcat Blade i afig nous punts d'entrada a `vite.config.mjs` quan calga.
 - Alertes: `use Intranet\Services\UI\AppAlert as Alert;` (no `Styde\Html\Facades\Alert`).
 - No dupliques lògica si ja existeix a `Application/*`, `Services/*`, `Finders/*` o `Presentation/*`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# Intranet CIP FP Batoi
+# 🏫 Intranet CIP FP Batoi
 
-Aplicació de gestió interna del centre (Laravel, namespace `Intranet\`; Blade + Bootstrap 4/Gentelella + Vue 2 + Livewire 3). Rutes separades per rol, capes `app/Domain` i `app/Application`, tests amb PHPUnit i Dusk.
+[![PHP Tests](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/php-tests.yml/badge.svg?branch=main)](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/php-tests.yml)
+[![Docker Build & Push](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/docker-build.yml/badge.svg?branch=main)](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/docker-build.yml)
+[![Lang Audit](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/lang-audit.yml/badge.svg?branch=main)](https://github.com/cipfpbatoi/intranetBatoi/actions/workflows/lang-audit.yml)
+![Laravel](https://img.shields.io/badge/Laravel-FF2D20?logo=laravel&logoColor=white)
+![Vue 3](https://img.shields.io/badge/Vue_3-4FC08D?logo=vuedotjs&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white)
+![Bootstrap 5](https://img.shields.io/badge/Bootstrap_5-7952B3?logo=bootstrap&logoColor=white)
+![Livewire 3](https://img.shields.io/badge/Livewire_3-4E56A6?logo=livewire&logoColor=white)
 
-## Com treballem amb IA: Filosofia Tetris
+Aplicació de gestió interna del centre (Laravel, namespace `Intranet\`; Blade + Bootstrap 5 + Vue 3 + Livewire 3, assets amb Vite). Rutes separades per rol, capes `app/Domain` i `app/Application`, tests amb PHPUnit i Dusk.
+
+## 🤖 Com treballem amb IA: Filosofia Tetris
 
 Este repo està preparat perquè els agents d'IA (Claude Code, Codex, Cursor…) treballen de forma **predictible**: cada peça encaixa sense buits, i quan falta context **s'omple la peça** en lloc de suposar.
 
@@ -10,27 +19,27 @@ Este repo està preparat perquè els agents d'IA (Claude Code, Codex, Cursor…)
 
 | Vull… | Vés a… |
 |---|---|
-| Entendre com treballar i quina eina usar | [`docs/agents/tetris.md`](docs/agents/tetris.md) |
-| La guia autoritzada per a agents (router) | [`AGENTS.md`](AGENTS.md) |
-| Implementar amb aprovació humana (propose → apply → archive) | [`docs/agents/openspec.md`](docs/agents/openspec.md) |
-| Plantilles de prompt reutilitzables | [`prompts/`](prompts/) |
-| Especificacions de comportament (BDD) | [`specs/`](specs/) |
-| Coneixement de domini (FCT, Activitats…) | [`docs/agents/`](docs/agents/README.md) |
+| 🧭 Entendre com treballar i quina eina usar | [`docs/agents/tetris.md`](docs/agents/tetris.md) |
+| 📖 La guia autoritzada per a agents (router) | [`AGENTS.md`](AGENTS.md) |
+| ✅ Implementar amb aprovació humana (propose → apply → archive) | [`docs/agents/openspec.md`](docs/agents/openspec.md) |
+| 📋 Plantilles de prompt reutilitzables | [`prompts/`](prompts/) |
+| 🧪 Especificacions de comportament (BDD) | [`specs/`](specs/) |
+| 🗺️ Coneixement de domini (FCT, Activitats…) | [`docs/agents/`](docs/agents/README.md) |
 
-## Documentació
+## 📚 Documentació
 
 Índex complet (arquitectura, operacions, manuals, governança): [`docs/README.md`](docs/README.md).
 
 | Necessitat | Document |
 |---|---|
-| Setup i instal·lació | [`docs/operations/setup.md`](docs/operations/setup.md) |
-| Tests, Docker i Dusk | [`docs/agents/testing-docker.md`](docs/agents/testing-docker.md) |
-| Desplegament Docker | [`docs/operations/docker-prod.md`](docs/operations/docker-prod.md) |
-| Esquema de la BD | [`docs/architecture/bbdd-esquema.md`](docs/architecture/bbdd-esquema.md) |
-| Preguntes freqüents | [`docs/governance/faqs.md`](docs/governance/faqs.md) |
-| Manuals d'usuari | [`docs/manuals/`](docs/manuals/) |
+| 🚀 Setup i instal·lació | [`docs/operations/setup.md`](docs/operations/setup.md) |
+| 🧪 Tests, Docker i Dusk | [`docs/agents/testing-docker.md`](docs/agents/testing-docker.md) |
+| 🐳 Desplegament Docker | [`docs/operations/docker-prod.md`](docs/operations/docker-prod.md) |
+| 🗄️ Esquema de la BD | [`docs/architecture/bbdd-esquema.md`](docs/architecture/bbdd-esquema.md) |
+| ❓ Preguntes freqüents | [`docs/governance/faqs.md`](docs/governance/faqs.md) |
+| 👥 Manuals d'usuari | [`docs/manuals/`](docs/manuals/) |
 
-## Contribuir
+## 🤝 Contribuir
 
 - Llig `AGENTS.md` abans de tocar codi i completa el seu **Pre-flight Checklist**.
 - Commits amb prefix `[ADD]`/`[MOD]`/`[DEL]`/`[FIX]` i referència a la issue (`#NNN`); sense atribució d'IA.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,25 @@
-# Documentació del projecte
+# 📚 Documentació del projecte
 
 Intranet del CIP FP Batoi. Documentació organitzada per tipus (alta cohesió, baix acoblament).
 
-## Estructura
+## 🗂️ Estructura
 
 | Carpeta | Contingut |
 |---|---|
-| [`agents/`](agents/README.md) | Coneixement de domini per a agents d'IA (Codex, Claude, Cursor…) |
-| [`architecture/`](architecture/) | Esquemes de BD, inventari de codi, fluxos tècnics, API |
-| [`governance/`](governance/) | FAQs, deute tècnic, convencions, seguretat |
-| [`operations/`](operations/) | Setup, desplegament, Docker, Dusk |
-| [`manuals/`](manuals/) | Manuals d'usuari per rol |
-| [`archive/`](archive/) | Sprints tancats, migracions, estudis històrics |
+| 🤖 [`agents/`](agents/README.md) | Coneixement de domini per a agents d'IA (Codex, Claude, Cursor…) |
+| 🏗️ [`architecture/`](architecture/) | Esquemes de BD, inventari de codi, fluxos tècnics, API |
+| ⚖️ [`governance/`](governance/) | FAQs, deute tècnic, convencions, seguretat |
+| 🔧 [`operations/`](operations/) | Setup, desplegament, Docker, Dusk |
+| 👥 [`manuals/`](manuals/) | Manuals d'usuari per rol |
+| 📦 [`archive/`](archive/) | Sprints tancats, migracions, estudis històrics |
 
-## Accés ràpid
+## ⚡ Accés ràpid
 
 - 📐 [Filosofia Tetris: mapa i guia d'ús amb IA](agents/tetris.md) — com treballem amb agents (comença ací)
-- [Manual del Professor](manuals/manual-profe.md)
-- [Manual del Tutor de pràctiques](manuals/manual-fct.md)
-- [Preguntes freqüents](governance/faqs.md)
-- [Setup i instal·lació](operations/setup.md)
-- [Esquema de la BD](architecture/bbdd-esquema.md)
-- [Desplegament Docker](operations/docker-prod.md)
-- [Selenium/SAO en producció](operations/selenium-sao-prod.md)
+- 👨‍🏫 [Manual del Professor](manuals/manual-profe.md)
+- 🎓 [Manual del Tutor de pràctiques](manuals/manual-fct.md)
+- ❓ [Preguntes freqüents](governance/faqs.md)
+- 🚀 [Setup i instal·lació](operations/setup.md)
+- 🗄️ [Esquema de la BD](architecture/bbdd-esquema.md)
+- 🐳 [Desplegament Docker](operations/docker-prod.md)
+- 🔍 [Selenium/SAO en producció](operations/selenium-sao-prod.md)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,4 +1,4 @@
-# Índex de coneixement de domini
+# 🤖 Índex de coneixement de domini
 
 Documents vius per a agents d'IA. Cada fitxer té **alta cohesió** (tot el que conté pertany al seu context) i **baix acoblament** (és autoexplicatiu sense dependre d'altres fitxers).
 
@@ -6,20 +6,20 @@ Quan la IA es comporta malament en un domini, **refines el fitxer** corresponent
 
 > **Comença ací si véns de nou:** [`tetris.md`](tetris.md) — mapa de les 4 peces i **guia d'ús al dia a dia** (receptes per escenari, exemple complet del flux OpenSpec, antipatrons i la regla de l'adaptador prim per a configs d'IA).
 
-## Convencions generals
+## 📏 Convencions generals
 
 | Fitxer | Contingut |
 |---|---|
 | [`conventions.md`](conventions.md) | Estil de codi, patrons del projecte, rutes/cache, commits |
 | [`testing-docker.md`](testing-docker.md) | Execució de tests, scripts Composer, Docker/Selenium |
 
-## UI operativa i graelles
+## 🖥️ UI operativa i graelles
 
 | Fitxer | Contingut |
 |---|---|
 | [`ui/grid-datatables.md`](ui/grid-datatables.md) | Components de graella, Panel/Pestana, DataTables, estat buit |
 
-## FCT (Formació en Centres de Treball)
+## 🏢 FCT (Formació en Centres de Treball)
 
 Dominis: annexos, signatures, SAO, expedients, empreses, col·laboracions.
 
@@ -29,19 +29,19 @@ Dominis: annexos, signatures, SAO, expedients, empreses, col·laboracions.
 | [`fct/signatures.md`](fct/signatures.md) | Flux `/signatura`, `sendTo`/`signed`, plantilles Annex I/II/III/V |
 | [`fct/sao-selenium.md`](fct/sao-selenium.md) | Descàrregues SAO, depuració Selenium |
 
-## Activitats complementàries i extraescolars
+## 🎒 Activitats complementàries i extraescolars
 
 | Fitxer | Contingut |
 |---|---|
 | [`activitats/activitats-map.md`](activitats/activitats-map.md) | Rutes, fitxers clau, camps llegats, coordinador, PDFs |
 
-## Notificacions i correu
+## 📨 Notificacions i correu
 
 | Fitxer | Contingut |
 |---|---|
 | [`notificacions/notificacions-map.md`](notificacions/notificacions-map.md) | `NotificationService`, avisos, `MyMail`, reutilització del sistema d'enviament |
 
-## Specs de comportament
+## 🧪 Specs de comportament
 
 Les especificacions BDD (Given/When/Then) viuen a [`specs/`](../../specs/). Cada spec descriu el comportament esperat d'un bounded context, independent de la tecnologia.
 
@@ -53,10 +53,10 @@ Les especificacions BDD (Given/When/Then) viuen a [`specs/`](../../specs/). Cada
 | [`specs/guardies.md`](../../specs/guardies.md) | Guàrdies: presència, panell donde, coincidències |
 | [`specs/horaris.md`](../../specs/horaris.md) | Horaris: canvi temporal, proposta JSON, bulk apply |
 
-## Flux OpenSpec
+## ✅ Flux OpenSpec
 
 Procediment per a implementar funcionalitats amb aprovació humana en tres passos (`propose → apply → archive`). Documentació: [`openspec.md`](openspec.md).
 
-## Pipeline IA revisora ≠ generadora
+## 🔍 Pipeline IA revisora ≠ generadora
 
 La IA que escriu el codi no pot revisar-lo amb objectivitat. Documentació del workflow de revisió creuada: [`ia-review-pipeline.md`](ia-review-pipeline.md).

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -5,7 +5,7 @@
 - `app/` conté domini, serveis, controladors, policies, finders i helpers.
 - `routes/` està separat per rol: `public.php`, `todos.php`, `profesor.php`, `alumno.php`, `direccion.php`, `administrador.php`, `conserge.php`, `mantenimiento.php`, `jefeDpto.php`; API en `routes/api.php`.
 - `resources/views/` conté Blade. Plantilles de correu en `resources/views/email/`.
-- Assets en `resources/assets/js` i `resources/assets/sass`, compilats amb Laravel Mix.
+- Assets en `resources/assets/js` i `resources/assets/sass`, compilats amb Vite (`vite.config.mjs`).
 - Migracions i seeders en `database/`; tests en `tests/Feature` i `tests/Unit`.
 - Paquets i extensions locals en `packages/` i `plugins/`.
 

--- a/docs/agents/testing-docker.md
+++ b/docs/agents/testing-docker.md
@@ -4,7 +4,7 @@
 
 - PHP dependencies: `composer install`.
 - JS dependencies: `npm install`.
-- Build assets: `npm run dev`, `npm run watch`, `npm run production`.
+- Build assets: `npm run dev` (servidor Vite amb HMR), `npm run build` / `npm run production` (bundles de producció).
 - App local: `php artisan serve`.
 - DB: `php artisan migrate --seed`.
 - Tests: `phpunit` o `php artisan test`; usar `--filter` per acotar.

--- a/docs/architecture/inventari.md
+++ b/docs/architecture/inventari.md
@@ -12,9 +12,9 @@ Nosaltres no hem d'entrar mai a les 2 darreres opcions del menú. Farem l'invent
 ## Veure materials
 El primer que farem és filtrar la taula per a no veure tots els materials del Centre sinò només els de l'espai que anem a inventariar. Per a això tenim sobre la taula a la dreta el quadre 'Filtrar' (zona 1 de la figura, color roig) on escriurem el nom curt de l'espai
 
-![Materiales](img/ajuda/50-materiales-up.png)
+![Materiales](../img/ajuda/50-materiales-up.png)
 
-![Materiales](img/ajuda/51-materiales-down.png)
+![Materiales](../img/ajuda/51-materiales-down.png)
 
 Si hi ha més materials dels que es mostren en la taula (zona 2 groc, baix) podem indicar que es mostren 50 o 100 registres per pàgina (zona 2 groc, dalt).
 
@@ -27,7 +27,7 @@ Ara ja podem inventariar l'espai. Comprovem que cada material correspon al que p
 
 En la columna _Operacions_ (zona 4, verd) tenim iconas per a cada cosa que podem fer amb un material 
 
-![operacions](img/ajuda/52-material-operacions.png):
+![operacions](../img/ajuda/52-material-operacions.png):
 
 1. **Esborrar** (icona de la paperera): elimina totalment el material. NO HO HEM DE FER MAI perquè la majoria de materials estan comptabilitzats i abans d'esborar-los s'han de donar de baixa des de Secretaria.
 2. **Editar** (llapicera): ens permet canviar la descripció del material i altres dades
@@ -42,7 +42,7 @@ En la columna _Operacions_ (zona 4, verd) tenim iconas per a cada cosa que podem
 El que hem de fer per a cada material és:
 * Veure el material i comprovar totes les seues dades
 
-![Veure material](img/ajuda/53-material-veure.png)
+![Veure material](../img/ajuda/53-material-veure.png)
 
 * Si hi ha alguna cosa mal canviar-la:
     * si és el número d'unitats des del botó de '_Canviar unitats_'

--- a/docs/governance/faqs.md
+++ b/docs/governance/faqs.md
@@ -35,7 +35,7 @@ Al arribar al Centre hem de fitxar a la Intranet. Podem fer-ho de 3 formes difer
 2. També podem fer-ho des de l'ordinador que hi ha en Consergeria introduint el nostre codi de professors (4 cifres)
 3. Es fa automàticament al iniciar sessió en la Intranet
 
-Per a fitxar la nostra eixida del Centre podem fer-ho exactament igual (des del mòbil, l'ordinador de Consergeria o la Intranet). Per a fer-ho des de la Intranet només hem de [polsar el rellotge blau](./manual-profe.md#control-de-presència) que hi ha en la part superior dreta
+Per a fitxar la nostra eixida del Centre podem fer-ho exactament igual (des del mòbil, l'ordinador de Consergeria o la Intranet). Per a fer-ho des de la Intranet només hem de [polsar el rellotge blau](../manuals/manual-profe.md#control-de-presència) que hi ha en la part superior dreta
 
 ## Com canviar la meua foto
 Des del menú del perfil (el meu nom a la part superior dreta) trie **_Fitxers personals_**. On diu _Imtage_ polse el botó d'_Examinar_ i trie el fitxer amb la meua foto. Intenta que la foto no siga masa pesada (pocs KB).
@@ -45,20 +45,20 @@ Cada vegada que fem una guàrdia hem de fitxar que estem fent-la. Només es pot 
 
 Si per algun motiu no fem la guàrdia la fitxarem després des de qualsevol equip però com no feta (no ens deixarà marcar-la com feta) i en els comentaris indicarem el motiu pel qual no l'hem feta. Això **NO cal fer-ho** si estem d'activitat extraescolar, comissió de servei o si hem notificat prèviament la nostra absència des de la intranet (en aquestos casos ja ens apareixerà marcada com no feta i omplit el comentari amb el motiu).
 
-Les guàrdies el fitxen des del [menú Docència->Guàrdia](./manual-profe.md#guàrdia).
+Les guàrdies el fitxen des del [menú Docència->Guàrdia](../manuals/manual-profe.md#guàrdia).
 
 ## Com Localitzar a un professor o a algú de Direcció
-Per a localitzar a qualsevol professor anem al [menú Docència->Claustre](./manual-profe.md#claustre) i el busquem dins del seu departement.
+Per a localitzar a qualsevol professor anem al [menú Docència->Claustre](../manuals/manual-profe.md#claustre) i el busquem dins del seu departement.
 
-En cas de algú de direcció anem al [menú Docència->Equip directiu](./manual-profe.md#equip-directiu) on trobem la mateixa informació però de la gent de Direcció.
+En cas de algú de direcció anem al [menú Docència->Equip directiu](../manuals/manual-profe.md#equip-directiu) on trobem la mateixa informació però de la gent de Direcció.
 
 ## Com Contactar amb un professor
-Per a contactar amb qualsevol professor anem al [menú Docència->Claustre](./manual-profe.md#claustre) i el busquem en el seu departement. Allí podem veure on està ara, el seu email i el seu telèfon (si no ho ha marcat com ocult). A més de enviar-li un e-mail podem enviar-li una notificació de la Intranet des del botó 'Avisar'. 
+Per a contactar amb qualsevol professor anem al [menú Docència->Claustre](../manuals/manual-profe.md#claustre) i el busquem en el seu departement. Allí podem veure on està ara, el seu email i el seu telèfon (si no ho ha marcat com ocult). A més de enviar-li un e-mail podem enviar-li una notificació de la Intranet des del botó 'Avisar'. 
 
 Recorda que **totes les notificacions no vistes** en el dia se li envien a l'usuari automàticament en un e-mail remitit per la Intranet.
 
 ## Com fer una Activitat extraescolar
-Es fa des del [menú Tràmits->Activitats Extraescolars](./manual-profe.md#activitats-extraescolars). Els pasos a seguir són:
+Es fa des del [menú Tràmits->Activitats Extraescolars](../manuals/manual-profe.md#activitats-extraescolars). Els pasos a seguir són:
 1. Donar d'alta la nova activitat des del botó '**Alta activitat**' (botó blau a la part superior). Hem d'indicar els professors participants i els grups d'alumnes en els que es fa l'activitat
 2. Una vegada feta, des de la taula d'activitats hem de polsar el botó de '**Enviar per a autoritzar**' per a que li arribe a Direcció l'activitat. Allí ens la han d'aprovar
 3. Una vegada aprovada per part de direcció polsem el botó de '**Avisar al professorat**'. Rebran una notificació informant d'aquesta activitat tot el professorat que participa en ella i tots els que imparteixen clase en els grups que participen en l'activitat
@@ -67,7 +67,7 @@ Es fa des del [menú Tràmits->Activitats Extraescolars](./manual-profe.md#activ
 ## Com fer una Comissió de servei
 Si hem de fer una visita (per FCT, activitat extraescolar o altre motiu), un viatge, etc. fora del Centre hem de registrar una Comissió de servei. Això ens permet estar assegurats fora del Centre i poder cobrar posterioment els gastos de desplaçament o altres que tingam.
 
-Es fa des del [menú Tràmits->Comissions de Servei](./manual-profe.html#comisions-de-servei). Els pasos a seguir són:
+Es fa des del [menú Tràmits->Comissions de Servei](../manuals/manual-profe.md#comisions-de-servei). Els pasos a seguir són:
 1. Donar d'alta la nova comissió des del botó '**Sol·licitut autorització comissió de servei**' (botó blau a la part superior). Hem d'indicar la data, el motiu i els gastos de quilometratge i altres que esperem tindre.
 2. Una vegada feta, des de la taula de comissions hem de polsar el botó de '**Enviar per a autoritzar**' per a que li arribe a Direcció la comissió. Allí ens l'han d'aprovar
 3. Una vegada aprovada per part de direcció polsem el botó de '**Avisar al professorat**'. Rebran una notificació els nostres companys d'equip educatiu per a que sàpien que no estarem en clase a eixes hores
@@ -76,7 +76,7 @@ Es fa des del [menú Tràmits->Comissions de Servei](./manual-profe.html#comisio
 ## Com Reservar un aula o el Saló d'Actes
 Si necessitem un espai diferent a la nostra aula (per exemple el Saló d'actes per a fer una xarrada o un aula per a fer un exàmen) hem de reservar-lo per a assegurar que el tindrem eixe dia.
 
-Es fa des del [menú Tràmits->Reserva aules](./manual-profe.md#reserva-aules).
+Es fa des del [menú Tràmits->Reserva aules](../manuals/manual-profe.md#reserva-aules).
 
 ## Com Notificar una absència
 NOTA: no cal notificar una absència si és per una activitat extraescolar o comissió de servei perquè ja es registra al crear l'activitat o la comissió.
@@ -85,7 +85,7 @@ Si sabem amb antelació que faltarem un dia o unes hores (perque tenim consulta 
 
 Si la nostra absència ha segut inesperada (per malaltia o altre motiu) aquest procès el farem quan siga possible.
 
-Es fa des del [menú Tràmits->Notificació Absències](./manual-profe.md#notificació-absències). Els pasos a seguir són:
+Es fa des del [menú Tràmits->Notificació Absències](../manuals/manual-profe.md#notificació-absències). Els pasos a seguir són:
 1. Donar d'alta l'absència des del botó '**Comunicació d'absència professorat**' (botó blau a la part superior). Hem d'indicar la data, el motiu i el justificant (podem escanejar-lo o fer-li una foto amb el mòbil i obrir allí la Intranet). Si encara no tenim el justificant l'adjuntarem quan el tingam modificant aquesta absència. Es crea el registre i el seu estat serà '**No enviada/autoritzada**'.
 2. Una vegada feta, des de la taula d'absències hem de polsar el botó de '**Enviar**' per a que li arribe a Direcció. Si no hem adjuntat el justificant el seu estat serà '**Sense justificant**'. Si ho hem adjuntat l'estat serà '**Justificada**'.
 3. Polsem el botó de '**Avisar equip**' per a que rebran una notificació els nostres companys d'equip educatiu per a que sàpien que no estarem en clase a eixes hores
@@ -100,38 +100,38 @@ La gestió d'incidències de la Intranet se utilitza per a informar de:
 - el procès de la FCT
 - queixes i sugerències
 
-Es fa des del [menú Tràmits->Gestió Incidències](./manual-profe.md#gestió-dincidències).
+Es fa des del [menú Tràmits->Gestió Incidències](../manuals/manual-profe.md#gestió-dincidències).
 
 ## Com consultar les propostes de millora per a fer la meua Programació
 Un dels punts que hem d'incloure en la Programació és reflectir les propostes de millora anotats en el seguiment de la programació pels professors que van impartir aquest mòdul el curs anterior.
 
-Aquesta informació la trobem en la intranet en [menú Docència->Programacions](./manual-profe.md#programacions). Allí ens apareixen totes les programacions dels mòduls que impartim i l'última icona que tenim en cadascuna és la de 'Omplir seguiment de la programació' (uns binoculars). Des d'alli omplirem el seguiment al final de cada avaluació però al principi de curs trobem les propostes de millora del curs anterior.
+Aquesta informació la trobem en la intranet en [menú Docència->Programacions](../manuals/manual-profe.md#programacions). Allí ens apareixen totes les programacions dels mòduls que impartim i l'última icona que tenim en cadascuna és la de 'Omplir seguiment de la programació' (uns binoculars). Des d'alli omplirem el seguiment al final de cada avaluació però al principi de curs trobem les propostes de millora del curs anterior.
 
 ## Com enviar la meua Programació
-Les programacions es guarden en el _Google Drive_ del Centre. Podem accedir a les nostres des de la intranet en [menú Docència->Programacions](./manual-profe.md#programacions) (només dins del Centre) o desde casa amb l'enllaç que ens han enviat per e-mail des de Caporalia.
+Les programacions es guarden en el _Google Drive_ del Centre. Podem accedir a les nostres des de la intranet en [menú Docència->Programacions](../manuals/manual-profe.md#programacions) (només dins del Centre) o desde casa amb l'enllaç que ens han enviat per e-mail des de Caporalia.
 
 Les programacions han de **modificar-se en Google Drive, no descarregant-les**. Quan ja estiga preparada polsem el botó de 'Enviar' (el del sobre) per a que li arribe al nostre cap de Departament. El seu estat pasarà de ‘No autoritzada/comunicada’ (el seu estat inicial) a ‘No autoritzada’. Quan el cap de Departament la revise pasarà a estar ‘Autoritzada’ si tot és correcte o ens enviarà un email amb les coses que hem de modificar.
 
 ## Com Buscar una programació o altra documentació
-Les nostres programacions les tenim acceibles des del [menú Docència->Programacions](./manual-profe.md#programacions) com hem explicat abans.
+Les nostres programacions les tenim acceibles des del [menú Docència->Programacions](../manuals/manual-profe.md#programacions) com hem explicat abans.
 
-La resta de documentación del Centre la trobem dins del [menú Documentació](./manual-profe.html#men%C3%BA-documentaci%C3%B3). Allí trobarem:
-- [Programacions](./manual-profe.html#veure-les-programacions): totes les programacions del Centre. Es tracta de ducoments públics i tant alumnes com professors tenen accés a elles
-- [Gestió de centre](./manual-profe.html#gestió-de-centre): ací trobem plantilles i documents comuns com justificants per a alumnes o pares així com el calendari escolar, els plànols del Centre o el Dossier del professor
-- [Informació de Centre](./manual-profe.html#informaci%C3%B3-de-centre): ací trobem la informació general del Centre com el Pla Funcional de Centre (PFC), el Pla d’atenció sanitària, el Pla d’Emergències, el Reglament de Règim Intern (RRI), la PGA o els resums dels Consells Socials del Centre.
-- [Actes](./manual-profe.html#actes): ací estan les actes de la COCOPE, de les resunions de departament o del Claustre
-- [Projectes](./manual-profe.html#projectes): ací estan els projectes de fi de cicle presentats pels alumnes de les anteriors promocions
-- [Esquema de la BBDD](./bbdd-esquema.html): diagrama i relacions de la base de dades en format web
+La resta de documentación del Centre la trobem dins del [menú Documentació](../manuals/manual-profe.md#men%C3%BA-documentaci%C3%B3). Allí trobarem:
+- [Programacions](../manuals/manual-profe.md#veure-les-programacions): totes les programacions del Centre. Es tracta de ducoments públics i tant alumnes com professors tenen accés a elles
+- [Gestió de centre](../manuals/manual-profe.md#gestió-de-centre): ací trobem plantilles i documents comuns com justificants per a alumnes o pares així com el calendari escolar, els plànols del Centre o el Dossier del professor
+- [Informació de Centre](../manuals/manual-profe.md#informaci%C3%B3-de-centre): ací trobem la informació general del Centre com el Pla Funcional de Centre (PFC), el Pla d’atenció sanitària, el Pla d’Emergències, el Reglament de Règim Intern (RRI), la PGA o els resums dels Consells Socials del Centre.
+- [Actes](../manuals/manual-profe.md#actes): ací estan les actes de la COCOPE, de les resunions de departament o del Claustre
+- [Projectes](../manuals/manual-profe.md#projectes): ací estan els projectes de fi de cicle presentats pels alumnes de les anteriors promocions
+- [Esquema de la BBDD](../architecture/bbdd-esquema.md): diagrama i relacions de la base de dades en format web
 
 ## Com fer el Seguiment de la programació
 Al final de cada avaluació hem de fer el seguiment de la programació en cadascun dels grups en que impartim classe. Haurem d'indicar el total d'alumnes matriculats, avaluats i aprovats  així com les unitats programades i impartides. També podem incloure comentaris.
 
-Es fa des del [menú Docència->Seguiments](./manual-profe.md#seguiments).
+Es fa des del [menú Docència->Seguiments](../manuals/manual-profe.md#seguiments).
 
 ## Com imprimir el meu Carnet de professor
 Els carnets s'han d'imprimr des de Caporalia d'Estudis on està la impressora de carnets. En un equip d'allí iniciem sessió en la intranet i anem al menú **'Docencia->Claustre'**. Allí ens busquem en la pestanya del nostre departament i ens apareixen 2 botons que no estan en els altres professors:
 
-![Imprimir el meu carnet](./img/ajuda/el-meu-carnet.png)
+![Imprimir el meu carnet](../img/ajuda/el-meu-carnet.png)
 
 * Carnet: per a imprimir el nostre carnet
 * Imprimeix targetes de visita: imprimeix targetes de visita per a utilitzar en les nostres visites a empreses, etc. Això podem fer-ho des de qualsevol ordinador perquè imprimeix un full sencer de visites. És recomanable utilitzar paper més gros per a imprimir-les
@@ -141,31 +141,31 @@ Els carnets s'han d'imprimr des de Caporalia d'Estudis on està la impressora de
 ## Com fer un Acta d'Avaluació o d'altre tipus
 Des del menú **'Actes/Convocatòries -> Gestió de reunions'** tenim accés a les actes de totes les reunions en les quals hem participat (reunions de departament, d'avaluació, d'equip educatiu, ...).
 
-Els tutors (i en ocasions també altres professors) han de convocar algunes d'aquestes reunions tal i com s'indica en el [manual del tutor](./manual-tutor.html#nova-reuni%C3%B3).
+Els tutors (i en ocasions també altres professors) han de convocar algunes d'aquestes reunions tal i com s'indica en el [manual del tutor](../manuals/manual-tutor.md#nova-reuni%C3%B3).
 
 ## Com imprimir els carnets dels alumnes
-Els carnets s'han d'imprimr des de Caporalia d'Estudis on està la impressora de carnets. Es fa des de 'Docència -> Gestió Grups'** tal i com s'explica en el [manual del tutor](./manual-tutor.md#men%C3%BA-docència--gesti%C3%B3-dels-grups).
+Els carnets s'han d'imprimr des de Caporalia d'Estudis on està la impressora de carnets. Es fa des de 'Docència -> Gestió Grups'** tal i com s'explica en el [manual del tutor](../manuals/manual-tutor.md#men%C3%BA-docència--gesti%C3%B3-dels-grups).
 
 # Altres
 
 ## Com fer l'inventari
 El responsable de manteniment de cada departament ha de fer al final de curs l'inventari de tots els materials del departament i les aules i tallers. 
 
-En el [manual d'inventari](./inventari.md) te tota al informació de com fer-ho.
+En el [manual d'inventari](../architecture/inventari.md) te tota al informació de com fer-ho.
 
 # FCT
 
 ## Com anyadir una empresa que no ha colaborat abans amb el centre
 Per tal de donar d'alta una nova empresa anem al menú **'Pràctiques->Empreses'** per arribar al Llistat d'empreses. Per tal de crear l'empresa cal fer us del botó '**Crear Empresa**'. Ara sens obri el següent formulari amb les dades que son necesaries.
 
-![Crear empresa](./img/ajuda/fct_crear_empresa.png)
+![Crear empresa](../img/ajuda/fct_crear_empresa.png)
 
 Cal tenir en compte que el checkbox **'Copia anexe 1'** apareix per defecte marcat. Posiblement en el moment de la creació de l'empresa no tenim eixe document per tant, en eixe cas, cal desmarcar-lo.
 
 Una volta creada l'empresa amb éxit, podem accedir a la seua informació fent click sobre la icona **'+'** de la columna **'Operacions'** i veurem que s'ha creat un centre de treball i una col.laboració amb el nostre departament.
 
-![info empresa centre treball](./img/ajuda/info_empresa_centre_treball.png)
-![info empresa colaboracio](./img/ajuda/info_empresa_colaboracio.png)
+![info empresa centre treball](../img/ajuda/info_empresa_centre_treball.png)
+![info empresa colaboracio](../img/ajuda/info_empresa_colaboracio.png)
 
 ## Com crear una nova col.laboració amb el departament
 Pot ocorrer que tingam que crear una FCT amb una empresa que ja havia col.laborat amb el centre però amb un departament diferent. En este cas necessitarem crear una nova col.laboració amb eixa empresa.
@@ -174,7 +174,7 @@ Per tal de crear la nova col.laboració buscarem l'empresa en el menú **'Pràct
 
 La següent imatge mostra les dades necessaries. El camp **'Llocs'** fa referència al nombre d'alumnes que requerixen.
 
-![dades colaboracio](./img/ajuda/dades_colaboracio.PNG)
+![dades colaboracio](../img/ajuda/dades_colaboracio.PNG)
 
 Es posible que amb la col.laboració siga necessari crear un nou instructor o tanmateix, un nou centre de treball.
 
@@ -182,8 +182,8 @@ Es posible que amb la col.laboració siga necessari crear un nou instructor o ta
 
 Per tal de crear un nou centre de treball, en la pestanya **'Centre de treball'** pulsem **'Afegir Centre de treball'** i s'ens obri el següent formulari:
 
-![nou centre treball](./img/ajuda/empresa_centre_treball.PNG)
+![nou centre treball](../img/ajuda/empresa_centre_treball.PNG)
 
 Una volta seleccionada l'empresa, en la pestanya **'Centre de treball'** pulsem sobre **'Nou instructor'** i s'ens obri el següent formulari:
 
-![nou instructor](./img/ajuda/empresa_nou_instructor.PNG)
+![nou instructor](../img/ajuda/empresa_nou_instructor.PNG)

--- a/docs/manuals/manual-cap.md
+++ b/docs/manuals/manual-cap.md
@@ -29,24 +29,24 @@ Per a convocar una nova reunió premem el botó de 'Nova reunió' i omplim els c
 * objectius de la reunió (camp opcional)
 * espai on es celebrarà la reunió
 
-![Nova reunió](img/tutor/01-nova-reunio.png)
+![Nova reunió](../img/tutor/01-nova-reunio.png)
 
 Una vegada guardada la reunió ja podem completar l'ordre del dia i els participants:
 
-![Nova reunió](img/tutor/02-acta-reunio.png)
+![Nova reunió](../img/tutor/02-acta-reunio.png)
 
 Per defecte ja apareix un ordre del dia de la reunió del qual podem llevar qualsevol punt i afegir punts nous.
 
 També apareixen ja seleccionats els professors participants: tots els de l'equip educatiu.
 
-![Nova reunió](img/tutor/03-profes-reunio.png)
+![Nova reunió](../img/tutor/03-profes-reunio.png)
 
 Igualment podem afegir o eliminar professors participants.
 
 ### Gestionar les reunions
 Una vegada creada la reunió ens apareix en el llistat de reunions des d'on podem fer:
 
-![Nova reunió](img/tutor/04-reunions.png)
+![Nova reunió](../img/tutor/04-reunions.png)
 
 * imprimir: s'imprimeix la convocatòria en PDF
 * editar: tornem a la finestra d'edició per a modificar qualsevol cosa
@@ -57,7 +57,7 @@ Una vegada creada la reunió ens apareix en el llistat de reunions des d'on pode
 ### Acta de la reunió
 Una vegada celebrada la reunió podem omplir l'acta de la mateixa. Per a això editem la reunió i des de la part de l''Ordre del dia' polsem en cada punt el botó d'Editar i ens apareix una zona on escriure el que s'ha parlat en la reunió sobre el punt en qüestió
 
-![Nova reunió](img/tutor/05-omplir-acta-reunio.png)
+![Nova reunió](../img/tutor/05-omplir-acta-reunio.png)
 
 Després d'omplir l'acta des del llistat de reunions podem tornar a avisar als participants o enviar l'acta. En aquest cas l'avís els indicarà que ja està l'acta disponible per a que la puguen veure.
 
@@ -69,7 +69,7 @@ Aquest menú només els apareix als caps de departament i inclou les accions esp
 ### Autoritzar programacions
 Des d'ací els caps autortzaran totes les programacions del seu departament. 
 
-![Nova reunió](img/tutor/01-cap-programacions-mant.png)
+![Nova reunió](../img/tutor/01-cap-programacions-mant.png)
 
 Les programacions poden estar en un d'aquests 3 estats:
 * Pendent: el professor ha pujat la programació però encara està per revisar

--- a/docs/manuals/manual-dir.md
+++ b/docs/manuals/manual-dir.md
@@ -25,7 +25,7 @@ Quan els professors alliberen hores perquè els alumnes de 2n curs sen van a fer
 #### Activar els canvis per als professors
 Pera a que puguen fer els canvis en el seu horari s'ha d'activar aquesta opció del menú (per defecte està desactivada perquè només es poden fer canvis quan s'alliberen les hores de 2n). Es fa des del _Menú **Administració** -> Manteniment del menú general_. Busquem l'opció de 'Canvi horari? (podem filtrar la taula) i l'editem:
 
-![Menu canviar horari](./img/ajuda/canviHorari-menu.png)
+![Menu canviar horari](../img/ajuda/canviHorari-menu.png)
 
 Editem el registre i canviem el camp _**Estat**_ (l'últim) per a habilitar aquesta opció en el menú:
 * 0: no habilitada
@@ -36,14 +36,14 @@ Quan està habilitada a tots els professors els apareix en el menú '_Professora
 #### Aprovar horaris
 Una vegada els professors han fet els canvis en els seus horaris s'han d'aprovar des de direcció. Es fa des de la taula de professors: _menú **Equip directiu** -> Dades Professors_. En la taula amb tots els professors tenim les següents opcions referents als horaris:
 
-![Taula professors](./img/ajuda/canviHorari-tabla-profes.png)
+![Taula professors](../img/ajuda/canviHorari-tabla-profes.png)
 
 * Horari (1a icona): permet veure l'horari actuañ del professor
 * Canviar horar (antepenúltima icona): obri la pantalla de modificació d'horari. Aquesta icona és diferent si el professor ha fet ja una proposta de canvi (segona filera de l'exemple, icona de taula amb 9 quadres) o si no ha fet cap proposta (primera filera, icona de taula amb 4 quadres grans).
 
 La pantalla de modificar l'horari és la mateixa que teel professor per a canviar el seu horari:
 
-![Canviar horari](./img/ajuda/canviHorari-horario-cambiar.png)
+![Canviar horari](../img/ajuda/canviHorari-horario-cambiar.png)
 
 El primer que apareix en la pantalla es l'_Estat_ del canvi que pot ser:
 * No hi ha proposta: el profesor no ha proposat cap canvi d'horari
@@ -66,7 +66,7 @@ A més de moure una hora a altra diferent  l'equip directiu també podem canviar
 
 Ens mostra una taula amb cada entrada de l'horari amb el mòdul, el grup (o l'ocupació) i quan s'imparteix i un botó d'editar:
 
-![Canvia funcio](./img/ajuda/canviHorari-funcio.png)
+![Canvia funcio](../img/ajuda/canviHorari-funcio.png)
 
 Des d'ací podem canviar a què dedica el professor eixa hora.
 
@@ -78,7 +78,7 @@ Ací tenim la majoria d'accions:
 ### Dades professors
 Ací tenim una taula amb tots els professors actius del Centre que podem filtrar, ordenar, ... 
 
-![Taula professors](./img/ajuda/canviHorari-tabla-profes.png)
+![Taula professors](../img/ajuda/canviHorari-tabla-profes.png)
 
 Les acciones que podem fer són:
 * **Horari**: mostra l'horari del professor
@@ -95,4 +95,4 @@ Les acciones que podem fer són:
 * **Canviar funcions d'horari**: per a modificar què fa un professor una hora determinada com s'explica en el [manual de canviar horari](#canvis-dhorari)
 * **Canviar usuari**: ens permet funcionar com si forem l'usuari indicat. Per a tornar al nostre usuari es fa des del menú del perfil amb l'opció de _Tornar al meu usuari_.
 
-![Tornar al meu usuari](./img/ajuda/direc-tornaUsuari.png)
+![Tornar al meu usuari](../img/ajuda/direc-tornaUsuari.png)

--- a/docs/manuals/manual-fct-alumno.md
+++ b/docs/manuals/manual-fct-alumno.md
@@ -6,7 +6,7 @@
 
 <br />
 
-   ![fct1](./img/ajuda/01.png)
+   ![fct1](../img/ajuda/01.png)
    
    **Captura 1**
 
@@ -14,7 +14,7 @@
 
    I quan estiguem dins veurem el següent:
 
-   ![fct2](./img/ajuda/02.png)
+   ![fct2](../img/ajuda/02.png)
 
    **Captura 2**
 
@@ -50,19 +50,19 @@
          * Imprimit informe de competències adquirides
 
 
-   ![fct6](./img/ajuda/06.jpg) Amb aquesta icona podem seleccionar l’idioma que volem que tinga tot el que veiem a la pantalla.
+   ![fct6](../img/ajuda/06.jpg) Amb aquesta icona podem seleccionar l’idioma que volem que tinga tot el que veiem a la pantalla.
 
-   ![fct7](./img/ajuda/07.jpg)
+   ![fct7](../img/ajuda/07.jpg)
 
-   ![fct8](./img/ajuda/08.jpg) Amb aquesta icona accedim a aquesta ajuda.
+   ![fct8](../img/ajuda/08.jpg) Amb aquesta icona accedim a aquesta ajuda.
 
-   ![fct9](./img/ajuda/09.jpg) Amb aquesta icona es tanca tot el contingut de la pantalla. Si fem això hem de tornar a accedir a la part d’FCT igual que ho hem fet des de la (Captura 1).
+   ![fct9](../img/ajuda/09.jpg) Amb aquesta icona es tanca tot el contingut de la pantalla. Si fem això hem de tornar a accedir a la part d’FCT igual que ho hem fet des de la (Captura 1).
 
    A la (Captura 2) veiem una sèrie de botons amb fons blau. D'esquerra a dreta tenim:
 
-   ![fct10](./img/ajuda/10.jpg) Este botó és per a la creació d’una FCT a la intranet. La pantalla que vorem és la següent (Captura 4).
+   ![fct10](../img/ajuda/10.jpg) Este botó és per a la creació d’una FCT a la intranet. La pantalla que vorem és la següent (Captura 4).
 
-   ![fct11](./img/ajuda/11.jpg) 
+   ![fct11](../img/ajuda/11.jpg) 
    
    **Captura 4**
 
@@ -78,7 +78,7 @@
 
    <br />
 
-   ![fct12](./img/ajuda/12.jpg)
+   ![fct12](../img/ajuda/12.jpg)
 
    **Captura 5**
 
@@ -86,7 +86,7 @@
 
    El camp (Data d'inici) té una icona amb forma de calendari i és on s'ha de dir la data de començament de les pràctiques. A aquest camp tenim dues opcions per introduir les dates. O bé s'escriu a mà o bé es polsa damunt de la icona de calendari , es desplega el mes y any actuals i es selecciona la data que volem. Veure la (Captura 6).
 
-   ![fct13](./img/ajuda/13.jpg)
+   ![fct13](../img/ajuda/13.jpg)
 
    **Captura 6**
 
@@ -96,12 +96,12 @@
 
    Finalment, el camp (Hores) s'usa per a escriure el nombre d'hores de durada de l'FCT. Els botons roig i verd de la part inferior esquerra són per guardar la informació introduïda (Guardar) o (Cancelar) si el que volem és esborrar tot el que s'ha introduït.
 
-   ![fct14](./img/ajuda/14.jpg) Aquest és el segon botó blau d'esquerra a dreta de la (Captura 2).
+   ![fct14](../img/ajuda/14.jpg) Aquest és el segon botó blau d'esquerra a dreta de la (Captura 2).
 
    Aquest botó serveix per a indicar al sistema si tenim algun alumne o alumna que està exempte de realitzar les FCT. La pantalla que veem quan polsem eixe botó és:
    <br />
 
-   ![fct15](./img/ajuda/15.jpg)
+   ![fct15](../img/ajuda/15.jpg)
 
    **Captura 7**
 
@@ -111,7 +111,7 @@
 
    Els botons roig i verd de la part inferior esquerra són (Cancelar) si el que volem és esborrar tot el que hem introduït al formulari i tornar a la pantalla anterior, i per guardar la informació introduïda polsarem en (Guardar).
 
-   ![fct16](./img/ajuda/16.jpg)  Aquest és el tercer botó blau d'esquerra a dreta de la (Captura 2).
+   ![fct16](../img/ajuda/16.jpg)  Aquest és el tercer botó blau d'esquerra a dreta de la (Captura 2).
 
    Quan polsem al botó (x Empresa), la nova pantalla ens mostra el llistat d'FCTs actives ordenades alfabèticament per nom d'empresa (Captura 8).
 
@@ -119,7 +119,7 @@
 
    El botó de la Captura anomenat (x Alumne/a) torna a la pantalla de la (Captura 2) i ens mostra la llista d'FCTs actives ordenades alfabèticament per alumne/a.
 
-   ![fct17](./img/ajuda/17.jpg)
+   ![fct17](../img/ajuda/17.jpg)
 
    **Captura 8**
 
@@ -131,7 +131,7 @@
 
    La pantalla que apareix quan polsem a aquesta opció té el següent aspecte:
 
-   ![fct18](./img/ajuda/18.jpg)
+   ![fct18](../img/ajuda/18.jpg)
 
    **Captura 9**
 
@@ -143,7 +143,7 @@
 
    El pdf generat té el següent aspecte:
 
-   ![fct19](./img/ajuda/19.jpg)
+   ![fct19](../img/ajuda/19.jpg)
 
    **Captura 10**
 
@@ -155,7 +155,7 @@
 
    Quan polsem en el botó (Confirmar) es genera un pdf com el següent:
 
-   ![fct20](./img/ajuda/20.jpg)
+   ![fct20](../img/ajuda/20.jpg)
 
    **Captura 11**
 
@@ -169,7 +169,7 @@
 
    Quan polsem damunt d'aquesta opció, ens apareix una pantalla com la de la (Captura 9) perquè seleccionem l'alumnat que volem convocar i una vegada polsem en el botó (Confirmar) es generarà un pdf com el següent:
 
-   ![fct21](./img/ajuda/21.jpg)
+   ![fct21](../img/ajuda/21.jpg)
 
    **Captura 12**
 
@@ -181,7 +181,7 @@
 
    **Imprimeix Full de Vacances:** aquesta és l'última opció de les que apareixen a la pantalla de la (Captura 2). Igual que s'ha operat amb l'anterior opció, quan polsem damunt apareix una pantalla igual que la (Captura 9) a on es seleccionarà l'alumnat del qual es vol generar el pdf i polsarem damunt del botó (Confirmar). El pdf generat té el següent aspecte:
 
-   ![fct22](./img/ajuda/22.jpg)
+   ![fct22](../img/ajuda/22.jpg)
 
    **Captura 13**
 
@@ -195,7 +195,7 @@
 
    Per una banda, tenim la següent llista desplegable:
 
-   ![fct23](./img/ajuda/23.jpg)
+   ![fct23](../img/ajuda/23.jpg)
 
    **Captura 14**
 
@@ -205,7 +205,7 @@
 
    Per l’altra banda, tenim el següent quadre de text anomenat “Filtrar”.
 
-   ![fct24](./img/ajuda/24.jpg)
+   ![fct24](../img/ajuda/24.jpg)
 
    **Captura 15**
 
@@ -217,7 +217,7 @@
 
    <br />
 
-   ![fct25](./img/ajuda/25.jpg)
+   ![fct25](../img/ajuda/25.jpg)
 
    **Captura 16**
 
@@ -239,7 +239,7 @@
 
    <br />
 
-   ![fct26](./img/ajuda/26.jpg)
+   ![fct26](../img/ajuda/26.jpg)
 
    **Captura 17**
 

--- a/docs/manuals/manual-fct-avaluacio.md
+++ b/docs/manuals/manual-fct-avaluacio.md
@@ -9,6 +9,6 @@ Per a cada alumne matriculat en qualsevol d'eixos mòduls tenim una serie d'oper
 | Icona | Descripció |
 | --------- | --------- |
 | MANETA AMUNT I MANETA AVALL | Marcar si l'alumne es qualificat APTE ò NO APTE en la FCT |
-| ![icona_insercio](./img/ajuda/fct_icona_insercio_laboral.png) | Marcar si existeix inserció laboral | 
-| ![icona_docu](./img/ajuda/fct_icona_pujar_docs.png) | Pujar els anexes A5 i A6 de l'alumne. Aquestos anexes s'han de nombrar de la següent forma: *A5 Nom_Cognoms.pdf* i *A6 Nom_Cognoms.pdf*  | 
+| ![icona_insercio](../img/ajuda/fct_icona_insercio_laboral.png) | Marcar si existeix inserció laboral | 
+| ![icona_docu](../img/ajuda/fct_icona_pujar_docs.png) | Pujar els anexes A5 i A6 de l'alumne. Aquestos anexes s'han de nombrar de la següent forma: *A5 Nom_Cognoms.pdf* i *A6 Nom_Cognoms.pdf*  | 
 

--- a/docs/manuals/manual-fct-empreses.md
+++ b/docs/manuals/manual-fct-empreses.md
@@ -6,11 +6,11 @@ ___
 
 A nivell de llistat, per cada empresa tenim dues icones que podem fer servir per tal de consultar les seues dades. Si premem sobre la icona  **+** de l'esquerra, ens mostra el seu **CIF** i la seua **activitat**:
 
-![dades_empresa_cif](./img/ajuda/fct_veure_cif_empresa.PNG)
+![dades_empresa_cif](../img/ajuda/fct_veure_cif_empresa.PNG)
 
 Si premem la icona **+** de la dreta ens mostra totes les dades de l'empresa i ens permet editar-les:
 
-![dades_empresa_totes](./img/ajuda/fct_veure_dades_empresa.PNG)
+![dades_empresa_totes](../img/ajuda/fct_veure_dades_empresa.PNG)
 
 ___
 
@@ -21,7 +21,7 @@ Des del punt de vista de la intranet, per a poder col.laborar amb una empresa en
 * Que s'haja establit un centre de treball (Entenem per centre de treball una localització on l'empresa tinga activitat)
 
 
-A la página de [Preguntes frequents](faqs.md) pots consultar:
+A la página de [Preguntes frequents](../governance/faqs.md) pots consultar:
   * Com anyadir una empresa que no ha colaborat abans amb el centre.
   * Com crear una col.laboració amb el departament.
   * Com crear un nou instructor o un nou centre de treball.

--- a/docs/manuals/manual-fct-gestio-contactes.md
+++ b/docs/manuals/manual-fct-gestio-contactes.md
@@ -48,9 +48,9 @@ Per ordre a l'esquerra apareix:
 Esta pestanya la fem servir en la fase de recerca de col.laboracions. El botó **Sol·licitud de pràctiques** envia un correu sol.licitant la col.laboració a les empreses. Al premer el botó ens apareix el llistat de colaboracions i podem seleccionar les colaboracions que desitgem:
 Un cuadrat de color roig significa que l'empresa no vol col·laborar enguany.
 
-![solicitud](./img/ajuda/fct_solicitud_practiques.PNG)
+![solicitud](../img/ajuda/fct_solicitud_practiques.PNG)
 
-![llistat](./img/ajuda/fct_seleccio_elements.PNG)
+![llistat](../img/ajuda/fct_seleccio_elements.PNG)
 
 Una vegada feta la selecció podrem editar el cos del correu que per defecte es el següent:
 
@@ -126,11 +126,11 @@ Salutacions cordials de Ignasi Gomis
 
 L'us d'aquest botó d'inici es queda enregistrat en cada una de les fitxes de les empreses amb l'aparició de la següent icona:
 
-![bandera](./img/ajuda/bandera_inici.PNG)
+![bandera](../img/ajuda/bandera_inici.PNG)
 
 En aquest moment de les FCT hem de fer servir el botó **Documentació alumnat** que envía un correu a l'alumne/a en el que se li informa de la data d'inici de les FCT i de la asegurança. **L'enviament d'aquest correu no es veu reflectit a les fitxes de les empreses però sens envia també al nostre correu personal, així queda constància de que s'ha enviat**. La següent imatge mostra el contingut d'aquest correu:
 
-![documentacio](./img/ajuda/documentacio_fct_alumne.PNG)
+![documentacio](../img/ajuda/documentacio_fct_alumne.PNG)
 
 
 Una volta iniciada la FCT farem servir el botó **Seguiment** per tal d'enviar correus automàtics als instructors per tal de demanar-los informació. S'envía el següent text:
@@ -149,7 +149,7 @@ Salutacions cordials de Ignasi Gomis
 
 L'enviament de cada correu queda registrat en la corresponent Fitxa del contacte amb un sobre. Inicialment aquesta icona apareix amb un **-** que indica que no hem aportat retroalimentació de la comunicació. Per tal d'aportar la retroalimentació, premem sobre el text amb la data i s'ens obri un formulari. Una vegada aportada la retroalimentació, la icona pasa a ser un **+** tal com es mostra en la següent imatge. 
 
-![correu_retro](./img/ajuda/correu_fct_retroalimentacio.png)
+![correu_retro](../img/ajuda/correu_fct_retroalimentacio.png)
 
 Si necessitem editar o consultar la retroalimentació aportada podem premer de nou sobre la data.
 
@@ -167,7 +167,7 @@ Salutacions cordials de Ignacio Pérez
 **IMPORTANT:**
 L'enviament del correu **Concertar visita** no genera cap nova icona a la fitxa del contacte. En cas d'acordar una data per tal de fer la visita serà necessari tramitar una **comissió de servei** i es aquest tràmit el que genera la corresponent icona. El comportament d'aquesta icona es anàloga a la del sobre. Ens permet aportar una retroalimentació de la reunió:
 
-![visita_retroalimentacio](./img/ajuda/comissio_servei_fct_retroalimentacio.png)
+![visita_retroalimentacio](../img/ajuda/comissio_servei_fct_retroalimentacio.png)
 
 
 Durant el període d'FCT hem de citar als alumnes per a que acudisquen al centre, aço ho fem amb el botó **Citar alumnes** que envia un correu als alumnes amb el següent text:
@@ -179,8 +179,8 @@ Salutacions cordials de Ignacio Pérez
 
 Per finalitzar, una vegada iniciada la FCT, en cada Fitxa de contacte trobem la icona del teléfon que ens permet registrar una conversació telefónica amb l'instructor:
 
-![telefon](./img/ajuda/telefon_fct.PNG)
+![telefon](../img/ajuda/telefon_fct.PNG)
 
 Aquesta icona permet registrar una cridada de telèfon. El comportament es exactament el mateix que el de les icones del sobre i el vehícle, possibilitant el registre de informació de retroalimentació.
 
-![telefon_retro](./img/ajuda/telefon_retroalimentacio.png)
+![telefon_retro](../img/ajuda/telefon_retroalimentacio.png)

--- a/docs/manuals/manual-fct-meues-colaboracions.md
+++ b/docs/manuals/manual-fct-meues-colaboracions.md
@@ -20,7 +20,7 @@ Cada pestanya presenta, a la part de dalt, una serie de botons amb accions. Ixem
 
 ## Que signifiquen totes les dades que hi ha en una col·laboració.
 
-Per ordre a l'esquerra apareix: ![colaboracio](./img/fct/02-profile-colaboracio.png)
+Per ordre a l'esquerra apareix: ![colaboracio](../img/fct/02-profile-colaboracio.png)
 
 * Nom centre treball (ordenats alfabèticament)
   * Número de conveni i si està actualitzat (ditet)
@@ -40,9 +40,9 @@ Per ordre a l'esquerra apareix: ![colaboracio](./img/fct/02-profile-colaboracio.
 Esta pestanya la fem servir en la fase de recerca de col.laboracions. El botó **Sol·licitud de pràctiques** envia un correu sol.licitant la col.laboració a les empreses. Al premer el botó ens apareix el llistat de colaboracions i podem seleccionar les colaboracions que desitgem:
 Un cuadrat de color roig significa que l'empresa no vol col·laborar enguany.
 
-![solicitud](./img/ajuda/fct_solicitud_practiques.PNG)
+![solicitud](../img/ajuda/fct_solicitud_practiques.PNG)
 
-![llistat](./img/ajuda/fct_seleccio_elements.PNG)
+![llistat](../img/ajuda/fct_seleccio_elements.PNG)
 
 Una vegada feta la selecció podrem editar el cos del correu que per defecte es el següent:
 

--- a/docs/manuals/manual-profe.md
+++ b/docs/manuals/manual-profe.md
@@ -51,11 +51,11 @@
 ## Entrada
 L'entrada a l'aplicació es realitza des de qualsevol dispositiu connectat a la xarxa del Centre, tant cablejada com WiFi. Per tant, a més del PC del aula podem usar el nostre portàtil, una tablet o el mòbil. Actualment també es pot accedir des de fora del Centre mitjançant l'enllaç que heu rebut al vostre email del Centre.
 
-![login](./img/ajuda/01-login.png)
+![login](../img/ajuda/01-login.png)
 
 Polsem el botó blau de 'Professor' e introduïm l'usuari (el nostre codi de 4 números o el nostre compte d'email del Centre -_...@edu.gva.es_-) i la contrasenya (al principi el nostre DNI amb 0 davant i lletra en majúscula però és convenient canviar-ho).
 
-![login professor](./img/ajuda/01-loginprofe.png)
+![login professor](../img/ajuda/01-loginprofe.png)
 
 Si no recordem la contrasenya polsem el botó de '**Canvia Password**' i escrivim el nostre email (de _...@edu.gva.es_) per a rebre un correu amb un enllaç per a posar una nova contrasenya.
 
@@ -66,7 +66,7 @@ Des de qualsevol pàgina podem accedir a aquesta pàgina polsant sobre el nom de
 
 La pàgina d'inici te vàries parts:
 
-<a name="fig2">![Pàgina d'inici](./img/ajuda/04-panel-control.png)
+<a name="fig2">![Pàgina d'inici](../img/ajuda/04-panel-control.png)
 
 1. Nom del Centre: des d'ací tornem a la pàgina d'inici des de qualsevol altra pàgina. A la seua dreta hi ha una icona que ens permet amagar o mostrar la barra lateral dels menús
 2. Menús: ens permeten realitzar qualsevol acció e la intranet. Els veurem en detall més avant
@@ -98,7 +98,7 @@ Quan iniciem sessió en la intranet es fitxa automàticament indicant que estem 
  
 De totes formes el més senzill és marcar l'entrada i l'eixida des del nostre mòbil quan estem connectats a la Wifi del Centre. Per a això només hem d'obrir l'enllaç que hi ha al email que ens han enviat des de Caporalia i s'obri una pàgina web en el navegador indicant que entrem al Centre (o eixim). 
  
-![fitxa](./img/ajuda/fitxa.png)
+![fitxa](../img/ajuda/fitxa.png)
  
 Si no trobem eixe email podem fer que ens torne a arribar polsant l'icona del sobre que hi ha a la part inferior esquerra de la intranet (zona 3). 
  
@@ -111,7 +111,7 @@ Per a no haver d'obrir el email cada vegada en el mòbil el més senzill és gua
 ### Notificacions
 En la zona 4 trobem una icona amb un sobre i el número de notificacions pendents que tenim. Aquestes notificacions són missatges d'altres usuaris de la intranet i tot tipus d'informacions automàtiques: si l'alumnat se'n van a fer una activitat extraescolar, si hi ha una reunió de departament, si no hem fixat un dia, ...
 
-![Notificacions](./img/ajuda/05-btnNotificacions.png)
+![Notificacions](../img/ajuda/05-btnNotificacions.png)
 
 Al polsar la icona es despleguen totes. Podem eliminar-les amb la icona de la paperera.
  
@@ -123,7 +123,7 @@ Des d'ací tenim accés a informació i documentació general del Centre.
 ### Programacions
 Ací trobem totes les programacions del Centre. Podem filtrar i ordenar pel criteri que vulguem (mòdul, cicle, departament, ...).
 
-![Programacions](./img/ajuda/09-programacions.png)
+![Programacions](../img/ajuda/09-programacions.png)
 
 Per a veure la programació desitjada polsem el botó de la cadena que trobem a la dreta. Si es tracta d'una programació nostra també ens apareix un botó per a editar les seues dades (mòdul a que correspon, any, ...).
 
@@ -133,7 +133,7 @@ Ací és on podem trobar documents generals del centre com:
 * Justificants d'assistència per a l'alumnat o per als pares
 * Calendari escolar
 * Plànols del centre
-* [Esquema de la BBDD (HTML)](./bbdd-esquema.html)
+* [Esquema de la BBDD (HTML)](../architecture/bbdd-esquema.md)
 * ...
 
 Els diferents documents estan organitzats en pestanyes segons qui els ha d'utilitzar (Professorat, Tutor/a, Cap de departament, …). A cada usuari només l'apareixeran les pestanyes referents al seu rol.
@@ -148,12 +148,12 @@ Ací trobem totes les actes ordenades per pestanyes:
 * Claustres
 * ...
 
-![Actes](./img/ajuda/acta.png)
+![Actes](../img/ajuda/acta.png)
 
 ### Projectes
 Ací trobem els projectes presentats per l'alumnat del cicles de grau superior en el mòdul de 'Projecte' que els seus tutors i tutores han pujat a la intranet. 
 
-![Projectes](./img/ajuda/proyecto.png)
+![Projectes](../img/ajuda/proyecto.png)
 
 
 ## Menú 'Docència'
@@ -163,13 +163,13 @@ On fer les accions més habituals que fa el professorat:
 Ens mostra tots els nostres grups. El botó de 'Filtrar' de la part superior dreta ens permet buscar un grup concret.
 
 Com qualsevol llistat de la intranet el podem ordenar per la columna desitjada polsant sobre el títol de la columna.
-![Grups](./img/ajuda/09-grupos.png)
+![Grups](../img/ajuda/09-grupos.png)
 
 Les opcions que tenim per a qualsevol grup són:
 * Imprimir full de fotos: mostra el llistat de l'alumnat del grup amb foto.
 * Horari del grup.
 * Vore alumnat: apareix el llistat de l'alumnat del grup. El podem veure com a llistat o mosaic.  
-![GestGrupVeureAl](./img/ajuda/gestiog_vorealumnat.png)
+![GestGrupVeureAl](../img/ajuda/gestiog_vorealumnat.png)
 
 Amb l'opció **llistat** tenim la llista de l'alumnat del grup i amb el botó **+** podem veure algunes dades personals de l'alumnat.
 Amb l'opció **mosaic** apareixen les dades personals de l'alumnat en forma de fitxa. 
@@ -184,7 +184,7 @@ Amb el perfil de tutor/a del grup, a més, podem:
 
 ### Claustre
 
-![Claustre](./img/ajuda/07-miDep.png)
+![Claustre](../img/ajuda/07-miDep.png)
 
 Podem veure a tot el professorat del claustre i comprovar si estan ara o no en el Centre i on es poden trobar (segons el seu horari). A la part superior tenim cada departament en una pestanya (per defecte ens apareix el nostre departament). A la part inferior trobem les icones:
 * rellotge: en blau vol dir que s'està en el Centre i en roig que no.
@@ -202,7 +202,7 @@ Disposem de la mateixa informació que en el [claustre](#claustre) però de l'eq
 ### Guàrdia
 Ens permet signar les guàrdies del nostre horari i incloure comentaris:
 
-![Signar guàrdia](./img/ajuda/14-guardia.png)
+![Signar guàrdia](../img/ajuda/14-guardia.png)
 
 Només podem signar les guàrdies del dia actual, encara que es pot modificar el camp de comentari personal de guàrdies ja passades, principalment per a indicar per quin motiu no es va fer una guàrdia.
 
@@ -213,7 +213,7 @@ Els camps que hi ha són:
 
 Trobem dos botons:
 
-![Botons Guàrdia](./img/ajuda/botonsguardia.png)
+![Botons Guàrdia](../img/ajuda/botonsguardia.png)
 
 El botó **Control Personal** l'utilitzarem per a veure les absències del personal del Centre eixe dia (comissions de serveis, extraescolars, baixes...).
 El botó **Guardar** l'utilitzarem per a guardar els canvis.
@@ -228,7 +228,7 @@ Si per algun motiu no ho hem fet (se'ns ha oblidat marcar-la o no l'hem feta per
 ### Seguiments
 Des d'ací pujarem el seguiment de la nostra programació al final de cada avaluació:
 
-![Seguiments](./img/ajuda/10-seguiments.png)
+![Seguiments](../img/ajuda/10-seguiments.png)
 
 Per a pujar un nou seguiment polsem el botó '**Crea resultats per un grup**' de la part superior i introduïm les dades:
 * Grup, mòdul i avaluació
@@ -276,7 +276,7 @@ Quan creem un nou expedient hem d'indicar l'alumne, el tipus d'expedient i una e
 * Pérdua avaluació contínua: per a gestionar la predua d'avaluació contínua de l'alumne a un mòdul per faltes d'assistència. Tant ací com en el cas anterior només es poden tindre en compte les faltes marcades en Ítaca.
 * Part d'amonestació: per a incoar un part d'amonestació a l'alumne
 
-![Expedients](./img/ajuda/expediente.png)
+![Expedients](../img/ajuda/expediente.png)
 
 Una vegada fet un expedient el podem eliminar o editar però l'expedient **no es tramita fins que ho enviem a direcció** (icona del sobre). A partir d'eixe moment direcció te conenxement de l'expedient i contactarà amb nosaltres per a fer els tràmits necessaris (com informar oficialment a l'alumne en cas de perdua de l'avaluació contínua, etc).
 
@@ -284,16 +284,16 @@ Una vegada fet un expedient el podem eliminar o editar però l'expedient **no es
 Ací apareixen totes les activitats extraescolars en las que nosaltres participem. Podem veure-las en format llistat o mosaic:
 
 * Llistat
-![Activitats extraescolars](./img/ajuda/12-actExtr-listado.png)
+![Activitats extraescolars](../img/ajuda/12-actExtr-listado.png)
 
 * Mosaic
 
-![Activitats extraescolars](./img/ajuda/12-actExtr-mosaico.png)
+![Activitats extraescolars](../img/ajuda/12-actExtr-mosaico.png)
 
 En cada activitat hi ha vàries operacions que podem fer:
 
 * Detall activitat: permet afegir o eliminar professors i grups participants. Pot fer-ho qualsevol professor participant. També podem canviar el coordinador de l'activitat
-![Activitats extraescolars - detall](./img/ajuda/12-actExtr-detalle.png)
+![Activitats extraescolars - detall](../img/ajuda/12-actExtr-detalle.png)
 
 * Modificar activitat: permet canviar les dades com el seu nom, las dates o els comentaris
 * Enviar per a autoritzar: s'envia a caporalia l'activitat per a que l'autoritzen
@@ -305,7 +305,7 @@ En cada activitat hi ha vàries operacions que podem fer:
 Els pasos a fer són:
 
 1. Polsar el botó **'Alta activitat'** i omplir els camps del formulari, es pot indicar si es fora el centre, requereix transport, decripció, etc.:
-![Alta activitat extraescolar](./img/ajuda/12-actExtr-alta.png)
+![Alta activitat extraescolar](../img/ajuda/12-actExtr-alta.png)
 2. Polsar sobre **'Detall activitat'** per a indicar els professors i grups participants
 3. Polsar sobre **'Enviar l'activitat per a autoritzar'**. 
 4. Polsar sobre **'Imprimir autorització menors'** i imprimir les autoritzacions per als alumnes menors d'edat (no apareix fins que s'envia per autoritzar)
@@ -315,7 +315,7 @@ Una activitat **NO ES POT REALITZAR** fins que no estiga autoritzada.
 
 ### Comissions de servei
 Aquest apartat ens permet gestionar totes les comisions per visites de FCT, viatges, etc.
-![Comissió de servei](./img/ajuda/13-comisions.png)
+![Comissió de servei](../img/ajuda/13-comisions.png)
 
 A la part dreta del llistat tenim les operacions que podem fer amb cada comissió:
 
@@ -343,11 +343,11 @@ No podem modificar ni anul·lar comisions cobrades ni pendents de cobrament.
 
 #### Alta nova comissió
 Polsem el botó 'Sol·licitud autorització comissió de servei' i omplim el formulari:
-![Alta Comissió de servei](./img/ajuda/13-comissions-alta.png)
+![Alta Comissió de servei](../img/ajuda/13-comissions-alta.png)
 
 Quan polsem el botó 'Guardar' (es troba a la part inferior del formulari) ens apareix un avís en el que se'ns informa si volem comunicar-ho formalment a Direcció i que s'envien els correus electrónics a les persones implicades. Si polsem que **SÍ** automàticament es comunicarà a direcció de la mateixa forma que si haguerem polsat la icona de Enviar/Tramitar (la icona del sobre). Si polsem que **NO** es guardarà com a un esborrany per a ser posteriorment modificat, pero no estarà tramitat de forma oficial a direcció. Posteriorment podria enviar-se polsant la icona de Enviar (icona del sobre).
 
-![Confirma enviar direcció](./img/ajuda/confirma-enviar-direccio.png)
+![Confirma enviar direcció](../img/ajuda/confirma-enviar-direccio.png)
 
 Ara, depenent de quina opció havem triat, podrem borrar-la, modificar-la o enviar-la per autoritzar.
 
@@ -356,7 +356,7 @@ Aquesta aplicació ens permet informar a Caporalia de qualsevol absència i just
 
 Si sabem prèviament que hem de faltar un dia, abans d'eixe dia entrem ací i polsem sobre 'Comunicació d'Absència Profesorat'. Si la falta és imprevista (malaltia, etc) quan tornem al Centre després de haver faltat fem el mateix.
 
-![Alta absència](./img/ajuda/14-ausencia-alta.png)
+![Alta absència](../img/ajuda/14-ausencia-alta.png)
 
 El que em d'omplir en el formulari és:
 
@@ -377,11 +377,11 @@ El que em d'omplir en el formulari és:
 
 Quan polsem el botó 'Guardar' (es troba a la part inferior del formulari) ens apareix un avís en el que se'ns informa si volem comunicar-ho formalment a Direcció i que s'envien els correus electrónics a les persones implicades. Si polsem que **SÍ** automàticament es comunicarà a direcció de la mateixa forma que si haguerem polsat la icona de Enviar/Tramitar (la icona del sobre). Si polsem que **NO** es guardarà com a un esborrany per a ser posteriorment modificat, pero no estarà comunicat de forma oficial a direcció. Posteriorment podria enviar-se polsant la icona de Enviar (icona del sobre).
 
-![Comunicar absencia direccio](./img/ajuda/confirma-enviar-direccio2.png)
+![Comunicar absencia direccio](../img/ajuda/confirma-enviar-direccio2.png)
 
 Les absències donades d'alta es poden visualitzar en format de **Llistat** o **Mosaic** polsant en les pestanyes de dalt a la dreta. Una vegada donada d'alta una absència, el podem eliminar o editar però l'expedient **no es tramita fins que ho enviem a direcció** (icona del sobre). 
 
-![Absències registrades](./img/ajuda/13-ausencia.png)
+![Absències registrades](../img/ajuda/13-ausencia.png)
 
 
 Amb les absències donades d'alta podem fer:
@@ -398,7 +398,7 @@ Una vegada resolta es pot consultar el doument justificatiu adjuntat i no es pot
 ### Gestió d'incidències
 Utilitzem la intranet per a gestionar les incidències que es produeixen en el centre (amb les instal·lacions, preblemes informàtics, ...). Ací trobem totes les incidències que hem obert i el seu estat:
 
-![Incidències](./img/ajuda/16-incidencies.png)
+![Incidències](../img/ajuda/16-incidencies.png)
 
 També tenim un botó per a obrir una nova incidència que li arribarà al responsable de resoldre-la. Els tipus d'incidències que tenim són:
 * Instal·lacions: fontaneria, electricitat, fusteria, obra, estors, cristaleria, etc
@@ -408,7 +408,7 @@ També tenim un botó per a obrir una nova incidència que li arribarà al respo
 
 Quan obrim una nova incidència hem d'indicar el seu tipus i a més:
 
-![Nova incidència](./img/ajuda/nova-incidencia.png)
+![Nova incidència](../img/ajuda/nova-incidencia.png)
 
 * Espai: en quin espai (quina aula, taller, etc) s'ha produit la incidència
 * Material: si hem triat espai ací ens apareixen tots els materials inventariats en eixe espai per a triar-lo. Si no està o no és algo inventariable ho deixarem en blanc i ho especificarem en l'apartat de '_descripció_'
@@ -422,13 +422,13 @@ Aquesta incidència es crea amb estat de **'Pendent'**.
 ### Reserva aules
 Permet a qualsevol professor reservar un espai, com un aula d'informàtica o el Saló d'actes, per a fer en ell qualsevol activitat (un examen, una xarrada, …).
 
-![Reserves](./img/ajuda/14-reservas.png)
+![Reserves](../img/ajuda/14-reservas.png)
 
 Al seleccionar l'espai i la data apareix a cada hora si l'espai està lliure o reservet i per qui.
 
 Per a reservar un espai seleccionem al quadre **TICKET** per a aconseguir un "ticket" de reserva. Cal que emplenem desde quina hora fins quan volem fer la reserva i polsem el botó 'Reservar'.
 
-![Reservar aula](./img/ajuda/14-reservar.png)
+![Reservar aula](../img/ajuda/14-reservar.png)
 
 Si hi ha alguna hora ja reservada dins de l'interval que hem indicat la reserva fallarà.
 
@@ -439,14 +439,14 @@ No es pot reservar un espai amb més de 30 dies d'antelació.
 ### Oblit birret
 Aquesta opció es per justificar si em oblidar marcar el birret a Ítaca. Indiquem quin dia s'hem oblidat de marcar i ens apareixeran totes les hores que hem impartit eixe dia. A la columna 'Estava al centre' s'indica si eixe dia hem fitxat a la Intranet.
 
-![Birret](./img/ajuda/20-birret.png)
+![Birret](../img/ajuda/20-birret.png)
 
 A continuació seleccionen totes les hores que hem oblidat marcar el birret, indiquem la causa en el quadre de "_Justificació_" i premem el botó _Enviar_.
 
 ### Canviar horari
 Aquesta opció només està disponible poc abans d'acabar les classes els grups de segon. Ens permet canviar el nostre horari a partir de Març per a recol·locar les hores que alliberem de 2n. Ens apareix el nostre horari actual i podem arrastar hores a altre horari fins que quede com vullguem:
 
-![Canviar-horari](./img/ajuda/cambiarHorarioUp.png)
+![Canviar-horari](../img/ajuda/cambiarHorarioUp.png)
 
 Per començar hem de polsar el botó '**Iniciar procediment**' i a partir d'eixe moment ja podem arrastrar hores del nostre horari. **ATENCIÓ**: si tornes a polsar aquest botó el teu horari es torna a quedar com estava i es perden els canvis que hages fet
  
@@ -454,7 +454,7 @@ NOTA: no s'ha de posar cap hora en les hores del pati o migdia
 
 Podem fer canvis totes les vegades que vulguem fins que el nou horari siga aprovat per _Caporalia_. Recorda omplir el quadre de **"_Observacions_"** que tenim baix de l'horari indicant a quina activitat dedicarem cadascuna de les hores alliberades. Per a que es guarden els canvis haurem de premer el botó de **_Guardar canvis i enviar_**. L'estat canvia a **'Pendent'**. 
 
-![Canviar-horari](./img/ajuda/cambiarHorarioDown.png)
+![Canviar-horari](../img/ajuda/cambiarHorarioDown.png)
 
 Podem continuar fent canvis fins que Caporalia accepte la nostra proposta. En eixe moment l'estat canvia a **'Aprovat'** i ja no podem fer més canvis. Encara que estiga aprovat, el nou horari no entra en vigor fins que ens ho indiquen des de Caporalia (normalment a Març).
 
@@ -464,7 +464,7 @@ Ací tenim els documents relacionats amb la qualitat així com les diferents enq
 ### Resultats
 Des d'ací podem accedir als resultats de les diferents enquestes passades al nostre alumnat:
 
-![Enquestes](./img/ajuda/enquestes.png)
+![Enquestes](../img/ajuda/enquestes.png)
 
 En cada enquesta tenim botons per a vore les dades i els resultats.
 
@@ -480,9 +480,9 @@ Ací trobem informació sobre les reunions de tot tipus i els Grups de treball a
 ### Gestió de reunions
 Ens apareixen totes les reunions a les que ens han convocat (Claustre, Departament, Equip docent, Grup de treball, ...) i podem veure l'acta de cadascuna d'elles des del botó 'Imprimir'.
 
-![Gestió de reunions](./img/ajuda/15-reunio.png)
+![Gestió de reunions](../img/ajuda/15-reunio.png)
 
-Per a vore com crear una nova reunió pots consultar-ho en el [Manual del tutor](../manual-tutor.html#nova-reunió).
+Per a vore com crear una nova reunió pots consultar-ho en el [Manual del tutor](./manual-tutor.md#nova-reunió).
 
 ### Grups de treball
 Des d'ací podem veure els nostres grups de treball o crear un nou grup.
@@ -499,7 +499,7 @@ En aquest apartat veurem altres eines que ens proporciona la intranet.
 ### Taules amb informació
 En moltes pàgines tenim la informació ordenada en taules. En qualsevol d'elles podem fer:
 
-![Treballar amb taules de dades](./img/ajuda/30-taula.png)
+![Treballar amb taules de dades](../img/ajuda/30-taula.png)
 
 1. **Mostrar**: per defecte es mostren 25 registres per pàgina i des d'ací podem canviar-ho
 2. **Filtrar**: filtra la taula per la paraula/paraules que posem ací. Mostrará només els registres que contenen eixa paraula en qualsevol camp
@@ -516,7 +516,7 @@ Des del botó de 'Editar perfil' podem canviar algunes opcions com:
 - el idioma per defecte de la intranet
 - el nostre correu electrònic
 
-![Editar perfil](./img/ajuda/08-perfil-modificar.png)
+![Editar perfil](../img/ajuda/08-perfil-modificar.png)
 
 #### Fitxers personals
 Des d'ací podem pujar la nostra foto de perfil a intranet, i a més podem estabir altres opcions com:
@@ -525,4 +525,4 @@ Des d'ací podem pujar la nostra foto de perfil a intranet, i a més podem estab
 - **Peu email**: ací podem pujar una imatge que s'inclourà en els emails que s'envien a alumnes i empreses (per a la FCT)
 - **Certificat Digital**: podem pujar el nostre certificat digital per a signar la documentació de les FCT (útil per als tutors de FCT)
 
-![Fitxers personals](./img/ajuda/08-fitxers-personals.png)
+![Fitxers personals](../img/ajuda/08-fitxers-personals.png)

--- a/docs/manuals/manual-tutor.md
+++ b/docs/manuals/manual-tutor.md
@@ -22,7 +22,7 @@
 
 
 ## Introducció
-Aquest manual només explica les accions que pot fer un tutor i no un professor normal. Les accions habituals de qualsevol professor estan explicades en el [manual del professor](./manual-profe.html).
+Aquest manual només explica les accions que pot fer un tutor i no un professor normal. Les accions habituals de qualsevol professor estan explicades en el [manual del professor](./manual-profe.md).
 
 L'accés a la intranet és igual per a tots els professors i és el sistema qui detecta quin és el seu rol (professor, tutor, cap de departament, …) i mostra les opcions adequades en cada cas.
 
@@ -48,14 +48,14 @@ També tenim l¡opció de vore els alumnes en **_Mosaic_** en compte de en _Llis
 
 Una vegada omplit **caldrà avisar a direcció de la tramitació de l'expedient** polsant el botó del sobre i ja s'encarregan de resoldre'l.
 
-![Nou expedient reunió](img/tutor/07-nou-expedient.png)
+![Nou expedient reunió](../img/tutor/07-nou-expedient.png)
 
 ### Remissió a Orientació
 Des d'ací podem derivar alumnes per a que siguen tractats pel departament d'Orientació. Per a cada alumne creem un 'Qüestionari de derivació' on indiquem el motiu i l'orientador responsable esposarà en contacte en el tutor o directament en l'alumne.
 
 En la taula podem vore totes les derivacions fetes i el resultat de les mateixes.
 
-![Remissió a Orientació](img/tutor/orientacio .png)
+![Remissió a Orientació](../img/tutor/orientacio.png)
 
 ## Menú 'Actes/Convocatòries' → 'Gestió de reunions'
 El tutor tindrà que convocar diferents reunions al llarg del curs. 
@@ -82,24 +82,24 @@ Per a convocar una nova reunió premem el botó de 'Nova reunió' i omplim els c
 * objectius de la reunió (camp opcional)
 * espai on es celebrarà la reunió
 
-![Nova reunió](img/tutor/01-nova-reunio.png)
+![Nova reunió](../img/tutor/01-nova-reunio.png)
 
 Una vegada guardada la reunió ja podem completar l'ordre del dia i els participants:
 
-![Acta reunió](img/tutor/02-acta-reunio.png)
+![Acta reunió](../img/tutor/02-acta-reunio.png)
 
 Per defecte ja apareix un ordre del dia de la reunió del qual podem llevar qualsevol punt i afegir punts nous.
 
 També apareixen ja seleccionats els professors participants: tots els de l'equip educatiu.
 
-![Nova reunió](img/tutor/03-profes-reunio.png)
+![Nova reunió](../img/tutor/03-profes-reunio.png)
 
 Igualment podem afegir o eliminar professors participants.
 
 ### Gestionar les reunions
 Una vegada creada la reunió ens apareix en el llistat de reunions, des d'on podem:
 
-![Reunions](img/tutor/04-reunions.png)
+![Reunions](../img/tutor/04-reunions.png)
 
 * imprimir: s'imprimeix la convocatòria en PDF
 * editar: tornem a la finestra d'edició per a modificar qualsevol cosa
@@ -110,7 +110,7 @@ Una vegada creada la reunió ens apareix en el llistat de reunions, des d'on pod
 ### Acta de la reunió
 Una vegada celebrada la reunió podem omplir l'acta de la mateixa. Per a això editem la reunió i des de la part de l'_**Ordre del dia**_ polsem en cada punt el botó d'_Editar_ (l'últim) i ens apareix una zona on escriure el que s'ha parlat en la reunió sobre el punt en qüestió. Quan acabes d'escriure en eixe recuadre és **MOLT IMPORTANT polsar la icona _V_** de la dreta per a guradar els canvis o **_X_** per a cancel·lar-los (si no polses es cancel·laran).
 
-![Acta reunió](img/tutor/05-omplir-acta-reunio.png)
+![Acta reunió](../img/tutor/05-omplir-acta-reunio.png)
 
 Després d'omplir l'acta des del llistat de reunions podem tornar a avisar als participants o enviar-los l'acta. En aquest cas l'avís els indicarà que ja està l'acta disponible per a que la puguen veure.
 
@@ -127,7 +127,7 @@ Hem d'omplir els camps amb les dades del projecte:
 * Fitxer: podem pujar un únic fitxer (si són més els comprimirem prèviament per a tindre només un) polsant en el botó de triar fitxer
 etiquetes: podem asociar al projecte tantes etiquetes com vulgam. Per a crear cada etiqueta la escribim ací dins i polsem Intro.
 
-![Nou projecte](img/tutor/06-nou-projecte.png)
+![Nou projecte](../img/tutor/06-nou-projecte.png)
 
 ## Menú 'Tutor'
 Aquest menú només els apareix als tutor i inclou la majoria d'accions específiques per a ells.
@@ -138,13 +138,13 @@ Apareixen els seguiments que hagen omplit tots els professors de l'equip educati
 ### Tutories
 Ací apareixen totes les tutories que ompli el departament d'orientació. 
 
-![Tutories](img/tutor/08-tutories.png)
+![Tutories](../img/tutor/08-tutories.png)
 
 De cada una podem:
 * Veure el fitxer: podem veure la tutoria que han fet des del departament d'orientació
 * Crear comentari: ací indiquem quan hem fet la tutoria i els comentaris. És important omplir això en sugeriments o millores per a que des del departament d'Orientació puguen saber cóm ha funcionat la tutoria
 
-![Nova tutoria](img/tutor/09-tutoria-crear.png)
+![Nova tutoria](../img/tutor/09-tutoria-crear.png)
 
 ## Menú 'Pràctiques'
 Aquest menú només els apareix als tutors de 2n curs per a gestionar les FCT tal i com s'explica en el [manual de FCT](./manual-fct.md)
@@ -158,20 +158,20 @@ Des d'aquest menú busquem la empresa. Si la empresa ja està ens hem d'asegurar
 
 Si la empresa no està donada de alta la donem nosaltres des de 'Nova empresa':
 
-![Nova empresa](img/tutor/10-nova-empresa.png)
+![Nova empresa](../img/tutor/10-nova-empresa.png)
 
 Ací omplim les dades excepte el fitxer de l'Annex I (a la part inferior). Quen tinguem l'annex I signat per l'empresa l'escanejarem i el pujarem ací per a que es quede guardat.
 
 Una vegada creada es fa automàticament la col·laboració amb el nostre cicle. 
 
-![Col·laboracions](img/tutor/11-colaboraciones.png)
+![Col·laboracions](../img/tutor/11-colaboraciones.png)
 
 Una vegada afegida l'empresa la intranet ens dona automàticament un número de concert per a l'empresa. Aquest número és el que utilitzem per a apuntar-la en el llibre d'empreses del departament de FCT i per al SAO.
 
 Si posterioment l'empresa ha de acogir alumnes de qualsevol altre cicle afegirem una nova col·laboració per a eixe cicle des d'ací:
 
-![Nova col·laboració](img/tutor/12-nova-colaboracio.png)
-![Nova col·laboració](img/tutor/13-nova-colaboracio-ii.png)
+![Nova col·laboració](../img/tutor/12-nova-colaboracio.png)
+![Nova col·laboració](../img/tutor/13-nova-colaboracio-ii.png)
 
 ### Centres de treball
 Una col.laboració no es vincula a una empresa sinó a un centre de treball. Una empresa pot tindre varios centres de treballs. Per defecte una empresa té un centre de treball que concidix amb les dades de l'empresa. Si calen més s'han de donar d'alta de la mateixa forma que s'ha fet amb les col.laboracions.
@@ -179,7 +179,7 @@ Una col.laboració no es vincula a una empresa sinó a un centre de treball. Una
 ### FCTs
 Quan ja existeix l'empresa i la col·laboració amb el nostre cicle ja podem crear la nova FCT des del menú FCTs amb el botó 'Nova FCT':
 
-![Nova FCT](img/tutor/14-nova-fct.png)
+![Nova FCT](../img/tutor/14-nova-fct.png)
 
 Una vegada guardada podem esborrar-la, editar-la o imprimir els certificats una vegada acabades les pràctiques.
 

--- a/docs/operations/desplegament.md
+++ b/docs/operations/desplegament.md
@@ -188,7 +188,7 @@ En el xml de Itaca per a la primera importació han d'estar les següents taules
 
 Les importacions es fan des del menú **Administració -> Importació des de Itaca**. Al ser la primera cal marcar la casella '_Hi ha professors amb horari nou (no és substitut)_'.
 
-![Importar dades itaca](./img/ajuda/setupImportItaca1a-1.png)
+![Importar dades itaca](../img/ajuda/setupImportItaca1a-1.png)
 
 A continuació seleccionen el fitxer amb les dades en format .XML i polsem 'Enviar'.
 
@@ -245,7 +245,7 @@ smtp.gmail.com:intranet@gmail.com:abcd@1234
 
 Per a finalitzar hem de configurar el compte de GMail per a permetre a exim eixir. Es fa des de **GMail -> Configuració -> Compte -> Configuració del compte de Google -> Inici de sessió i seguretat -> Aplicacions amb accés al compte -> Permet l'accés a les aplicacions menys segures** i ACTIVEM aquesta opció:
 
-![Activar compte Google](./img/ajuda/exim-google.png)
+![Activar compte Google](../img/ajuda/exim-google.png)
 
 Podem conprovar que funciona correctament enviant un e-mail des de la terminal:
 ```bash

--- a/docs/operations/docker-prod.md
+++ b/docs/operations/docker-prod.md
@@ -14,7 +14,7 @@ Els fitxers base del repositori són:
 
 ## Què canvia respecte a desenvolupament
 
-En desenvolupament, [`docker-compose.yml`](/Users/arturo/Documents/desarrollo/intranetBatoi/docker-compose.yml) munta el repositori complet com a volum (`.:/var/www/html`). En producció o preproducció, [`docker-compose.prod.yml`](/Users/arturo/Documents/desarrollo/intranetBatoi/docker-compose.prod.yml) usa una imatge publicada i només munta els elements que han de persistir o injectar-se en runtime:
+En desenvolupament, [`docker-compose.yml`](../../docker-compose.yml) munta el repositori complet com a volum (`.:/var/www/html`). En producció o preproducció, [`docker-compose.prod.yml`](../../docker-compose.prod.yml) usa una imatge publicada i només munta els elements que han de persistir o injectar-se en runtime:
 
 - el fitxer `.env`
 - la carpeta `storage`
@@ -70,8 +70,8 @@ La carpeta `storage/` ha de persistir entre desplegaments perquè conté logs, f
 
 No s'ha de copiar mai el `.env` dins de la imatge. En este projecte, això es reforça de dues maneres:
 
-- [`.dockerignore`](/Users/arturo/Documents/desarrollo/intranetBatoi/.dockerignore) exclou `.env*` i només permet `.env.example`
-- [`docker-compose.prod.yml`](/Users/arturo/Documents/desarrollo/intranetBatoi/docker-compose.prod.yml) munta `./.env:/var/www/html/.env`
+- [`.dockerignore`](../../.dockerignore) exclou `.env*` i només permet `.env.example`
+- [`docker-compose.prod.yml`](../../docker-compose.prod.yml) munta `./.env:/var/www/html/.env`
 
 Abans de publicar una imatge convé revisar:
 

--- a/docs/operations/setup.md
+++ b/docs/operations/setup.md
@@ -231,7 +231,7 @@ En el xml de Itaca per a la primera importació han d'estar les següents taules
 
 Les importacions es fan des del menú **Administració -> Importació des de Itaca**. Al ser la primera cal marcar la casella '_Primera Importació anual_'.
 
-![Importar dades itaca](./img/ajuda/setupImportItaca1a-1.png)
+![Importar dades itaca](../img/ajuda/setupImportItaca1a-1.png)
 
 A continuació seleccionen el fitxer amb les dades en format .XML i polsem 'Enviar'.
 

--- a/prompts/nou-controlador.md
+++ b/prompts/nou-controlador.md
@@ -7,7 +7,7 @@
 ## Context i Rol
 
 Ets un desenvolupador PHP/Laravel expert en el projecte intranetBatoi.
-Namespace arrel: `Intranet\`. Stack: Laravel, Blade, Bootstrap 4, Livewire 3.
+Namespace arrel: `Intranet\`. Stack: Laravel, Blade, Bootstrap 5, Livewire 3.
 Llegeix `AGENTS.md` i `docs/agents/conventions.md` abans de generar res.
 
 ## Tasca

--- a/prompts/nova-vista-blade.md
+++ b/prompts/nova-vista-blade.md
@@ -7,7 +7,7 @@
 ## Context i Rol
 
 Ets un desenvolupador PHP/Laravel expert en el projecte intranetBatoi.
-Stack de vistes: Blade, Bootstrap 4, Gentelella admin theme, Livewire 3.
+Stack de vistes: Blade, Bootstrap 5, Livewire 3 (assets amb Vite).
 Llegeix `AGENTS.md` i `docs/agents/conventions.md` abans de generar res.
 
 ## Tasca
@@ -28,7 +28,7 @@ Crea la vista Blade per a **{{nom de la pantalla}}** (rol: `{{rol}}`).
 
 - Tot el text visible en Valencià.
 - Usar `AppAlert::render()` per a missatges d'èxit/error.
-- Classes CSS alineades amb el tema Gentelella (no afegir CSS inline).
+- Classes CSS alineades amb Bootstrap 5 i els estils del projecte (no afegir CSS inline).
 - Si hi ha formulari: token CSRF `@csrf` i mètode `@method` quan siga necessari.
 
 ## Format de resposta


### PR DESCRIPTION
Auditoria completa del directori `docs/` sobre `main`. Tanca #245.

## Resum

**1. ~125 enllaços trencats reparats** — la reorganització de docs/ (#197) va moure els fitxers a subcarpetes sense actualitzar els enllaços relatius: imatges (`./img/` → `../img/`) en tots els manuals, FAQs, setup, desplegament i inventari; enllaços creuats entre docs amb les rutes noves; artefactes `.html` → `.md`; rutes absolutes de màquina local a `docker-prod.md`; typo `orientacio .png`.

**2. Contingut desfasat actualitzat** — `webpack.mix.js` ja no existeix: el build real és **Vite** (`vite.config.mjs`) amb **Vue 3** i **Bootstrap 5** (sense Gentelella). Actualitzats `AGENTS.md`, `conventions.md`, `testing-docker.md` i el README arrel. La plantilla d'issues apuntava a `blob/Laravel13/` → ara `blob/main/`.

**3. Estil ✨** — badges de CI (PHP Tests, Docker Build, Lang Audit) i d'stack al README arrel; icones funcionals per secció a `docs/README.md` i `docs/agents/README.md`.

## Verificació

Comprovador d'enllaços relatius executat sobre tots els `.md` vius (fora d'`archive/`) + README/AGENTS/CLAUDE arrel: **zero enllaços trencats**.

## Test plan

- [ ] Revisar el render del README arrel a GitHub (badges i taules).
- [ ] Obrir un parell de manuals (p. ex. `manual-profe.md`) i confirmar que les imatges es veuen.
- [ ] Confirmar que els enllaços de FAQs cap als manuals naveguen bé.