### PR TITLE
[ADD] Descarrega certificats optatius individuals #250

### DIFF
--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intranet\Application\ModuloOptatiu;
+
+use Illuminate\Support\Collection;
+use Intranet\Entities\Alumno;
+use Intranet\Entities\AlumnoResultado;
+use Intranet\Entities\Modulo_grupo;
+use Intranet\Entities\ModulOptatiuCertificat;
+use Intranet\Entities\ModulOptatiuCertificatAlumne;
+use Intranet\Jobs\SendEmail;
+use Intranet\Services\Document\PdfService;
+use Intranet\Services\School\ModuloGrupoService;
+use Intranet\Services\School\SecretariaService;
+
+/**
+ * Cas d'ús per preparar, guardar i emetre certificats de mòduls optatius.
+ */
+class ModuloOptatiuCertificatService
+{
+    public const DOCUMENT_TYPE = 16;
+
+    public function __construct(
+        private ?ModuloGrupoService $moduloGrupoService = null,
+        private ?PdfService $pdfService = null,
+        private ?SecretariaService $secretariaService = null
+    ) {
+    }
+
+    /**
+     * Retorna els mòduls-grup assignats al professor segons l'horari.
+     *
+     * @param string $dni
+     * @return Collection<int, Modulo_grupo>
+     */
+    public function modulesForTeacher(string $dni): Collection
+    {
+        return collect($this->modulos()->misModulos($dni))
+            ->each(static fn (Modulo_grupo $modulo): Modulo_grupo => $modulo->loadMissing('Grupo.Alumnos', 'ModuloCiclo.Modulo'))
+            ->sortBy(static fn (Modulo_grupo $modulo): string => $modulo->literal)
+            ->values();
+    }
+
+    /**
+     * Indica si el professor pot gestionar el mòdul-grup.
+     */
+    public function canManage(Modulo_grupo $moduloGrupo, string $dni): bool
+    {
+        return $this->modulesForTeacher($dni)
+            ->contains(static fn (Modulo_grupo $candidate): bool => (int) $candidate->id === (int) $moduloGrupo->id);
+    }
+
+    /**
+     * Obté o crea les metadades del certificat per al mòdul-grup.
+     */
+    public function certificateFor(Modulo_grupo $moduloGrupo, string $dni): ModulOptatiuCertificat
+    {
+        return ModulOptatiuCertificat::query()->firstOrCreate(
+            ['idModuloGrupo' => $moduloGrupo->id],
+            [
+                'denominacio' => (string) ($moduloGrupo->Xmodulo ?: $moduloGrupo->literal),
+                'idProfesor' => $dni,
+            ]
+        );
+    }
+
+    /**
+     * Dades del panell: alumnat, notes existents i estat d'emissió.
+     *
+     * @return array{alumnes:Collection<int, Alumno>, resultats:Collection<string, AlumnoResultado>, estats:Collection<string, ModulOptatiuCertificatAlumne>}
+     */
+    public function panelData(ModulOptatiuCertificat $certificat): array
+    {
+        $moduloGrupo = $certificat->ModuloGrupo;
+        $alumnes = $moduloGrupo->Grupo->Alumnos
+            ->sortBy('nameFull')
+            ->values();
+        $resultats = AlumnoResultado::query()
+            ->where('idModuloGrupo', $moduloGrupo->id)
+            ->whereIn('idAlumno', $alumnes->pluck('nia')->all())
+            ->get()
+            ->keyBy('idAlumno');
+        $estats = ModulOptatiuCertificatAlumne::query()
+            ->where('idCertificat', $certificat->id)
+            ->whereIn('idAlumno', $alumnes->pluck('nia')->all())
+            ->get()
+            ->keyBy('idAlumno');
+
+        return compact('alumnes', 'resultats', 'estats');
+    }
+
+    /**
+     * Guarda denominació i notes del certificat.
+     *
+     * @param array<string, mixed> $notes
+     * @return int
+     */
+    public function save(ModulOptatiuCertificat $certificat, string $denominacio, array $notes): int
+    {
+        $certificat->denominacio = trim($denominacio);
+        $certificat->save();
+
+        $saved = 0;
+        foreach ($notes as $idAlumno => $nota) {
+            $nota = (int) $nota;
+            if ($nota < 0 || $nota > 13) {
+                continue;
+            }
+
+            AlumnoResultado::query()->updateOrCreate(
+                [
+                    'idAlumno' => (string) $idAlumno,
+                    'idModuloGrupo' => $certificat->idModuloGrupo,
+                ],
+                ['nota' => $nota]
+            );
+            $saved++;
+        }
+
+        return $saved;
+    }
+
+    /**
+     * Llista les dades que impedeixen emetre certificats.
+     *
+     * @return array<int, string>
+     */
+    public function validationErrors(ModulOptatiuCertificat $certificat): array
+    {
+        $errors = [];
+        if (trim((string) $certificat->denominacio) === '') {
+            $errors[] = 'Cal informar la denominació del mòdul optatiu.';
+        }
+
+        $data = $this->panelData($certificat);
+        foreach ($data['alumnes'] as $alumne) {
+            $nota = (int) ($data['resultats']->get($alumne->nia)?->nota ?? 0);
+            if ($nota <= 0) {
+                $errors[] = "Falta la nota de {$alumne->fullName}.";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Emet certificats, els registra a expedient i envia el correu a cada alumne.
+     *
+     * @return array{sent:int,errors:array<int,string>}
+     */
+    public function emit(ModulOptatiuCertificat $certificat): array
+    {
+        $errors = $this->validationErrors($certificat);
+        if ($errors !== []) {
+            return ['sent' => 0, 'errors' => $errors];
+        }
+
+        $sent = 0;
+        $data = $this->panelData($certificat);
+        $secretario = cargo('secretario');
+        if (!$secretario) {
+            return ['sent' => 0, 'errors' => ['No està configurat el càrrec de secretaria.']];
+        }
+        $remitente = ['email' => $secretario->email, 'nombre' => $secretario->FullName];
+
+        foreach ($data['alumnes'] as $alumne) {
+            $resultado = $data['resultats']->get($alumne->nia);
+            try {
+                $route = $this->pdfRoute($certificat, $alumne);
+                $path = storage_path($route);
+                if (!is_dir(dirname($path))) {
+                    mkdir(dirname($path), 0777, true);
+                }
+                if (file_exists($path)) {
+                    unlink($path);
+                }
+
+                $this->pdfs()->hazPdf(
+                    'pdf.modulOptatiu.certificat',
+                    ['alumne' => $alumne, 'certificat' => $certificat, 'resultat' => $resultado],
+                    cargaDatosCertificado([]),
+                    'portrait'
+                )->save($path);
+
+                $estat = ModulOptatiuCertificatAlumne::query()->updateOrCreate(
+                    ['idCertificat' => $certificat->id, 'idAlumno' => $alumne->nia],
+                    ['fitxer' => $route]
+                );
+
+                $this->secretaria()->uploadFile([
+                    'title' => self::DOCUMENT_TYPE,
+                    'dni' => $alumne->dni,
+                    'alumne' => trim($alumne->shortName),
+                    'route' => $route,
+                    'name' => basename($route),
+                    'size' => filesize($path),
+                ]);
+
+                $estat->registrat_at = now();
+                $estat->enviat_at = now();
+                $estat->save();
+
+                dispatch(new SendEmail(
+                    $alumne->email,
+                    $remitente,
+                    'email.modulOptatiuCertificat',
+                    $estat,
+                    [$route => 'application/pdf']
+                ));
+                $sent++;
+            } catch (\Throwable $exception) {
+                $errors[] = $alumne->fullName . ': ' . $exception->getMessage();
+            }
+        }
+
+        return ['sent' => $sent, 'errors' => $errors];
+    }
+
+    /**
+     * Ruta relativa al directori `storage`.
+     */
+    private function pdfRoute(ModulOptatiuCertificat $certificat, Alumno $alumne): string
+    {
+        return "tmp/modul_optatiu_{$certificat->id}_{$alumne->nia}.pdf";
+    }
+
+    private function modulos(): ModuloGrupoService
+    {
+        return $this->moduloGrupoService ??= app(ModuloGrupoService::class);
+    }
+
+    private function pdfs(): PdfService
+    {
+        return $this->pdfService ??= app(PdfService::class);
+    }
+
+    private function secretaria(): SecretariaService
+    {
+        return $this->secretariaService ??= app(SecretariaService::class);
+    }
+}

--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -22,6 +22,8 @@ class ModuloOptatiuCertificatService
 {
     public const DOCUMENT_TYPE = 16;
 
+    private const OPTIONAL_MODULE_CODE = 'CVOPT';
+
     public function __construct(
         private ?ModuloGrupoService $moduloGrupoService = null,
         private ?PdfService $pdfService = null,
@@ -39,8 +41,17 @@ class ModuloOptatiuCertificatService
     {
         return collect($this->modulos()->misModulos($dni))
             ->each(static fn (Modulo_grupo $modulo): Modulo_grupo => $modulo->loadMissing('Grupo.Alumnos', 'ModuloCiclo.Modulo'))
+            ->filter(static fn (Modulo_grupo $modulo): bool => self::isOptionalModule($modulo))
             ->sortBy(static fn (Modulo_grupo $modulo): string => $modulo->literal)
             ->values();
+    }
+
+    /**
+     * Indica si el mòdul-grup correspon al mòdul optatiu codificat a ITACA.
+     */
+    public static function isOptionalModule(Modulo_grupo $moduloGrupo): bool
+    {
+        return strtoupper(trim((string) $moduloGrupo->ModuloCiclo?->idModulo)) === self::OPTIONAL_MODULE_CODE;
     }
 
     /**

--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -71,7 +71,7 @@ class ModuloOptatiuCertificatService
         return ModulOptatiuCertificat::query()->firstOrCreate(
             ['idModuloGrupo' => $moduloGrupo->id],
             [
-                'denominacio' => (string) ($moduloGrupo->Xmodulo ?: $moduloGrupo->literal),
+                'denominacio' => '',
                 'idProfesor' => $dni,
             ]
         );
@@ -141,8 +141,8 @@ class ModuloOptatiuCertificatService
     public function validationErrors(ModulOptatiuCertificat $certificat): array
     {
         $errors = [];
-        if (trim((string) $certificat->denominacio) === '') {
-            $errors[] = 'Cal informar la denominació del mòdul optatiu.';
+        if (!$this->hasRealDenomination($certificat)) {
+            $errors[] = 'Cal informar la denominació real del mòdul optatiu impartit.';
         }
 
         $data = $this->panelData($certificat);
@@ -154,6 +154,35 @@ class ModuloOptatiuCertificatService
         }
 
         return $errors;
+    }
+
+    /**
+     * Evita emetre certificats amb el literal genèric del codi CVOPT.
+     */
+    private function hasRealDenomination(ModulOptatiuCertificat $certificat): bool
+    {
+        $denominacio = trim((string) $certificat->denominacio);
+        if ($denominacio === '') {
+            return false;
+        }
+
+        $genericNames = collect([
+            $certificat->ModuloGrupo?->Xmodulo,
+            $certificat->ModuloGrupo?->ModuloCiclo?->Modulo?->cliteral,
+            $certificat->ModuloGrupo?->ModuloCiclo?->Modulo?->vliteral,
+            'Mòdul optatiu',
+            'Módulo optativo',
+            'Optatiu',
+            'Optativo',
+        ])
+            ->map(static fn ($name): string => trim((string) $name))
+            ->filter()
+            ->unique()
+            ->values();
+
+        return !$genericNames->contains(
+            static fn (string $generic): bool => strcasecmp($denominacio, $generic) === 0
+        );
     }
 
     /**

--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -157,6 +157,26 @@ class ModuloOptatiuCertificatService
     }
 
     /**
+     * Llista les dades que impedeixen generar el certificat d'un alumne.
+     *
+     * @return array<int, string>
+     */
+    public function validationErrorsForAlumno(ModulOptatiuCertificat $certificat, Alumno $alumne): array
+    {
+        $errors = [];
+        if (!$this->hasRealDenomination($certificat)) {
+            $errors[] = 'Cal informar la denominació real del mòdul optatiu impartit.';
+        }
+
+        $resultat = $this->resultForAlumno($certificat, $alumne);
+        if (!$resultat || (int) $resultat->nota <= 0) {
+            $errors[] = "Falta la nota de {$alumne->fullName}.";
+        }
+
+        return $errors;
+    }
+
+    /**
      * Evita emetre certificats amb el literal genèric del codi CVOPT.
      */
     private function hasRealDenomination(ModulOptatiuCertificat $certificat): bool
@@ -217,12 +237,7 @@ class ModuloOptatiuCertificatService
                     unlink($path);
                 }
 
-                $this->pdfs()->hazPdf(
-                    'pdf.modulOptatiu.certificat',
-                    ['alumne' => $alumne, 'certificat' => $certificat, 'resultat' => $resultado],
-                    cargaDatosCertificado([]),
-                    'portrait'
-                )->save($path);
+                $this->pdf($certificat, $alumne, $resultado)->save($path);
 
                 $estat = ModulOptatiuCertificatAlumne::query()->updateOrCreate(
                     ['idCertificat' => $certificat->id, 'idAlumno' => $alumne->nia],
@@ -259,11 +274,37 @@ class ModuloOptatiuCertificatService
     }
 
     /**
+     * Genera el PDF d'un alumne sense registrar-lo ni enviar correus.
+     */
+    public function pdf(ModulOptatiuCertificat $certificat, Alumno $alumne, ?AlumnoResultado $resultat = null): mixed
+    {
+        $resultat ??= $this->resultForAlumno($certificat, $alumne);
+
+        return $this->pdfs()->hazPdf(
+            'pdf.modulOptatiu.certificat',
+            ['alumne' => $alumne, 'certificat' => $certificat, 'resultat' => $resultat],
+            cargaDatosCertificado([]),
+            'portrait'
+        );
+    }
+
+    /**
      * Ruta relativa al directori `storage`.
      */
     private function pdfRoute(ModulOptatiuCertificat $certificat, Alumno $alumne): string
     {
         return "tmp/modul_optatiu_{$certificat->id}_{$alumne->nia}.pdf";
+    }
+
+    /**
+     * Retorna el resultat de l'alumne per al mòdul-grup del certificat.
+     */
+    private function resultForAlumno(ModulOptatiuCertificat $certificat, Alumno $alumne): ?AlumnoResultado
+    {
+        return AlumnoResultado::query()
+            ->where('idModuloGrupo', $certificat->idModuloGrupo)
+            ->where('idAlumno', $alumne->nia)
+            ->first();
     }
 
     private function modulos(): ModuloGrupoService

--- a/app/Entities/ModulOptatiuCertificat.php
+++ b/app/Entities/ModulOptatiuCertificat.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Intranet\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Intranet\Entities\Concerns\BatoiModels;
+
+/**
+ * Metadades comunes d'un certificat de mòdul optatiu per a un mòdul-grup.
+ *
+ * Les notes de l'alumnat viuen en `alumno_resultados`.
+ *
+ * @property int $id
+ * @property int $idModuloGrupo
+ * @property string $denominacio
+ * @property string $idProfesor
+ */
+class ModulOptatiuCertificat extends Model
+{
+    use BatoiModels;
+
+    protected $table = 'modul_optatiu_certificats';
+
+    protected $fillable = [
+        'idModuloGrupo',
+        'denominacio',
+        'idProfesor',
+    ];
+
+    protected $rules = [
+        'idModuloGrupo' => 'required|integer',
+        'denominacio' => 'required|string|max:200',
+        'idProfesor' => 'required|string|max:10',
+    ];
+
+    /**
+     * Mòdul-grup al qual pertany el certificat.
+     */
+    public function ModuloGrupo(): BelongsTo
+    {
+        return $this->belongsTo(Modulo_grupo::class, 'idModuloGrupo', 'id');
+    }
+
+    /**
+     * Professor responsable del certificat.
+     */
+    public function Profesor(): BelongsTo
+    {
+        return $this->belongsTo(Profesor::class, 'idProfesor', 'dni');
+    }
+
+    /**
+     * Estat d'emissió per alumne.
+     */
+    public function AlumnosCertificado(): HasMany
+    {
+        return $this->hasMany(ModulOptatiuCertificatAlumne::class, 'idCertificat', 'id');
+    }
+}

--- a/app/Entities/ModulOptatiuCertificatAlumne.php
+++ b/app/Entities/ModulOptatiuCertificatAlumne.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Intranet\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Intranet\Entities\Concerns\BatoiModels;
+
+/**
+ * Estat d'emissió del certificat de mòdul optatiu per alumne.
+ *
+ * @property int $id
+ * @property int $idCertificat
+ * @property string $idAlumno
+ * @property string|null $enviat_at
+ * @property string|null $registrat_at
+ * @property string|null $fitxer
+ */
+class ModulOptatiuCertificatAlumne extends Model
+{
+    use BatoiModels;
+
+    protected $table = 'modul_optatiu_certificat_alumnes';
+
+    protected $fillable = [
+        'idCertificat',
+        'idAlumno',
+        'enviat_at',
+        'registrat_at',
+        'fitxer',
+    ];
+
+    protected $rules = [
+        'idCertificat' => 'required|integer',
+        'idAlumno' => 'required|string|max:8',
+    ];
+
+    /**
+     * Certificat al qual pertany l'estat.
+     */
+    public function Certificat(): BelongsTo
+    {
+        return $this->belongsTo(ModulOptatiuCertificat::class, 'idCertificat', 'id');
+    }
+
+    /**
+     * Alumne associat a l'estat.
+     */
+    public function Alumno(): BelongsTo
+    {
+        return $this->belongsTo(Alumno::class, 'idAlumno', 'nia');
+    }
+}

--- a/app/Http/Controllers/ModuloOptatiuCertificatController.php
+++ b/app/Http/Controllers/ModuloOptatiuCertificatController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Intranet\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
+use Intranet\Entities\Modulo_grupo;
+use Intranet\Entities\ModulOptatiuCertificat;
+use Intranet\Exceptions\NotFoundDomainException;
+use Intranet\Services\UI\AppAlert as Alert;
+
+/**
+ * Panell de preparació i emissió de certificats de mòduls optatius.
+ */
+class ModuloOptatiuCertificatController extends Controller
+{
+    protected $perfil = 'profesor';
+    protected $model = 'ModulOptatiuCertificat';
+
+    private ?ModuloOptatiuCertificatService $certificatService = null;
+
+    /**
+     * Mostra els mòduls assignats al professor autenticat.
+     */
+    public function index()
+    {
+        $moduls = $this->certificats()->modulesForTeacher((string) authUser()->dni);
+
+        return view('modul_optatiu_certificat.index', compact('moduls'));
+    }
+
+    /**
+     * Mostra el formulari de denominació i notes d'un mòdul-grup.
+     *
+     * @param int|string $moduloGrupo
+     */
+    public function show($moduloGrupo)
+    {
+        $modul = $this->allowedModuloGrupo($moduloGrupo);
+        $certificat = $this->certificats()->certificateFor($modul, (string) authUser()->dni);
+        $data = $this->certificats()->panelData($certificat);
+
+        return view('modul_optatiu_certificat.show', [
+            'modul' => $modul,
+            'certificat' => $certificat,
+            'alumnes' => $data['alumnes'],
+            'resultats' => $data['resultats'],
+            'estats' => $data['estats'],
+            'notes' => config('auxiliares.notas'),
+        ]);
+    }
+
+    /**
+     * Guarda denominació i notes del mòdul optatiu.
+     *
+     * @param Request $request
+     * @param int|string $moduloGrupo
+     */
+    public function update(Request $request, $moduloGrupo)
+    {
+        $modul = $this->allowedModuloGrupo($moduloGrupo);
+        $certificat = $this->certificats()->certificateFor($modul, (string) authUser()->dni);
+
+        $validated = $request->validate([
+            'denominacio' => 'required|string|max:200',
+            'notes' => 'nullable|array',
+            'notes.*' => 'nullable|integer|min:0|max:13',
+        ]);
+
+        $saved = $this->certificats()->save(
+            $certificat,
+            $validated['denominacio'],
+            $validated['notes'] ?? []
+        );
+
+        Alert::success("S'han guardat {$saved} notes del mòdul optatiu.");
+
+        return redirect()->route('modulOptatiuCertificat.show', ['moduloGrupo' => $modul->id]);
+    }
+
+    /**
+     * Genera, envia i registra els certificats del mòdul.
+     *
+     * @param int|string $certificat
+     */
+    public function emit($certificat)
+    {
+        $certificat = ModulOptatiuCertificat::query()->findOrFail((int) $certificat);
+        $this->allowedModuloGrupo($certificat->idModuloGrupo);
+
+        $result = $this->certificats()->emit($certificat);
+        foreach ($result['errors'] as $error) {
+            Alert::danger($error);
+        }
+
+        if ($result['sent'] > 0) {
+            Alert::success("S'han emés {$result['sent']} certificats.");
+        }
+
+        return redirect()->route('modulOptatiuCertificat.show', ['moduloGrupo' => $certificat->idModuloGrupo]);
+    }
+
+    /**
+     * Retorna un mòdul-grup gestionable pel professor autenticat.
+     *
+     * @param int|string $moduloGrupo
+     * @throws NotFoundDomainException
+     */
+    private function allowedModuloGrupo($moduloGrupo): Modulo_grupo
+    {
+        $modul = Modulo_grupo::query()
+            ->with('Grupo.Alumnos', 'ModuloCiclo.Modulo')
+            ->findOrFail((int) $moduloGrupo);
+
+        if (!$this->certificats()->canManage($modul, (string) authUser()->dni)) {
+            throw new NotFoundDomainException('Mòdul no assignat al professor', [
+                'modulo_grupo_id' => $moduloGrupo,
+                'profesor' => authUser()->dni,
+            ]);
+        }
+
+        return $modul;
+    }
+
+    private function certificats(): ModuloOptatiuCertificatService
+    {
+        return $this->certificatService ??= app(ModuloOptatiuCertificatService::class);
+    }
+}

--- a/app/Http/Controllers/ModuloOptatiuCertificatController.php
+++ b/app/Http/Controllers/ModuloOptatiuCertificatController.php
@@ -4,6 +4,7 @@ namespace Intranet\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
+use Intranet\Entities\Alumno;
 use Intranet\Entities\Modulo_grupo;
 use Intranet\Entities\ModulOptatiuCertificat;
 use Intranet\Exceptions\NotFoundDomainException;
@@ -98,6 +99,38 @@ class ModuloOptatiuCertificatController extends Controller
         }
 
         return redirect()->route('modulOptatiuCertificat.show', ['moduloGrupo' => $certificat->idModuloGrupo]);
+    }
+
+    /**
+     * Mostra el certificat PDF d'un alumne sense registrar-lo ni enviar correus.
+     *
+     * @param int|string $certificat
+     * @param int|string $alumne
+     */
+    public function pdf($certificat, $alumne)
+    {
+        $certificat = ModulOptatiuCertificat::query()->findOrFail((int) $certificat);
+        $modul = $this->allowedModuloGrupo($certificat->idModuloGrupo);
+
+        $alumne = $modul->Grupo->Alumnos
+            ->firstWhere('nia', (string) $alumne);
+        if (!$alumne instanceof Alumno) {
+            throw new NotFoundDomainException('Alumne no matriculat en el grup del mòdul optatiu', [
+                'certificat_id' => $certificat->id,
+                'alumne' => $alumne,
+            ]);
+        }
+
+        $errors = $this->certificats()->validationErrorsForAlumno($certificat, $alumne);
+        if ($errors !== []) {
+            foreach ($errors as $error) {
+                Alert::danger($error);
+            }
+
+            return redirect()->route('modulOptatiuCertificat.show', ['moduloGrupo' => $certificat->idModuloGrupo]);
+        }
+
+        return $this->certificats()->pdf($certificat, $alumne)->stream();
     }
 
     /**

--- a/app/Services/School/SecretariaService.php
+++ b/app/Services/School/SecretariaService.php
@@ -3,8 +3,11 @@ namespace Intranet\Services\School;
 
 use Illuminate\Support\Facades\Http;
 use Intranet\Exceptions\IntranetException;
+use Intranet\Services\Auth\RemoteLoginService;
 
-
+/**
+ * Client per registrar documents d'alumnat al servidor de secretaria.
+ */
 class SecretariaService
 {
     protected $link;

--- a/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
+++ b/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Crea les taules de metadades d'emissió de certificats de mòduls optatius.
+     */
+    public function up(): void
+    {
+        Schema::create('modul_optatiu_certificats', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedInteger('idModuloGrupo')->unique();
+            $table->string('denominacio', 200);
+            $table->string('idProfesor', 10);
+            $table->timestamps();
+
+            $table->foreign('idModuloGrupo')
+                ->references('id')
+                ->on('modulo_grupos')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreign('idProfesor')
+                ->references('dni')
+                ->on('profesores')
+                ->cascadeOnUpdate();
+        });
+
+        Schema::create('modul_optatiu_certificat_alumnes', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('idCertificat')
+                ->constrained('modul_optatiu_certificats')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->string('idAlumno', 8);
+            $table->timestamp('enviat_at')->nullable();
+            $table->timestamp('registrat_at')->nullable();
+            $table->string('fitxer', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique(['idCertificat', 'idAlumno']);
+            $table->foreign('idAlumno')
+                ->references('nia')
+                ->on('alumnos')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
+    }
+
+    /**
+     * Elimina les taules de metadades d'emissió.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('modul_optatiu_certificat_alumnes');
+        Schema::dropIfExists('modul_optatiu_certificats');
+    }
+};

--- a/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
+++ b/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
@@ -15,7 +15,9 @@ return new class extends Migration
             $table->id();
             $table->unsignedInteger('idModuloGrupo')->unique();
             $table->string('denominacio', 200);
-            $table->string('idProfesor', 10);
+            $table->string('idProfesor', 10)
+                ->charset('utf8mb3')
+                ->collation('utf8mb3_unicode_ci');
             $table->timestamps();
 
             $table->foreign('idModuloGrupo')
@@ -35,7 +37,9 @@ return new class extends Migration
                 ->constrained('modul_optatiu_certificats')
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
-            $table->string('idAlumno', 8);
+            $table->string('idAlumno', 8)
+                ->charset('utf8mb3')
+                ->collation('utf8mb3_unicode_ci');
             $table->timestamp('enviat_at')->nullable();
             $table->timestamp('registrat_at')->nullable();
             $table->string('fitxer', 255)->nullable();

--- a/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
+++ b/database/migrations/2026_06_12_120000_create_modul_optatiu_certificats_table.php
@@ -12,12 +12,13 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('modul_optatiu_certificats', function (Blueprint $table): void {
+            $table->charset = 'utf8mb3';
+            $table->collation = 'utf8mb3_unicode_ci';
+
             $table->id();
             $table->unsignedInteger('idModuloGrupo')->unique();
             $table->string('denominacio', 200);
-            $table->string('idProfesor', 10)
-                ->charset('utf8mb3')
-                ->collation('utf8mb3_unicode_ci');
+            $table->string('idProfesor', 10);
             $table->timestamps();
 
             $table->foreign('idModuloGrupo')
@@ -32,14 +33,15 @@ return new class extends Migration
         });
 
         Schema::create('modul_optatiu_certificat_alumnes', function (Blueprint $table): void {
+            $table->charset = 'utf8mb3';
+            $table->collation = 'utf8mb3_unicode_ci';
+
             $table->id();
             $table->foreignId('idCertificat')
                 ->constrained('modul_optatiu_certificats')
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
-            $table->string('idAlumno', 8)
-                ->charset('utf8mb3')
-                ->collation('utf8mb3_unicode_ci');
+            $table->string('idAlumno', 8);
             $table->timestamp('enviat_at')->nullable();
             $table->timestamp('registrat_at')->nullable();
             $table->string('fitxer', 255)->nullable();

--- a/database/migrations/2026_06_12_121000_add_modul_optatiu_certificat_menu.php
+++ b/database/migrations/2026_06_12_121000_add_modul_optatiu_certificat_menu.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Afig l'entrada de menú del panell de certificats de mòduls optatius.
+ */
+return new class extends Migration
+{
+    /**
+     * Crea l'entrada de menú si no existeix.
+     */
+    public function up(): void
+    {
+        $exists = DB::table('menus')
+            ->where('nombre', 'certOptatiu')
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        DB::table('menus')->insert([
+            'nombre' => 'certOptatiu',
+            'url' => '/modul-optatiu-certificat',
+            'class' => 'fa-file-pdf-o',
+            'rol' => config('roles.rol.profesor'),
+            'menu' => 'docencia',
+            'submenu' => '',
+            'activo' => 1,
+            'orden' => 9999,
+            'ajuda' => '',
+        ]);
+    }
+
+    /**
+     * Retira l'entrada de menú creada.
+     */
+    public function down(): void
+    {
+        DB::table('menus')
+            ->where('nombre', 'certOptatiu')
+            ->delete();
+    }
+};

--- a/resources/lang/ca/messages.php
+++ b/resources/lang/ca/messages.php
@@ -235,6 +235,7 @@ return array(
         'Gtrabajo' => 'Actes/Convocatòries',
         'Grtrabajo' => 'Grups de Treball',
         'Resultados' => 'Seguiments',
+        'CertOptatiu' => 'Certificats optatius',
         'Register' => 'Registrar Curs/Ponència',
         'Documento' => 'Gestor Documental',
         'Nohanfichado' => 'Presència',

--- a/resources/lang/ca/models.php
+++ b/resources/lang/ca/models.php
@@ -574,6 +574,7 @@ return array(
             'Fctcap' => 'Revisió FCT',
             'Solicitud' => "Derivació al departament d'orientació",
             'Signatura' => 'Signatures Digitals',
+            'ModulOptatiuCertificatAlumne' => 'Certificat de mòdul optatiu',
             'Cotxe' => 'Vehicles'
         ),
         'resign' => array(

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -234,6 +234,7 @@ return array(
         'Gtrabajo' => 'Proceedings/Announcements',
         'Grtrabajo' => 'Working groups',
         'Resultados' => 'Tracking',
+        'CertOptatiu' => 'Optional certificates',
         'Register' => 'Register Course/Lecture',
         'Documento' => 'Document Manager',
         'Nohanfichado' => 'Presence',

--- a/resources/lang/en/models.php
+++ b/resources/lang/en/models.php
@@ -574,6 +574,7 @@ return array(
             'Fctcap' => 'Revisió FCT',
             'Solicitud' => "Derivació al departament d'orientació",
             'Signatura' => 'Signatures Digitals',
+            'ModulOptatiuCertificatAlumne' => 'Optional module certificate',
             'Cotxe' => 'Vehicles'
         ),
         'resign' => array(

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -233,6 +233,7 @@ return array(
         'Gtrabajo' => 'Actas/Convocatorias',
         'Grtrabajo' => 'Grupos de Trabajo',
         'Resultados' => 'Seguimientos',
+        'CertOptatiu' => 'Certificados optativos',
         'Register' => 'Registrar Curso/Ponencia',
         'Documento' => 'Gestor Documental',
         'Nohanfichado' => 'Presencia',

--- a/resources/lang/es/models.php
+++ b/resources/lang/es/models.php
@@ -572,6 +572,7 @@ return array(
             'Fctcap' => 'Revisión FCT',
             'Solicitud' => 'Derivación al departamento de orientación',
             'Signatura' => 'Firmas Digitales',
+            'ModulOptatiuCertificatAlumne' => 'Certificado de módulo optativo',
             'Cotxe' => 'Vehículos'
         ),
         'resign' => array(

--- a/resources/views/email/modulOptatiuCertificat.blade.php
+++ b/resources/views/email/modulOptatiuCertificat.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.email')
+
+@section('body')
+    <table style="text-align: center">
+        <tr>
+            <th>Certificat de mòdul optatiu</th>
+        </tr>
+    </table>
+    <div>
+        <table style="border:#000 solid 1;">
+            <tr>
+                <td><strong>De: </strong>{!! $remitente['nombre'] !!}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="container">
+        Estimat/da {{ $elemento->Alumno->fullName }}:<br/>
+        Adjunt et remetem el certificat del mòdul optatiu {{ $elemento->Certificat->denominacio }}.<br/>
+        Salutacions cordials.
+    </div>
+@endsection

--- a/resources/views/modul_optatiu_certificat/index.blade.php
+++ b/resources/views/modul_optatiu_certificat/index.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.intranet')
+
+@section('titulo', 'Certificats de mòduls optatius')
+
+@section('content')
+    <table class="table table-striped table-hover">
+        <thead>
+        <tr>
+            <th>Grup</th>
+            <th>Mòdul</th>
+            <th>Accions</th>
+        </tr>
+        </thead>
+        <tbody>
+        @forelse ($moduls as $modul)
+            <tr>
+                <td>{{ $modul->XGrupo }}</td>
+                <td>{{ $modul->XModulo }}</td>
+                <td>
+                    <a class="btn btn-primary btn-sm" href="{{ route('modulOptatiuCertificat.show', ['moduloGrupo' => $modul->id]) }}">
+                        Gestionar
+                    </a>
+                </td>
+            </tr>
+        @empty
+        @endforelse
+        </tbody>
+    </table>
+@endsection

--- a/resources/views/modul_optatiu_certificat/show.blade.php
+++ b/resources/views/modul_optatiu_certificat/show.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.intranet')
+
+@section('titulo', 'Certificat de mòdul optatiu')
+
+@section('content')
+    <div class="mb-3">
+        <a class="btn btn-default btn-sm" href="{{ route('modulOptatiuCertificat.index') }}">Tornar</a>
+    </div>
+
+    <form method="post" action="{{ route('modulOptatiuCertificat.update', ['moduloGrupo' => $modul->id]) }}">
+        @csrf
+        @method('put')
+
+        <div class="form-group">
+            <label for="denominacio">Denominació del mòdul optatiu</label>
+            <input
+                id="denominacio"
+                name="denominacio"
+                class="form-control"
+                value="{{ old('denominacio', $certificat->denominacio) }}"
+                maxlength="200"
+                required
+            >
+        </div>
+
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>Alumne/a</th>
+                <th style="width: 180px;">Nota</th>
+                <th style="width: 220px;">Estat</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach ($alumnes as $alumne)
+                @php
+                    $resultat = $resultats->get($alumne->nia);
+                    $estat = $estats->get($alumne->nia);
+                @endphp
+                <tr>
+                    <td>{{ $alumne->fullName }}</td>
+                    <td>
+                        <select name="notes[{{ $alumne->nia }}]" class="form-control">
+                            @foreach ($notes as $key => $label)
+                                <option value="{{ $key }}" @selected((string) old("notes.{$alumne->nia}", $resultat->nota ?? 0) === (string) $key)>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </td>
+                    <td>
+                        @if ($estat?->registrat_at)
+                            Registrat i enviat
+                        @else
+                            Pendent
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+
+        <button type="submit" class="btn btn-primary">Guardar notes</button>
+    </form>
+
+    <form method="post" action="{{ route('modulOptatiuCertificat.emit', ['certificat' => $certificat->id]) }}" class="mt-3">
+        @csrf
+        <button type="submit" class="btn btn-success">Emetre certificats PDF</button>
+    </form>
+@endsection

--- a/resources/views/modul_optatiu_certificat/show.blade.php
+++ b/resources/views/modul_optatiu_certificat/show.blade.php
@@ -12,12 +12,13 @@
         @method('put')
 
         <div class="form-group">
-            <label for="denominacio">Denominació del mòdul optatiu</label>
+            <label for="denominacio">Nom del mòdul optatiu impartit</label>
             <input
                 id="denominacio"
                 name="denominacio"
                 class="form-control"
                 value="{{ old('denominacio', $certificat->denominacio) }}"
+                placeholder="Nom real del mòdul optatiu d'este grup"
                 maxlength="200"
                 required
             >

--- a/resources/views/modul_optatiu_certificat/show.blade.php
+++ b/resources/views/modul_optatiu_certificat/show.blade.php
@@ -30,6 +30,7 @@
                 <th>Alumne/a</th>
                 <th style="width: 180px;">Nota</th>
                 <th style="width: 220px;">Estat</th>
+                <th style="width: 140px;">PDF</th>
             </tr>
             </thead>
             <tbody>
@@ -55,6 +56,15 @@
                         @else
                             Pendent
                         @endif
+                    </td>
+                    <td>
+                        <a
+                            class="btn btn-default btn-sm"
+                            href="{{ route('modulOptatiuCertificat.pdf', ['certificat' => $certificat->id, 'alumne' => $alumne->nia]) }}"
+                            target="_blank"
+                        >
+                            <i class="fa fa-file-pdf-o"></i> Certificat
+                        </a>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/pdf/modulOptatiu/certificat.blade.php
+++ b/resources/views/pdf/modulOptatiu/certificat.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.pdf')
+
+@section('content')
+    @php
+        $alumne = $todos['alumne'];
+        $certificat = $todos['certificat'];
+        $resultat = $todos['resultat'];
+        $nota = config('auxiliares.notas')[(int) $resultat->nota] ?? $resultat->nota;
+    @endphp
+    <div class="page">
+        @include('pdf.partials.cabecera')
+        <h2 style="text-align:center; margin-top: 40px;">CERTIFICAT DE MÒDUL OPTATIU</h2>
+
+        <p style="font-size: 1.2em; line-height: 175%; text-align: justify; margin-top: 50px;">
+            {{ $datosInforme['director']['articulo'] ?? 'La' }}
+            {{ $datosInforme['director']['genero'] ?? 'directora' }}
+            del {{ config('contacto.titulo') }}, certifica que
+            {{ nomAmbTitol($alumne->sexo, $alumne->fullName) }}, amb DNI núm. {{ $alumne->dni }},
+            ha cursat el mòdul optatiu <strong>{{ $certificat->denominacio }}</strong>
+            amb una qualificació de <strong>{{ $nota }}</strong>.
+        </p>
+
+        @include('pdf.partials.firmaDS')
+    </div>
+@endsection

--- a/routes/profesor.php
+++ b/routes/profesor.php
@@ -236,6 +236,22 @@ Route::post('/resultado/create', ['as' => 'resultado.store', 'uses' => 'Resultad
 Route::put('/resultado/{resultado}/edit', ['as' => 'resultado.update', 'uses' => 'ResultadoController@update']);
 Route::get('/resultado/pdf', ['as' => 'resultado.pdf', 'uses' => 'ResultadoController@listado']);
 
+Route::get('/modul-optatiu-certificat', [
+    'as' => 'modulOptatiuCertificat.index',
+    'uses' => 'ModuloOptatiuCertificatController@index',
+]);
+Route::get('/modul-optatiu-certificat/{moduloGrupo}', [
+    'as' => 'modulOptatiuCertificat.show',
+    'uses' => 'ModuloOptatiuCertificatController@show',
+]);
+Route::put('/modul-optatiu-certificat/{moduloGrupo}', [
+    'as' => 'modulOptatiuCertificat.update',
+    'uses' => 'ModuloOptatiuCertificatController@update',
+]);
+Route::post('/modul-optatiu-certificat/{certificat}/emet', [
+    'as' => 'modulOptatiuCertificat.emit',
+    'uses' => 'ModuloOptatiuCertificatController@emit',
+]);
 
 //Empreses
 Route::resource('/empresa', 'EmpresaController', ['except' => ['destroy', 'store', 'update', 'show']]);

--- a/routes/profesor.php
+++ b/routes/profesor.php
@@ -248,6 +248,10 @@ Route::put('/modul-optatiu-certificat/{moduloGrupo}', [
     'as' => 'modulOptatiuCertificat.update',
     'uses' => 'ModuloOptatiuCertificatController@update',
 ]);
+Route::get('/modul-optatiu-certificat/{certificat}/alumne/{alumne}/pdf', [
+    'as' => 'modulOptatiuCertificat.pdf',
+    'uses' => 'ModuloOptatiuCertificatController@pdf',
+]);
 Route::post('/modul-optatiu-certificat/{certificat}/emet', [
     'as' => 'modulOptatiuCertificat.emit',
     'uses' => 'ModuloOptatiuCertificatController@emit',

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\ModuloOptatiu;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
+use Intranet\Entities\Modulo_grupo;
+use Intranet\Entities\ModulOptatiuCertificat;
+use Tests\TestCase;
+
+class ModuloOptatiuCertificatServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        $schema = Schema::connection('sqlite');
+        foreach ([
+            'modul_optatiu_certificat_alumnes',
+            'modul_optatiu_certificats',
+            'alumno_resultados',
+            'alumnos_grupos',
+            'alumnos',
+            'modulo_grupos',
+            'modulo_ciclos',
+            'modulos',
+            'grupos',
+        ] as $table) {
+            $schema->dropIfExists($table);
+        }
+
+        $schema->create('modulos', function (Blueprint $table): void {
+            $table->string('codigo', 20)->primary();
+            $table->string('cliteral')->nullable();
+            $table->string('vliteral')->nullable();
+        });
+
+        $schema->create('modulo_ciclos', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('idModulo', 20)->nullable();
+            $table->unsignedInteger('idCiclo')->nullable();
+            $table->unsignedInteger('idDepartamento')->nullable();
+            $table->unsignedTinyInteger('curso')->default(1);
+        });
+
+        $schema->create('grupos', function (Blueprint $table): void {
+            $table->string('codigo', 10)->primary();
+            $table->unsignedInteger('idCiclo')->nullable();
+            $table->string('nombre')->nullable();
+            $table->string('turno', 1)->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('modulo_grupos', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idModuloCiclo')->nullable();
+            $table->string('idGrupo', 10)->nullable();
+        });
+
+        $schema->create('alumnos', function (Blueprint $table): void {
+            $table->string('nia', 8)->primary();
+            $table->string('dni')->nullable();
+            $table->string('nombre')->nullable();
+            $table->string('apellido1')->nullable();
+            $table->string('apellido2')->nullable();
+            $table->string('email')->nullable();
+            $table->string('sexo', 1)->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        $schema->create('alumnos_grupos', function (Blueprint $table): void {
+            $table->string('idAlumno', 8);
+            $table->string('idGrupo', 10);
+        });
+
+        $schema->create('alumno_resultados', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('idAlumno', 8);
+            $table->unsignedInteger('idModuloGrupo');
+            $table->unsignedTinyInteger('nota')->default(0);
+            $table->unsignedTinyInteger('valoraciones')->default(0);
+            $table->string('observaciones', 200)->nullable();
+        });
+
+        $schema->create('modul_optatiu_certificats', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idModuloGrupo')->unique();
+            $table->string('denominacio');
+            $table->string('idProfesor', 10);
+            $table->timestamps();
+        });
+
+        $schema->create('modul_optatiu_certificat_alumnes', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idCertificat');
+            $table->string('idAlumno', 8);
+            $table->timestamp('enviat_at')->nullable();
+            $table->timestamp('registrat_at')->nullable();
+            $table->string('fitxer')->nullable();
+            $table->timestamps();
+        });
+
+        DB::table('modulos')->insert([
+            'codigo' => 'OPT1',
+            'cliteral' => 'Optatiu',
+            'vliteral' => 'Mòdul optatiu',
+        ]);
+        DB::table('modulo_ciclos')->insert([
+            'id' => 1,
+            'idModulo' => 'OPT1',
+            'idCiclo' => 1,
+            'idDepartamento' => 1,
+            'curso' => 1,
+        ]);
+        DB::table('grupos')->insert([
+            'codigo' => 'G1',
+            'idCiclo' => 1,
+            'nombre' => 'Grup 1',
+            'turno' => 'M',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        DB::table('modulo_grupos')->insert([
+            'id' => 1,
+            'idModuloCiclo' => 1,
+            'idGrupo' => 'G1',
+        ]);
+        DB::table('alumnos')->insert([
+            [
+                'nia' => 'A1',
+                'dni' => '11111111A',
+                'nombre' => 'ALFA',
+                'apellido1' => 'U',
+                'apellido2' => 'UNO',
+                'email' => 'a1@example.test',
+                'sexo' => 'H',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'nia' => 'A2',
+                'dni' => '22222222B',
+                'nombre' => 'BETA',
+                'apellido1' => 'D',
+                'apellido2' => 'DOS',
+                'email' => 'a2@example.test',
+                'sexo' => 'M',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+        DB::table('alumnos_grupos')->insert([
+            ['idAlumno' => 'A1', 'idGrupo' => 'G1'],
+            ['idAlumno' => 'A2', 'idGrupo' => 'G1'],
+        ]);
+    }
+
+    public function test_guarda_les_notes_en_alumno_resultados(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 1,
+            'denominacio' => 'Optativa aplicada',
+            'idProfesor' => 'P1',
+        ]);
+
+        $saved = $service->save($certificat, 'Optativa actualitzada', [
+            'A1' => 8,
+            'A2' => 9,
+        ]);
+
+        $this->assertSame(2, $saved);
+        $this->assertDatabaseHas('alumno_resultados', [
+            'idAlumno' => 'A1',
+            'idModuloGrupo' => 1,
+            'nota' => 8,
+        ]);
+        $this->assertDatabaseHas('modul_optatiu_certificats', [
+            'id' => $certificat->id,
+            'denominacio' => 'Optativa actualitzada',
+        ]);
+    }
+
+    public function test_detecta_alumnat_sense_nota_abans_demetre(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 1,
+            'denominacio' => 'Optativa aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            'idAlumno' => 'A1',
+            'idModuloGrupo' => 1,
+            'nota' => 7,
+        ]);
+
+        $errors = $service->validationErrors($certificat);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('BETA', $errors[0]);
+    }
+
+    public function test_reutilitza_la_nota_existent_del_mateix_modul_grup(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 1,
+            'denominacio' => 'Optativa aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            'idAlumno' => 'A1',
+            'idModuloGrupo' => 1,
+            'nota' => 6,
+        ]);
+
+        $data = $service->panelData($certificat);
+
+        $this->assertSame(6, (int) $data['resultats']->get('A1')->nota);
+    }
+}

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -10,8 +10,12 @@ use Illuminate\Support\Facades\Schema;
 use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
 use Intranet\Entities\Modulo_grupo;
 use Intranet\Entities\ModulOptatiuCertificat;
+use Intranet\Services\School\ModuloGrupoService;
 use Tests\TestCase;
 
+/**
+ * Proves del cas d'ús de certificats de mòduls optatius.
+ */
 class ModuloOptatiuCertificatServiceTest extends TestCase
 {
     protected function setUp(): void
@@ -111,16 +115,32 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         });
 
         DB::table('modulos')->insert([
-            'codigo' => 'OPT1',
-            'cliteral' => 'Optatiu',
-            'vliteral' => 'Mòdul optatiu',
+            [
+                'codigo' => 'OPT1',
+                'cliteral' => 'Optatiu antic',
+                'vliteral' => 'Mòdul no optatiu',
+            ],
+            [
+                'codigo' => 'CVOPT',
+                'cliteral' => 'Optatiu',
+                'vliteral' => 'Mòdul optatiu',
+            ],
         ]);
         DB::table('modulo_ciclos')->insert([
-            'id' => 1,
-            'idModulo' => 'OPT1',
-            'idCiclo' => 1,
-            'idDepartamento' => 1,
-            'curso' => 1,
+            [
+                'id' => 1,
+                'idModulo' => 'OPT1',
+                'idCiclo' => 1,
+                'idDepartamento' => 1,
+                'curso' => 1,
+            ],
+            [
+                'id' => 2,
+                'idModulo' => 'CVOPT',
+                'idCiclo' => 1,
+                'idDepartamento' => 1,
+                'curso' => 1,
+            ],
         ]);
         DB::table('grupos')->insert([
             'codigo' => 'G1',
@@ -131,9 +151,16 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
             'updated_at' => now(),
         ]);
         DB::table('modulo_grupos')->insert([
-            'id' => 1,
-            'idModuloCiclo' => 1,
-            'idGrupo' => 'G1',
+            [
+                'id' => 1,
+                'idModuloCiclo' => 1,
+                'idGrupo' => 'G1',
+            ],
+            [
+                'id' => 2,
+                'idModuloCiclo' => 2,
+                'idGrupo' => 'G1',
+            ],
         ]);
         DB::table('alumnos')->insert([
             [
@@ -191,6 +218,31 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         ]);
     }
 
+    public function test_mostra_només_moduls_codificats_com_a_cvopt(): void
+    {
+        $moduloGrupoService = new class extends ModuloGrupoService {
+            /**
+             * Retorna mòduls de prova sense consultar l'horari real.
+             *
+             * @return array<int, Modulo_grupo>
+             */
+            public function misModulos(string $dni, ?string $modulo = null): array
+            {
+                return [
+                    Modulo_grupo::query()->findOrFail(1),
+                    Modulo_grupo::query()->findOrFail(2),
+                ];
+            }
+        };
+        $service = new ModuloOptatiuCertificatService($moduloGrupoService);
+
+        $modules = $service->modulesForTeacher('P1');
+
+        $this->assertSame([2], $modules->pluck('id')->all());
+        $this->assertTrue($service->canManage(Modulo_grupo::query()->findOrFail(2), 'P1'));
+        $this->assertFalse($service->canManage(Modulo_grupo::query()->findOrFail(1), 'P1'));
+    }
+
     public function test_detecta_alumnat_sense_nota_abans_demetre(): void
     {
         $service = new ModuloOptatiuCertificatService();
@@ -208,7 +260,7 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         $errors = $service->validationErrors($certificat);
 
         $this->assertCount(1, $errors);
-        $this->assertStringContainsString('BETA', $errors[0]);
+        $this->assertStringContainsString('Beta', $errors[0]);
     }
 
     public function test_reutilitza_la_nota_existent_del_mateix_modul_grup(): void

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -8,9 +8,14 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
+use Intranet\Application\Profesor\ProfesorService;
+use Intranet\Entities\Alumno;
 use Intranet\Entities\Modulo_grupo;
 use Intranet\Entities\ModulOptatiuCertificat;
+use Intranet\Entities\Profesor;
+use Intranet\Services\Document\PdfService;
 use Intranet\Services\School\ModuloGrupoService;
+use Intranet\Services\School\SecretariaService;
 use Tests\TestCase;
 
 /**
@@ -340,5 +345,139 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         $data = $service->panelData($certificat);
 
         $this->assertSame(6, (int) $data['resultats']->get('A1')->nota);
+    }
+
+    public function test_genera_un_pdf_individual_sense_registrar_ni_enviar(): void
+    {
+        $this->bindProfesorServiceSenseCarrecs();
+        $pdfService = new ModuloOptatiuPdfServiceFake();
+        $secretariaService = new ModuloOptatiuSecretariaServiceFake();
+        $service = new ModuloOptatiuCertificatService(null, $pdfService, $secretariaService);
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            'idAlumno' => 'A1',
+            'idModuloGrupo' => 2,
+            'nota' => 7,
+        ]);
+
+        $pdf = $service->pdf($certificat, Alumno::query()->findOrFail('A1'));
+
+        $this->assertSame($pdfService->pdf, $pdf);
+        $this->assertCount(1, $pdfService->calls);
+        $this->assertSame('pdf.modulOptatiu.certificat', $pdfService->calls[0]['informe']);
+        $this->assertSame('A1', $pdfService->calls[0]['todos']['alumne']->nia);
+        $this->assertSame(7, (int) $pdfService->calls[0]['todos']['resultat']->nota);
+        $this->assertSame(0, $secretariaService->uploads);
+        $this->assertDatabaseMissing('modul_optatiu_certificat_alumnes', [
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A1',
+        ]);
+    }
+
+    public function test_valida_un_alumne_abans_de_generar_el_pdf_individual(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            'idAlumno' => 'A1',
+            'idModuloGrupo' => 2,
+            'nota' => 7,
+        ]);
+
+        $errorsAmbNota = $service->validationErrorsForAlumno($certificat, Alumno::query()->findOrFail('A1'));
+        $errorsSenseNota = $service->validationErrorsForAlumno($certificat, Alumno::query()->findOrFail('A2'));
+
+        $this->assertSame([], $errorsAmbNota);
+        $this->assertCount(1, $errorsSenseNota);
+        $this->assertStringContainsString('Falta la nota de Beta', $errorsSenseNota[0]);
+    }
+
+    private function bindProfesorServiceSenseCarrecs(): void
+    {
+        $this->app->instance(ProfesorService::class, new class extends ProfesorService {
+            public function __construct()
+            {
+            }
+
+            public function find(string $dni): ?Profesor
+            {
+                return null;
+            }
+        });
+    }
+}
+
+/**
+ * Doble de PDF per comprovar la generació sense renderitzar documents reals.
+ */
+class ModuloOptatiuPdfServiceFake extends PdfService
+{
+    public array $calls = [];
+
+    public ModuloOptatiuGeneratedPdfFake $pdf;
+
+    public function __construct()
+    {
+        $this->pdf = new ModuloOptatiuGeneratedPdfFake();
+    }
+
+    public function hazPdf(
+        $informe,
+        $todos,
+        $datosInforme = null,
+        $orientacion = 'portrait',
+        $dimensiones = 'a4',
+        $marginTop = 15,
+        $driver = null
+    ) {
+        $this->calls[] = compact('informe', 'todos', 'datosInforme', 'orientacion', 'dimensiones', 'marginTop', 'driver');
+
+        return $this->pdf;
+    }
+}
+
+/**
+ * PDF generat de prova.
+ */
+class ModuloOptatiuGeneratedPdfFake
+{
+    public array $savedPaths = [];
+
+    public function save(string $path): void
+    {
+        file_put_contents($path, 'pdf');
+        $this->savedPaths[] = $path;
+    }
+
+    public function stream(): string
+    {
+        return 'pdf';
+    }
+}
+
+/**
+ * Doble de Secretaria per garantir que el PDF individual no puja fitxers.
+ */
+class ModuloOptatiuSecretariaServiceFake extends SecretariaService
+{
+    public int $uploads = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function uploadFile($document)
+    {
+        $this->uploads++;
+
+        return 1;
     }
 }

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -243,6 +243,15 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         $this->assertFalse($service->canManage(Modulo_grupo::query()->findOrFail(1), 'P1'));
     }
 
+    public function test_el_certificat_nou_no_usa_el_literal_generic_del_cvopt(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+
+        $certificat = $service->certificateFor(Modulo_grupo::query()->findOrFail(2), 'P1');
+
+        $this->assertSame('', $certificat->denominacio);
+    }
+
     public function test_detecta_alumnat_sense_nota_abans_demetre(): void
     {
         $service = new ModuloOptatiuCertificatService();
@@ -261,6 +270,57 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Beta', $errors[0]);
+    }
+
+    public function test_no_permet_emetre_amb_el_literal_generic_del_cvopt(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Mòdul optatiu',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 8,
+            ],
+        ]);
+
+        $errors = $service->validationErrors($certificat);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('denominació real', $errors[0]);
+    }
+
+    public function test_permet_emetre_amb_denominacio_real_i_notes_completes(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 8,
+            ],
+        ]);
+
+        $this->assertSame([], $service->validationErrors($certificat));
     }
 
     public function test_reutilitza_la_nota_existent_del_mateix_modul_grup(): void


### PR DESCRIPTION
## Resum
- Afig la descàrrega individual del certificat de mòdul optatiu sense registre en Secretaria ni enviament de correu.
- Reutilitza la mateixa generació PDF que l'emissió massiva, amb la capçalera i la signatura institucional del certificat.
- Manté l'emissió massiva amb pujada a Secretaria i correu electrònic.

## Validació
- docker compose exec -T laravel.test php artisan test --filter=ModuloOptatiuCertificatServiceTest
- docker compose exec -T laravel.test php artisan route:cache
- docker compose exec -T laravel.test php artisan route:clear

Closes #250