### PR TITLE
[FIX] Mostra annexos SAO als substituts FCT

### DIFF
--- a/resources/views/fct/partials/alumnos.blade.php
+++ b/resources/views/fct/partials/alumnos.blade.php
@@ -1,10 +1,15 @@
 <ul class="messages fct">
+    @php
+        $userDni = (string) (authUser()->dni ?? '');
+        $professorsAccessibles = $userDni !== ''
+            ? \Intranet\Entities\Profesor::getSubstituts($userDni)
+            : [];
+    @endphp
     @foreach($fct->alFct as $alfct)
         @php
             $alumno = $alfct->Alumno;
-            $userDni = (string) (authUser()->dni ?? '');
             $tutorFct = $alfct->Tutor;
-            $mio = $userDni !== '' && in_array($userDni, $tutorFct?->Sustituidos ?? [], true);
+            $mio = in_array((string) ($alfct->idProfesor ?? ''), $professorsAccessibles, true);
         @endphp
         @if ($mio)
             <li>

--- a/tests/Feature/FctAlumnosPartialFeatureTest.php
+++ b/tests/Feature/FctAlumnosPartialFeatureTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Intranet\Entities\Profesor;
 use Tests\TestCase;
 
@@ -13,12 +16,27 @@ use Tests\TestCase;
  */
 class FctAlumnosPartialFeatureTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::connection('sqlite')->create('profesores', function (Blueprint $table): void {
+            $table->string('dni', 10)->primary();
+            $table->string('sustituye_a')->nullable();
+        });
+    }
+
     public function test_partial_renders_when_alumno_fct_has_null_tutor(): void
     {
         $user = new Profesor();
         $user->dni = 'PRFTEST';
 
-        $this->actingAs($user);
+        $this->actingAs($user, 'profesor');
 
         $tutorGrup = new \stdClass();
         $tutorGrup->FullName = 'Tutor del grup';
@@ -39,6 +57,7 @@ class FctAlumnosPartialFeatureTest extends TestCase
         $alumnoFct->saoAnnexes = 0;
         $alumnoFct->correoAlumno = 0;
         $alumnoFct->id = 1;
+        $alumnoFct->idProfesor = 'ALTRE';
 
         $fct = new \stdClass();
         $fct->alFct = new Collection([$alumnoFct]);
@@ -47,5 +66,50 @@ class FctAlumnosPartialFeatureTest extends TestCase
 
         $this->assertStringContainsString('Alumne Prova', $html);
         $this->assertStringContainsString('Tutor del grup', $html);
+        $this->assertStringNotContainsString('Fitxers Annexes', $html);
+        $this->assertStringNotContainsString('Enllaçar fitxers', $html);
+    }
+
+    public function test_partial_shows_sao_annex_files_to_substitute_teacher(): void
+    {
+        DB::table('profesores')->insert([
+            ['dni' => 'PTIT', 'sustituye_a' => null],
+            ['dni' => 'PSUB', 'sustituye_a' => 'PTIT'],
+        ]);
+
+        $user = new Profesor();
+        $user->dni = 'PSUB';
+
+        $this->actingAs($user, 'profesor');
+
+        $alumno = new \stdClass();
+        $alumno->FullName = 'Alumne amb annexos';
+        $alumno->telef1 = '600000001';
+        $alumno->email = 'annexos@example.test';
+        $alumno->Tutor = new Collection();
+
+        $tutorFct = new \stdClass();
+        $tutorFct->fullName = 'Tutor titular';
+
+        $alumnoFct = new \stdClass();
+        $alumnoFct->Alumno = $alumno;
+        $alumnoFct->Tutor = $tutorFct;
+        $alumnoFct->desde = '2026-03-01';
+        $alumnoFct->hasta = '2026-04-01';
+        $alumnoFct->horas = 380;
+        $alumnoFct->idSao = 'SAO-1';
+        $alumnoFct->saoAnnexes = 0;
+        $alumnoFct->correoAlumno = 0;
+        $alumnoFct->id = 2;
+        $alumnoFct->idProfesor = 'PTIT';
+
+        $fct = new \stdClass();
+        $fct->alFct = new Collection([$alumnoFct]);
+
+        $html = view('fct.partials.alumnos', compact('fct'))->render();
+
+        $this->assertStringContainsString('SAO -', $html);
+        $this->assertStringContainsString('Fitxers Annexes', $html);
+        $this->assertStringContainsString('Enllaçar fitxers', $html);
     }
 }


### PR DESCRIPTION
## Resum
- Corregeix la comprovació de la partial d'alumnat FCT perquè considere pròpies les FCT del tutor substituït pel professor autenticat.
- Afig regressió perquè el substitut veja `SAO - Fitxers Annexes` i un professor no relacionat no veja l'enllaç de fitxers.

## Causa
La vista comparava l'usuari autenticat contra `Sustituidos` calculat des del tutor titular de la FCT. `Profesor::getSubstituts()` recorre la cadena en sentit substitut -> titular, per això el substitut no apareixia quan es partia del titular.

## Validació
- `php artisan test --filter=FctAlumnosPartialFeatureTest`

Closes #247