### PR TITLE
[codex] Corregeix estat pendent dels optatius sense certificables

### DIFF
--- a/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
+++ b/app/Application/ModuloOptatiu/ModuloOptatiuCertificatService.php
@@ -157,7 +157,7 @@ class ModuloOptatiuCertificatService
             'certificables' => $totalCertificables,
             'emesos' => $emesos,
             'pendents' => $pendents,
-            'complet' => $pendents === 0,
+            'complet' => $totalCertificables > 0 && $pendents === 0,
         ];
     }
 

--- a/app/Http/Controllers/PanelFinCursoController.php
+++ b/app/Http/Controllers/PanelFinCursoController.php
@@ -131,13 +131,12 @@ class PanelFinCursoController extends BaseController
             $literal = $modulo->literal;
 
             if ($summary['complet']) {
-                $avisos[self::SUCCESS][] = $summary['certificables'] > 0
-                    ? "Certificats del mòdul optatiu {$literal} emesos ({$summary['emesos']}/{$summary['certificables']})"
-                    : "Mòdul optatiu {$literal} sense certificats pendents d'emetre";
+                $avisos[self::SUCCESS][] = "Certificats del mòdul optatiu {$literal} emesos "
+                    . "({$summary['emesos']}/{$summary['certificables']} emesos)";
                 continue;
             }
 
-            $avisos[self::DANGER][] = "Falten {$summary['pendents']} certificats del mòdul optatiu {$literal} "
+            $avisos[self::DANGER][] = "Certificats del mòdul optatiu {$literal} pendents "
                 . "({$summary['emesos']}/{$summary['certificables']} emesos)";
         }
     }

--- a/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
+++ b/tests/Unit/Application/ModuloOptatiu/ModuloOptatiuCertificatServiceTest.php
@@ -520,6 +520,37 @@ class ModuloOptatiuCertificatServiceTest extends TestCase
         ], $summary);
     }
 
+    public function test_resume_emissio_no_es_complet_si_no_hi_ha_alumnat_certificable(): void
+    {
+        $service = new ModuloOptatiuCertificatService();
+        ModulOptatiuCertificat::query()->create([
+            'idModuloGrupo' => 2,
+            'denominacio' => 'Robòtica aplicada',
+            'idProfesor' => 'P1',
+        ]);
+        DB::table('alumno_resultados')->insert([
+            [
+                'idAlumno' => 'A1',
+                'idModuloGrupo' => 2,
+                'nota' => 12,
+            ],
+            [
+                'idAlumno' => 'A2',
+                'idModuloGrupo' => 2,
+                'nota' => 4,
+            ],
+        ]);
+
+        $summary = $service->emissionSummary(Modulo_grupo::query()->findOrFail(2));
+
+        $this->assertSame([
+            'certificables' => 0,
+            'emesos' => 0,
+            'pendents' => 0,
+            'complet' => false,
+        ], $summary);
+    }
+
     public function test_resume_emissio_es_complet_quan_tots_els_certificables_estan_emesos(): void
     {
         $service = new ModuloOptatiuCertificatService();


### PR DESCRIPTION
## Resum

Corregeix l'estat de `/fiCurs` per als mòduls optatius que encara no tenen cap alumne certificable.

- Un mòdul amb `0/0` certificats emesos ja no es considera complet.
- L'avís ix en roig com a pendent.
- El text queda homogeni: `Certificats del mòdul optatiu ... emesos/pendents (x/y emesos)`.

## Validació

- `docker compose exec -T laravel.test php artisan test --filter=ModuloOptatiuCertificatServiceTest`
- Resultat: 21 tests passats, 60 assertions.

Refs #250