### PR TITLE
[codex] Estat certificats optatius en fi de curs

### DIFF
--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -116,6 +116,52 @@ class ModuloOptatiuCertificatService
     }
 
     /**
+     * Resumeix l'estat d'emissió dels certificats possibles d'un mòdul-grup.
+     *
+     * @return array{certificables:int,emesos:int,pendents:int,complet:bool}
+     */
+    public function emissionSummary(Modulo_grupo $moduloGrupo): array
+    {
+        $moduloGrupo->loadMissing('Grupo.Alumnos');
+        $alumnes = $moduloGrupo->Grupo?->Alumnos ?? collect();
+        $alumneIds = $alumnes->pluck('nia')->all();
+
+        $certificables = AlumnoResultado::query()
+            ->where('idModuloGrupo', $moduloGrupo->id)
+            ->whereIn('idAlumno', $alumneIds)
+            ->get()
+            ->filter(static fn (AlumnoResultado $resultat): bool => self::isCertifiableNote((int) $resultat->nota))
+            ->pluck('idAlumno')
+            ->unique()
+            ->values();
+
+        $totalCertificables = $certificables->count();
+        $certificat = ModulOptatiuCertificat::query()
+            ->where('idModuloGrupo', $moduloGrupo->id)
+            ->first();
+
+        $emesos = 0;
+        if ($certificat && $totalCertificables > 0) {
+            $emesos = ModulOptatiuCertificatAlumne::query()
+                ->where('idCertificat', $certificat->id)
+                ->whereIn('idAlumno', $certificables->all())
+                ->whereNotNull('enviat_at')
+                ->pluck('idAlumno')
+                ->unique()
+                ->count();
+        }
+
+        $pendents = max(0, $totalCertificables - $emesos);
+
+        return [
+            'certificables' => $totalCertificables,
+            'emesos' => $emesos,
+            'pendents' => $pendents,
+            'complet' => $pendents === 0,
+        ];
+    }
+
+    /**
      * Opcions de qualificació pròpies del certificat optatiu.
      *
      * @return array<int, string>

--- a/app/Http/Controllers/PanelFinCursoController.php
+++ b/app/Http/Controllers/PanelFinCursoController.php
@@ -4,6 +4,7 @@ namespace Intranet\Http\Controllers;
 
 use Intranet\Application\Comision\ComisionService;
 use Intranet\Application\Grupo\GrupoService;
+use Intranet\Application\ModuloOptatiu\ModuloOptatiuCertificatService;
 use Intranet\Application\Profesor\ProfesorService;
 use Intranet\Http\Controllers\Core\BaseController;
 use Intranet\Entities\Documento;
@@ -21,8 +22,7 @@ use function PHPUnit\Framework\isNull;
 
 
 /**
- * Class PanelActaController
- * @package Intranet\Http\Controllers
+ * Panell d'avisos de final de curs per rols del professorat.
  */
 class PanelFinCursoController extends BaseController
 {
@@ -62,6 +62,7 @@ class PanelFinCursoController extends BaseController
 
         self::lookForMyResults($avisos);
         self::lookforMyPrograms($avisos);
+        self::lookForOptionalModuleCertificates($avisos);
         self::lookUnPaidBills($avisos);
 
         if (AuthUser()->xdepartamento == 'Fol' ){
@@ -115,6 +116,29 @@ class PanelFinCursoController extends BaseController
             if ($grupo->fol == 0) {
                 $avisos[self::DANGER][] = "FOL Grupo no revisado : ".$grupo->nombre;
             }
+        }
+    }
+
+    /**
+     * Afig l'estat d'emissió dels certificats de mòduls optatius del professor.
+     */
+    private static function lookForOptionalModuleCertificates(&$avisos): void
+    {
+        $service = app(ModuloOptatiuCertificatService::class);
+
+        foreach ($service->modulesForTeacher((string) AuthUser()->dni) as $modulo) {
+            $summary = $service->emissionSummary($modulo);
+            $literal = $modulo->literal;
+
+            if ($summary['complet']) {
+                $avisos[self::SUCCESS][] = $summary['certificables'] > 0
+                    ? "Certificats del mòdul optatiu {$literal} emesos ({$summary['emesos']}/{$summary['certificables']})"
+                    : "Mòdul optatiu {$literal} sense certificats pendents d'emetre";
+                continue;
+            }
+
+            $avisos[self::DANGER][] = "Falten {$summary['pendents']} certificats del mòdul optatiu {$literal} "
+                . "({$summary['emesos']}/{$summary['certificables']} emesos)";
         }
     }
 

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -480,6 +480,86 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         $this->assertFalse($data['potEmetre']);
     }
 
+    public function test_resume_emissio_detecta_certificats_pendents_amb_nota_certificable(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 8,
+            ],
+        ]);
+        DB::table('modul_optatiu_certificat_alumnes')->insert([
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A1',
+            'enviat_at' => now(),
+            'registrat_at' => now(),
+            'fitxer' => 'tmp/a1.pdf',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $summary = $service->emissionSummary(Modulo_grupo::query()->findOrFail(2));
+
+        $this->assertSame([
+            'certificables' => 2,
+            'emesos' => 1,
+            'pendents' => 1,
+            'complet' => false,
+        ], $summary);
+    }
+
+    public function test_resume_emissio_es_complet_quan_tots_els_certificables_estan_emesos(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        $certificat = ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 7,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 4,
+            ],
+        ]);
+        DB::table('modul_optatiu_certificat_alumnes')->insert([
+            'idCertificat' => $certificat->id,
+            'idAlumno' => 'A1',
+            'enviat_at' => now(),
+            'registrat_at' => now(),
+            'fitxer' => 'tmp/a1.pdf',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $summary = $service->emissionSummary(Modulo_grupo::query()->findOrFail(2));
+
+        $this->assertSame([
+            'certificables' => 1,
+            'emesos' => 1,
+            'pendents' => 0,
+            'complet' => true,
+        ], $summary);
+    }
+
     public function test_no_permet_descarregar_certificats_individuals_sense_denominacio_real(): void
     {
         $service = new ModuloOptatiuCertificatService();


### PR DESCRIPTION
## Resum

Afig a `/fiCurs` l'estat d'emissió dels certificats de mòduls optatius del professorat.

- Blau quan tots els certificats possibles del grup estan emesos.
- Roig quan queda algun alumne amb nota certificable (`>= 5`) sense certificat emés.
- Roig també quan el mòdul encara no té cap alumne certificable; no es considera complet per tindre `0/0`.
- Centralitza el càlcul en `ModuloOptatiuCertificatService::emissionSummary()`.

## Impacte

El professorat amb mòduls optatius veu en el llistat de final de curs si pot donar per tancada l'emissió dels certificats o si encara en falta algun. El text dels avisos és homogeni: `Certificats del mòdul optatiu ... emesos/pendents (x/y emesos)`.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=ModuloOptatiuCertificatServiceTest`
- Resultat: 21 tests passats, 60 assertions.

Fixes #250