### PR TITLE
[codex] Corregeix la icona de menor en alumnat FCT

### DIFF
--- a/app/Presentation/AlumnoFct/AlumnoFctPresenter.php
+++ b/app/Presentation/AlumnoFct/AlumnoFctPresenter.php
@@ -49,6 +49,9 @@ final class AlumnoFctPresenter
         return (string) ($this->alumnoFct->Alumno?->ShortName ?? '');
     }
 
+    /**
+     * Retorna el nom curt amb la icona HTML controlada si l'alumne és menor d'edat.
+     */
     public function studentNameWithMinorIcon(): string
     {
         $name = $this->studentShortName();
@@ -56,7 +59,7 @@ final class AlumnoFctPresenter
             return $name;
         }
 
-        return $name . "<em class='fa fa-child'></em>";
+        return e($name) . " <em class='fa fa-child' aria-hidden='true'></em>";
     }
 
     public function remainingPracticeTimeLabel(): string

--- a/docs/archive/modernitzacio-front-backlog.md
+++ b/docs/archive/modernitzacio-front-backlog.md
@@ -50,6 +50,16 @@ Impacte:
 Impacte:
 - Menys acoblament global i menys “efectes col·laterals” entre pantalles.
 
+### Incidència #251 resolta - `/alumnofct` mostrava HTML escapolit
+
+- Data de registre: 2026-06-15.
+- Resolució local: 2026-06-15.
+- Pantalla afectada: `/alumnofct`, graella principal d'alumnat FCT.
+- Símptoma: en algunes entrades es mostra literalment el text `<em class='fa fa-child'></em>` al costat del nom de l'alumne, en lloc de renderitzar la icona de menor d'edat.
+- Origen probable: el camp `NomEdat` de `AlumnoFctCrudSchema::GRID_FIELDS` acaba consumint `AlumnoFctPresenter::studentNameWithMinorIcon()`, que retorna una cadena amb HTML. La capa de graella actual sembla escapar eixe valor en alguns casos.
+- Correcció: `AlumnoFctPresenter::studentNameWithMinorIcon()` escapa el nom abans d'afegir la icona i `resources/views/components/grid/row.blade.php` tracta `AlumnoFct/NomEdat` com a HTML controlat.
+- Regressió: `GridTableComponentTest` comprova que la icona es renderitza i `AlumnoFctTest` comprova que el nom continua escapolit.
+
 ### Fase C - Migració funcional (decisió d’arquitectura)
 
 - C1: Definir criteri: què va a Livewire i què queda en Vue.

--- a/resources/views/components/grid/row.blade.php
+++ b/resources/views/components/grid/row.blade.php
@@ -3,8 +3,8 @@
 <tr class="lineaGrupo {{ $elemento->class ?? '' }}" id="{{ $elemento->getKey() }}">
     @foreach ($pestana->getRejilla() as $item)
         @php($long = str_starts_with($item, 'L') ? 200 : 100)
-        @php($teHtmlControlat = $item === 'FullName' && isset($elemento->incidenciaFullName))
-        @php($valor = $teHtmlControlat ? $elemento->incidenciaFullName : rescue(fn() => $elemento->$item, ''))
+        @php($teHtmlControlat = ($item === 'FullName' && isset($elemento->incidenciaFullName)) || ($panel->getModel() === 'AlumnoFct' && $item === 'NomEdat'))
+        @php($valor = ($item === 'FullName' && isset($elemento->incidenciaFullName)) ? $elemento->incidenciaFullName : rescue(fn() => $elemento->$item, ''))
         @php($valorRetallat = $teHtmlControlat ? $valor : in_substr($valor, $long))
         @php($ordreData = null)
         @if (is_string($valor) && preg_match('/^(\d{2})[-\/](\d{2})[-\/](\d{4})$/', trim($valor), $parts))

--- a/tests/Feature/GridTableComponentTest.php
+++ b/tests/Feature/GridTableComponentTest.php
@@ -91,4 +91,32 @@ class GridTableComponentTest extends TestCase
 
         $this->assertSame('[[0,"desc"]]', $table?->getAttribute('data-order'));
     }
+
+    public function test_nom_edat_d_alumno_fct_renderitza_icona_controlada_sense_escapar_html(): void
+    {
+        $panel = new Panel('AlumnoFct', ['NomEdat']);
+        $pestana = $panel->getPestanas()[0];
+        $elemento = new class () {
+            public string $class = '';
+            public string $NomEdat = 'Alba &lt;script&gt; <em class=\'fa fa-child\' aria-hidden=\'true\'></em>';
+
+            public function getKey(): int
+            {
+                return 1;
+            }
+        };
+
+        $html = Blade::render(
+            '<x-grid.table :panel="$panel" :pestana="$pestana" :elementos="$elementos" />',
+            [
+                'panel' => $panel,
+                'pestana' => $pestana,
+                'elementos' => new Collection([$elemento]),
+            ]
+        );
+
+        $this->assertStringContainsString("<em class='fa fa-child' aria-hidden='true'></em>", $html);
+        $this->assertStringNotContainsString('&lt;em class=', $html);
+        $this->assertStringContainsString('Alba &lt;script&gt;', $html);
+    }
 }

--- a/tests/Unit/Entities/AlumnoFctTest.php
+++ b/tests/Unit/Entities/AlumnoFctTest.php
@@ -57,6 +57,29 @@ class AlumnoFctTest extends TestCase
     }
 
     #[Test]
+    public function get_nom_edat_attribute_escapa_el_nom_i_renderitza_icona_si_es_menor(): void
+    {
+        $mockAlumno = Mockery::mock(Alumno::class)->makePartial();
+
+        $mockAlumno->shouldReceive('offsetExists')->andReturn(true);
+        $mockAlumno->shouldReceive('getAttribute')
+            ->andReturnUsing(fn($key) => match ($key) {
+                'ShortName' => 'Joan <script>',
+                default => null,
+            });
+        $mockAlumno->shouldReceive('esMenorEdat')->andReturn(true);
+
+        $alumnoFct = new AlumnoFct();
+        $alumnoFct->desde = '2026-01-01';
+        $alumnoFct->setRelation('Alumno', $mockAlumno);
+
+        $this->assertSame(
+            "Joan &lt;script&gt; <em class='fa fa-child' aria-hidden='true'></em>",
+            $alumnoFct->NomEdat
+        );
+    }
+
+    #[Test]
     public function get_centro_attribute_trunca_el_text_correctament()
     {
         $mockFct = Mockery::mock(Fct::class)->makePartial();


### PR DESCRIPTION
## Resum

Corregeix el renderitzat del camp `NomEdat` en la graella `/alumnofct`, on algunes files mostraven literalment `<em class='fa fa-child'></em>` en lloc de la icona de menor d'edat.

Fixes #251

## Causa arrel

`AlumnoFctPresenter::studentNameWithMinorIcon()` retornava una cadena amb HTML, però el component genèric de graella escapava les cel·les per defecte. Això feia visible l'etiqueta HTML en la UI.

## Canvis

- `AlumnoFctPresenter::studentNameWithMinorIcon()` escapa el nom de l'alumne abans d'afegir la icona controlada.
- `resources/views/components/grid/row.blade.php` permet HTML controlat només per al camp `AlumnoFct/NomEdat`, mantenint la resta de camps escapats.
- S'actualitza el backlog local de modernització frontend marcant la incidència #251 com a resolta localment.
- S'afigen regressions per al renderitzat de la graella i l'accessor `NomEdat`.

## Validació

- `php artisan test --filter=GridTableComponentTest`
- `php artisan test --filter=AlumnoFctTest`
- `git diff --check`

Nota: `gh auth status` indica que el token local de `gh` és invàlid, així que el PR s'ha obert amb el connector de GitHub.