### PR TITLE
[MOD] Ajusta emissio de certificats optatius #250

### DIFF
--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -23,6 +23,8 @@ class ModuloOptatiuCertificatService
     public const DOCUMENT_TYPE = 16;
 
     private const OPTIONAL_MODULE_CODE = 'CVOPT';
+    private const NO_CURSA_NOTES = [12, 13];
+    private const NO_SUPERA_NOTE = 4;
 
     public function __construct(
         private ?ModuloGrupoService $moduloGrupoService = null,
@@ -80,7 +82,7 @@ class ModuloOptatiuCertificatService
     /**
      * Dades del panell: alumnat, notes existents i estat d'emissió.
      *
-     * @return array{alumnes:Collection<int, Alumno>, resultats:Collection<string, AlumnoResultado>, estats:Collection<string, ModulOptatiuCertificatAlumne>, pdfDisponibles:Collection<string, bool>}
+     * @return array{alumnes:Collection<int, Alumno>, resultats:Collection<string, AlumnoResultado>, estats:Collection<string, ModulOptatiuCertificatAlumne>, pdfDisponibles:Collection<string, bool>, potEmetre:bool}
      */
     public function panelData(ModulOptatiuCertificat $certificat): array
     {
@@ -101,11 +103,31 @@ class ModuloOptatiuCertificatService
         $denominacioValida = $this->hasRealDenomination($certificat);
         $pdfDisponibles = $alumnes->mapWithKeys(
             static fn (Alumno $alumne): array => [
-                $alumne->nia => $denominacioValida && (int) ($resultats->get($alumne->nia)?->nota ?? 0) > 0,
+                $alumne->nia => $denominacioValida
+                    && self::isCertifiableNote((int) ($resultats->get($alumne->nia)?->nota ?? 0)),
             ]
         );
+        $totesLesNotesGuardades = $alumnes->every(
+            static fn (Alumno $alumne): bool => (int) ($resultats->get($alumne->nia)?->nota ?? 0) > 0
+        );
+        $potEmetre = $denominacioValida && $totesLesNotesGuardades && $pdfDisponibles->contains(true);
 
-        return compact('alumnes', 'resultats', 'estats', 'pdfDisponibles');
+        return compact('alumnes', 'resultats', 'estats', 'pdfDisponibles', 'potEmetre');
+    }
+
+    /**
+     * Opcions de qualificació pròpies del certificat optatiu.
+     *
+     * @return array<int, string>
+     */
+    public function noteOptions(): array
+    {
+        $notes = config('auxiliares.notas');
+        unset($notes[1], $notes[2], $notes[3]);
+        $notes[self::NO_SUPERA_NOTE] = 'No supera';
+        ksort($notes);
+
+        return $notes;
     }
 
     /**
@@ -122,8 +144,11 @@ class ModuloOptatiuCertificatService
         $saved = 0;
         foreach ($notes as $idAlumno => $nota) {
             $nota = (int) $nota;
-            if ($nota < 0 || $nota > 13) {
+            if ($nota < 0 || $nota > 12) {
                 continue;
+            }
+            if ($nota > 0 && $nota < 5) {
+                $nota = self::NO_SUPERA_NOTE;
             }
 
             AlumnoResultado::query()->updateOrCreate(
@@ -175,8 +200,13 @@ class ModuloOptatiuCertificatService
         }
 
         $resultat = $this->resultForAlumno($certificat, $alumne);
-        if (!$resultat || (int) $resultat->nota <= 0) {
+        $nota = (int) ($resultat?->nota ?? 0);
+        if ($nota <= 0) {
             $errors[] = "Falta la nota de {$alumne->fullName}.";
+        } elseif ($nota < 5) {
+            $errors[] = "{$alumne->fullName} figura com a No supera.";
+        } elseif (!self::isCertifiableNote($nota)) {
+            $errors[] = "{$alumne->fullName} figura com a No cursa.";
         }
 
         return $errors;
@@ -233,6 +263,10 @@ class ModuloOptatiuCertificatService
 
         foreach ($data['alumnes'] as $alumne) {
             $resultado = $data['resultats']->get($alumne->nia);
+            if (!self::isCertifiableNote((int) ($resultado?->nota ?? 0))) {
+                continue;
+            }
+
             try {
                 $route = $this->pdfRoute($certificat, $alumne);
                 $path = storage_path($route);
@@ -311,6 +345,14 @@ class ModuloOptatiuCertificatService
             ->where('idModuloGrupo', $certificat->idModuloGrupo)
             ->where('idAlumno', $alumne->nia)
             ->first();
+    }
+
+    /**
+     * Indica si la qualificació genera certificat.
+     */
+    private static function isCertifiableNote(int $nota): bool
+    {
+        return $nota >= 5 && !in_array($nota, self::NO_CURSA_NOTES, true);
     }
 
     private function modulos(): ModuloGrupoService

--- a/app/Http/Controllers/ModuloOptatiuCertificatController.php
+++ b/app/Http/Controllers/ModuloOptatiuCertificatController.php
@@ -48,7 +48,8 @@ class ModuloOptatiuCertificatController extends Controller
             'resultats' => $data['resultats'],
             'estats' => $data['estats'],
             'pdfDisponibles' => $data['pdfDisponibles'],
-            'notes' => config('auxiliares.notas'),
+            'potEmetre' => $data['potEmetre'],
+            'notes' => $this->certificats()->noteOptions(),
         ]);
     }
 
@@ -66,7 +67,7 @@ class ModuloOptatiuCertificatController extends Controller
         $validated = $request->validate([
             'denominacio' => 'required|string|max:200',
             'notes' => 'nullable|array',
-            'notes.*' => 'nullable|integer|min:0|max:13',
+            'notes.*' => 'nullable|integer|min:0|max:12',
         ]);
 
         $saved = $this->certificats()->save(

--- a/config/auxiliares.php
+++ b/config/auxiliares.php
@@ -117,8 +117,7 @@ return [
         9=>'9',
         10=>'10',
         11=>'MH',
-        12=>'Convalida',
-        13=>'Aprovada amb anterioritat'
+        12=>'No cursa'
     ],
     'valoraciones' => [
         0=>'Ha seguit de manera satisfactòria el procés de formació online,

--- a/resources/views/modul_optatiu_certificat/show.blade.php
+++ b/resources/views/modul_optatiu_certificat/show.blade.php
@@ -39,13 +39,15 @@
                     $resultat = $resultats->get($alumne->nia);
                     $estat = $estats->get($alumne->nia);
                     $pdfDisponible = (bool) ($pdfDisponibles->get($alumne->nia) ?? false);
+                    $notaActual = (int) old("notes.{$alumne->nia}", $resultat->nota ?? 0);
+                    $notaActual = $notaActual > 0 && $notaActual < 5 ? 4 : $notaActual;
                 @endphp
                 <tr>
                     <td>{{ $alumne->fullName }}</td>
                     <td>
                         <select name="notes[{{ $alumne->nia }}]" class="form-control">
                             @foreach ($notes as $key => $label)
-                                <option value="{{ $key }}" @selected((string) old("notes.{$alumne->nia}", $resultat->nota ?? 0) === (string) $key)>
+                                <option value="{{ $key }}" @selected($notaActual === (int) $key)>
                                     {{ $label }}
                                 </option>
                             @endforeach
@@ -81,8 +83,14 @@
         <button type="submit" class="btn btn-primary">Guardar notes</button>
     </form>
 
-    <form method="post" action="{{ route('modulOptatiuCertificat.emit', ['certificat' => $certificat->id]) }}" class="mt-3">
-        @csrf
-        <button type="submit" class="btn btn-success">Emetre certificats PDF</button>
-    </form>
+    @if ($potEmetre)
+        <form method="post" action="{{ route('modulOptatiuCertificat.emit', ['certificat' => $certificat->id]) }}" class="mt-3">
+            @csrf
+            <button type="submit" class="btn btn-success">Emetre certificats PDF</button>
+        </form>
+    @else
+        <div class="alert alert-danger mt-3" role="alert">
+            S'ha d'avaluar tot l'alumnat i guardar les notes per poder emetre els certificats.
+        </div>
+    @endif
 @endsection

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Application\ModuloOptatiu;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
@@ -13,6 +14,7 @@ use Intranet\Entities\Alumno;
 use Intranet\Entities\Modulo_grupo;
 use Intranet\Entities\ModulOptatiuCertificat;
 use Intranet\Entities\Profesor;
+use Intranet\Jobs\SendEmail;
 use Intranet\Services\Document\PdfService;
 use Intranet\Services\School\ModuloGrupoService;
 use Intranet\Services\School\SecretariaService;
@@ -223,6 +225,23 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         ]);
     }
 
+    public function test_el_selector_de_notes_te_una_sola_opcio_no_cursa(): void
+    {
+        $notes = collect((new ModuloOptatiuCertificatService())->noteOptions());
+
+        $this->assertSame([12], $notes->filter(fn (string $nota): bool => $nota === 'No cursa')->keys()->all());
+    }
+
+    public function test_el_selector_de_notes_te_una_sola_opcio_no_supera(): void
+    {
+        $notes = (new ModuloOptatiuCertificatService())->noteOptions();
+
+        $this->assertArrayNotHasKey(1, $notes);
+        $this->assertArrayNotHasKey(2, $notes);
+        $this->assertArrayNotHasKey(3, $notes);
+        $this->assertSame('No supera', $notes[4]);
+    }
+
     public function test_mostra_només_moduls_codificats_com_a_cvopt(): void
     {
         $moduloGrupoService = new class extends ModuloGrupoService {
@@ -365,6 +384,100 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
 
         $this->assertTrue($data['pdfDisponibles']->get('A1'));
         $this->assertFalse($data['pdfDisponibles']->get('A2'));
+        $this->assertFalse($data['potEmetre']);
+    }
+
+    public function test_no_cursa_no_bloqueja_el_grup_pero_no_te_pdf_individual(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 12,
+            ],
+        ]);
+
+        $data = $service->panelData($certificat);
+
+        $this->assertSame([], $service->validationErrors($certificat));
+        $this->assertTrue($data['pdfDisponibles']->get('A1'));
+        $this->assertFalse($data['pdfDisponibles']->get('A2'));
+        $this->assertTrue($data['potEmetre']);
+        $this->assertSame(
+            ['Beta D Dos figura com a No cursa.'],
+            $service->validationErrorsForAlumno($certificat, Alumno::query()->findOrFail('A2'))
+        );
+    }
+
+    public function test_no_supera_no_bloqueja_el_grup_pero_no_te_pdf_individual(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 4,
+            ],
+        ]);
+
+        $data = $service->panelData($certificat);
+
+        $this->assertSame([], $service->validationErrors($certificat));
+        $this->assertTrue($data['pdfDisponibles']->get('A1'));
+        $this->assertFalse($data['pdfDisponibles']->get('A2'));
+        $this->assertTrue($data['potEmetre']);
+        $this->assertSame(
+            ['Beta D Dos figura com a No supera.'],
+            $service->validationErrorsForAlumno($certificat, Alumno::query()->findOrFail('A2'))
+        );
+    }
+
+    public function test_no_mostra_emissio_si_tot_lalumnat_no_cursa(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 12,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 12,
+            ],
+        ]);
+
+        $data = $service->panelData($certificat);
+
+        $this->assertFalse($data['pdfDisponibles']->contains(true));
+        $this->assertFalse($data['potEmetre']);
     }
 
     public function test_no_permet_descarregar_certificats_individuals_sense_denominacio_real(): void
@@ -417,6 +530,86 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         ]);
     }
 
+    public function test_emissio_de_grup_salta_alumnat_que_no_cursa(): void
+    {
+        Bus::fake();
+        $this->bindProfesorServiceAmbSecretari();
+        $pdfService = new ModuloOptatiuPdfServiceFake();
+        $secretariaService = new ModuloOptatiuSecretariaServiceFake();
+        $service = new ModuloOptatiuCertificatService(null, $pdfService, $secretariaService);
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 12,
+            ],
+        ]);
+
+        $result = $service->emit($certificat);
+
+        $this->assertSame(['sent' => 1, 'errors' => []], $result);
+        $this->assertSame(1, $secretariaService->uploads);
+        $this->assertCount(1, $pdfService->calls);
+        $this->assertSame('A1', $pdfService->calls[0]['todos']['alumne']->nia);
+        $this->assertDatabaseHas('modul_optatiu_certificat_alumnes', [
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A1',
+        ]);
+        $this->assertDatabaseMissing('modul_optatiu_certificat_alumnes', [
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A2',
+        ]);
+        Bus::assertDispatchedTimes(SendEmail::class, 1);
+    }
+
+    public function test_emissio_de_grup_salta_alumnat_que_no_supera(): void
+    {
+        Bus::fake();
+        $this->bindProfesorServiceAmbSecretari();
+        $pdfService = new ModuloOptatiuPdfServiceFake();
+        $secretariaService = new ModuloOptatiuSecretariaServiceFake();
+        $service = new ModuloOptatiuCertificatService(null, $pdfService, $secretariaService);
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 4,
+            ],
+        ]);
+
+        $result = $service->emit($certificat);
+
+        $this->assertSame(['sent' => 1, 'errors' => []], $result);
+        $this->assertSame(1, $secretariaService->uploads);
+        $this->assertCount(1, $pdfService->calls);
+        $this->assertSame('A1', $pdfService->calls[0]['todos']['alumne']->nia);
+        $this->assertDatabaseMissing('modul_optatiu_certificat_alumnes', [
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A2',
+        ]);
+        Bus::assertDispatchedTimes(SendEmail::class, 1);
+    }
+
     public function test_valida_un_alumne_abans_de_generar_el_pdf_individual(): void
     {
         $service = new ModuloOptatiuCertificatService();
@@ -449,6 +642,27 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
             public function find(string $dni): ?Profesor
             {
                 return null;
+            }
+        });
+    }
+
+    private function bindProfesorServiceAmbSecretari(): void
+    {
+        $secretari = new Profesor();
+        $secretari->dni = 'S1';
+        $secretari->nombre = 'SECRETARI';
+        $secretari->apellido1 = 'BATOI';
+        $secretari->apellido2 = '';
+        $secretari->email = 'secretaria@example.test';
+
+        $this->app->instance(ProfesorService::class, new class ($secretari) extends ProfesorService {
+            public function __construct(private Profesor $secretari)
+            {
+            }
+
+            public function find(string $dni): ?Profesor
+            {
+                return $this->secretari;
             }
         });
     }


### PR DESCRIPTION
## Resum
- Redueix el selector a una sola opció No cursa i una sola opció No supera per al certificat optatiu.
- No genera certificats per a No cursa ni No supera, però permet emetre el grup si totes les notes estan guardades.
- Mostra el botó d'emissió només quan el grup està preparat i un avís roig quan falta guardar notes.

## Validació
- docker compose exec -T laravel.test php artisan test --filter=ModuloOptatiuCertificatServiceTest

Refs #250