### PR TITLE
[FIX] Usa el curs actual en documents de matrícula

### DIFF
--- a/app/Services/School/SecretariaService.php
+++ b/app/Services/School/SecretariaService.php
@@ -22,12 +22,17 @@ class SecretariaService
     }
 
 
+    /**
+     * Puja un document a l'expedient de matrícula del curs acadèmic actual.
+     *
+     * @param array{title:int|string,dni:string,alumne:string,route:string,name:string,size?:int} $document
+     * @return int
+     */
     public function uploadFile($document)
     {
         try {
-            $curso = substr(curso(), 0, 4);
-            $link = $this->link."application/2024-2025/student/".$document['dni']."/document/".$document['title'];
-            //$link = $this->link."application/".$curso."/student/".$document['dni']."/document/".$document['title'];
+            $curso = curso();
+            $link = $this->link."application/".$curso."/student/".$document['dni']."/document/".$document['title'];
             $route = storage_path($document['route']);
 
             $response = Http::withToken($this->token)

--- a/tests/Unit/Entities/ReunionTest.php
+++ b/tests/Unit/Entities/ReunionTest.php
@@ -65,8 +65,7 @@ class ReunionTest extends TestCase
 
     public function test_mostra_notes_fe_retorna_true_per_avaluacio_final_de_primer_semipresencial(): void
     {
-        Reunion::query()->create([
-            'id' => 2,
+        $reunion = Reunion::query()->create([
             'idProfesor' => 'P100',
             'tipo' => 7,
             'numero' => 34,
@@ -80,15 +79,12 @@ class ReunionTest extends TestCase
         $grupoService->method('largestByTutor')->with('P100')->willReturn($grupo);
         app()->instance(GrupoService::class, $grupoService);
 
-        $reunion = Reunion::query()->findOrFail(2);
-
         $this->assertTrue($reunion->mostra_notes_fe);
     }
 
     public function test_mostra_notes_fe_retorna_false_per_avaluacio_final_de_primer_no_semipresencial(): void
     {
-        Reunion::query()->create([
-            'id' => 3,
+        $reunion = Reunion::query()->create([
             'idProfesor' => 'P200',
             'tipo' => 7,
             'numero' => 34,
@@ -101,8 +97,6 @@ class ReunionTest extends TestCase
         $grupoService = $this->createMock(GrupoService::class);
         $grupoService->method('largestByTutor')->with('P200')->willReturn($grupo);
         app()->instance(GrupoService::class, $grupoService);
-
-        $reunion = Reunion::query()->findOrFail(3);
 
         $this->assertFalse($reunion->mostra_notes_fe);
     }


### PR DESCRIPTION
## Què canvia

- El client de secretaria deixa d'enviar documents al curs fix `2024-2025`.
- La URL de pujada al servidor de matrícules usa `curso()` complet, per exemple `2025-2026` en el curs actual.
- S'afig PHPDoc al mètode `uploadFile()`.
- Es corregeix `ReunionTest` perquè no depenga d'ids forçats que Eloquent descarta per `$fillable`.

## Per què

La pujada de certificats de mòdul optatiu fallava per a alumnat que no tenia aplicació en matrícula en `2024-2025`, encara que el document pertanyia al curs acadèmic actual. La causa era una URL hardcoded en `SecretariaService`.

En integrar `main`, els tests nous de `Reunion` fallaven perquè el test intentava crear models amb ids explícits (`2` i `3`) i després buscar-los amb `findOrFail()`. Com `id` no és assignable en massa, SQLite assignava un altre id.

## Impacte

A partir d'ara, qualsevol document pujat per `SecretariaService` s'associa al curs acadèmic calculat per la intranet i canviarà automàticament cada any.

## Validació

- `git diff --check`
- `docker compose exec -T laravel.test php artisan test --filter=ReunionTest`