### PR TITLE
[FIX] Evita certificat FCT a alumnat

### DIFF
--- a/app/Console/Commands/SendFctEmails.php
+++ b/app/Console/Commands/SendFctEmails.php
@@ -5,15 +5,13 @@ namespace Intranet\Console\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
-use Intranet\Entities\AlumnoFct;
-use Intranet\Mail\CertificatAlumneFct;
 use Intranet\Mail\CertificatInstructorFct;
 use Illuminate\Support\Facades\Mail;
 use Intranet\Mail\AvalFct;
 use Intranet\Entities\Fct;
 
 /**
- * Envia correus diaris de FCT a alumnat i instructors.
+ * Envia correus diaris de certificació de FCT a instructors.
  */
 class SendFctEmails extends Command
 {
@@ -40,41 +38,6 @@ class SendFctEmails extends Command
      */
     public function handle()
     {
-        $alumnosPendientes = AlumnoFct::pendienteNotificar()->get();
-
-        foreach ($alumnosPendientes as $alumno) {
-            $fct = $alumno->Fct;
-
-            try {
-                Mail::to($alumno->Alumno->email, $alumno->Alumno->fullName)
-                    ->cc($alumno->Tutor->email)
-                    ->send(new CertificatAlumneFct($alumno));
-                avisa($alumno->Tutor->dni,
-                    'El correu amb el certificat de FCT de ' . $alumno->Alumno->fullName . " ha estat enviat a l'adreça " . $alumno->Alumno->email,
-                    '#', 'Servidor de correu');
-                $alumno->correoAlumno = 1;
-                $alumno->save();
-            } catch (Exception  $e) {
-                $mensaje = "Error : Enviant certificats a l'alumne:  ".$e->getMessage().".".
-                    $alumno->Alumno->fullName.' al email '.
-                    $alumno->Alumno->email;
-                avisa(config('avisos.errores'), $mensaje, '#', 'Servidor de correu');
-                if ($alumno->Tutor != null) {
-                    avisa($alumno->Tutor->dni, $mensaje, '#', 'Servidor de correu');
-                }
-                report($e);
-                Log::error('Error enviant certificat a l\'alumne', [
-                    'alumno_id' => $alumno->idAlumno,
-                    'dni' => $alumno->Alumno->dni,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-
-            if ($this->shouldSendInstructorCertificate($fct)) {
-                $this->correuInstructor($fct);
-            }
-        }
-
         $fcts = Fct::where('correoInstructor', 0)->get();
         foreach ($fcts as $fct) {
             if ($this->shouldSendInstructorCertificate($fct)) {
@@ -96,12 +59,12 @@ class SendFctEmails extends Command
             return false;
         }
 
-        $alumnos = $fct->AlFct()->get(['calificacion', 'correoAlumno']);
+        $alumnos = $fct->AlFct()->get(['calificacion']);
         if ($alumnos->isEmpty()) {
             return false;
         }
 
-        $hasNotifiedApprovedStudent = false;
+        $hasApprovedStudent = false;
 
         foreach ($alumnos as $alumno) {
             if ($alumno->calificacion === null) {
@@ -109,15 +72,11 @@ class SendFctEmails extends Command
             }
 
             if ((int) $alumno->calificacion === 1) {
-                if ((int) $alumno->correoAlumno !== 1) {
-                    return false;
-                }
-
-                $hasNotifiedApprovedStudent = true;
+                $hasApprovedStudent = true;
             }
         }
 
-        return $hasNotifiedApprovedStudent;
+        return $hasApprovedStudent;
     }
 
     /**

--- a/app/Http/Controllers/AdministracionController.php
+++ b/app/Http/Controllers/AdministracionController.php
@@ -411,20 +411,4 @@ class AdministracionController extends Controller
         $doors = Espacio::whereNotNull('dispositivo')->get();
         return view('espai.show', compact('missatge', 'doors'));
     }
-
-    /*public function consulta()
-    {
-        $alumnosPendientes = app(AlumnoFctService::class)->all()->filter(fn ($fct) => $fct->erasmus);
-
-            foreach ($alumnosPendientes as $alumno) {
-                try {
-                    Mail::to($alumno->Alumno->email)->send(new CertificatAlumneFct($alumno));
-                    $alumno->correoAlumno = 1;
-                    $alumno->save();
-                } catch (Exception $e) {
-                    Alert::info($e->getMessage());
-                }
-            }
-    }
-    */
 }

--- a/routes/administrador.php
+++ b/routes/administrador.php
@@ -91,7 +91,7 @@ Route::get('/actualizaLang', ['as' => 'actualizaLang','uses'=>'AdministracionCon
 Route::get('/secure', ['as' => 'show.door','uses' => 'AdministracionController@showDoor']);
 Route::post('/secure', ['as' => 'secure.door','uses' => 'AdministracionController@secure']);
 
-Route::get('/consulta', 'AdministracionController@consulta');
+// Route::get('/consulta', 'AdministracionController@consulta');
 Route::post('centro/{id}/empresa/create', 'CentroController@empresaCreateCentro');
 
 Route::resource('/ipguardia', 'IpGuardiaController', ['except' => ['destroy', 'update', 'edit', 'show']]);

--- a/tests/Unit/Console/Commands/SendFctEmailsTest.php
+++ b/tests/Unit/Console/Commands/SendFctEmailsTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
+use Intranet\Mail\AvalFct;
+use Intranet\Mail\CertificatAlumneFct;
+use Intranet\Mail\CertificatInstructorFct;
+use Tests\TestCase;
+
+/**
+ * Proves del comandament diari d'enviament de certificats FCT.
+ */
+class SendFctEmailsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createSchema();
+    }
+
+    public function test_no_envia_certificat_a_alumnat_i_envia_certificat_a_instructor(): void
+    {
+        Event::fake();
+        Mail::fake();
+        Notification::fake();
+        $this->seedFct([
+            ['id' => 100, 'idAlumno' => 'A1', 'calificacion' => 1, 'correoAlumno' => 0],
+        ]);
+
+        $result = Artisan::call('fct:Daily');
+
+        $this->assertSame(0, $result);
+        Mail::assertNotSent(CertificatAlumneFct::class);
+        Mail::assertSent(AvalFct::class, 1);
+        Mail::assertSent(CertificatInstructorFct::class, 1);
+        $this->assertSame(0, (int) DB::table('alumno_fcts')->where('id', 100)->value('correoAlumno'));
+        $this->assertSame(1, (int) DB::table('fcts')->where('id', 10)->value('correoInstructor'));
+    }
+
+    public function test_no_envia_certificat_a_instructor_si_queda_alumnat_sense_qualificar(): void
+    {
+        Event::fake();
+        Mail::fake();
+        Notification::fake();
+        $this->seedFct([
+            ['id' => 100, 'idAlumno' => 'A1', 'calificacion' => 1, 'correoAlumno' => 0],
+            ['id' => 101, 'idAlumno' => 'A2', 'calificacion' => null, 'correoAlumno' => 0],
+        ]);
+
+        $result = Artisan::call('fct:Daily');
+
+        $this->assertSame(0, $result);
+        Mail::assertNotSent(CertificatAlumneFct::class);
+        Mail::assertNotSent(AvalFct::class);
+        Mail::assertNotSent(CertificatInstructorFct::class);
+        $this->assertSame(0, (int) DB::table('fcts')->where('id', 10)->value('correoInstructor'));
+    }
+
+    /**
+     * Crea una FCT compartida amb instructor, tutor i alumnat associat.
+     *
+     * @param array<int, array{id:int,idAlumno:string,calificacion:int|null,correoAlumno:int}> $alumnosFct
+     */
+    private function seedFct(array $alumnosFct): void
+    {
+        DB::table('profesores')->insert([
+            'dni' => 'P1',
+            'nombre' => 'Tutora',
+            'apellido1' => 'FCT',
+            'apellido2' => '',
+            'email' => 'tutora@example.test',
+        ]);
+
+        DB::table('instructores')->insert([
+            'dni' => 'I1',
+            'email' => 'instructor@example.test',
+            'name' => 'Instructor',
+            'surnames' => 'Empresa',
+        ]);
+
+        DB::table('colaboraciones')->insert([
+            'id' => 200,
+            'tutor' => 'P1',
+        ]);
+
+        DB::table('fcts')->insert([
+            'id' => 10,
+            'idColaboracion' => 200,
+            'idInstructor' => 'I1',
+            'correoInstructor' => 0,
+            'asociacion' => 1,
+        ]);
+
+        foreach ($alumnosFct as $alumnoFct) {
+            DB::table('alumnos')->insert([
+                'nia' => $alumnoFct['idAlumno'],
+                'dni' => $alumnoFct['idAlumno'],
+                'nombre' => 'Alumne',
+                'apellido1' => $alumnoFct['idAlumno'],
+                'apellido2' => '',
+                'email' => strtolower($alumnoFct['idAlumno']).'@example.test',
+            ]);
+
+            DB::table('alumno_fcts')->insert([
+                'id' => $alumnoFct['id'],
+                'idAlumno' => $alumnoFct['idAlumno'],
+                'idFct' => 10,
+                'idProfesor' => 'P1',
+                'calificacion' => $alumnoFct['calificacion'],
+                'correoAlumno' => $alumnoFct['correoAlumno'],
+            ]);
+        }
+    }
+
+    private function createSchema(): void
+    {
+        $schema = Schema::connection('sqlite');
+
+        $schema->dropIfExists('alumno_fcts');
+        $schema->dropIfExists('fcts');
+        $schema->dropIfExists('colaboraciones');
+        $schema->dropIfExists('instructores');
+        $schema->dropIfExists('profesores');
+        $schema->dropIfExists('alumnos');
+
+        $schema->create('profesores', function (Blueprint $table): void {
+            $table->string('dni')->primary();
+            $table->string('nombre')->nullable();
+            $table->string('apellido1')->nullable();
+            $table->string('apellido2')->nullable();
+            $table->string('email')->nullable();
+        });
+
+        $schema->create('alumnos', function (Blueprint $table): void {
+            $table->string('nia')->primary();
+            $table->string('dni')->nullable();
+            $table->string('nombre')->nullable();
+            $table->string('apellido1')->nullable();
+            $table->string('apellido2')->nullable();
+            $table->string('email')->nullable();
+        });
+
+        $schema->create('instructores', function (Blueprint $table): void {
+            $table->string('dni')->primary();
+            $table->string('email')->nullable();
+            $table->string('name')->nullable();
+            $table->string('surnames')->nullable();
+        });
+
+        $schema->create('colaboraciones', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('tutor')->nullable();
+        });
+
+        $schema->create('fcts', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedInteger('idColaboracion')->nullable();
+            $table->string('idInstructor')->nullable();
+            $table->string('cotutor')->nullable();
+            $table->unsignedTinyInteger('correoInstructor')->default(0);
+            $table->unsignedTinyInteger('asociacion')->default(1);
+        });
+
+        $schema->create('alumno_fcts', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('idAlumno')->nullable();
+            $table->unsignedInteger('idFct')->nullable();
+            $table->string('idProfesor')->nullable();
+            $table->unsignedTinyInteger('calificacion')->nullable();
+            $table->unsignedTinyInteger('correoAlumno')->default(0);
+        });
+    }
+}


### PR DESCRIPTION
## Què canvia

- El comandament `fct:Daily` deixa d'enviar `CertificatAlumneFct` a l'alumnat.
- L'enviament del certificat a l'instructor ja no depén de `correoAlumno`; depén que totes les línies d'alumnat de la FCT estiguen qualificades i que hi haja almenys un alumne apte.
- S'elimina el bloc comentat antic que enviava certificats FCT a alumnat des d'`AdministracionController`.
- Es comenta la ruta administrativa `/consulta` perquè exposava un patch manual.
- S'afig cobertura unitària del comportament del comandament.

## Per què

El flux automàtic continuava enviant certificats finals a l'alumnat. El comportament desitjat és no enviar eixe certificat a l'alumne, però mantindre l'enviament de l'avaluació/certificat a l'instructor quan la FCT ja està completament avaluada.

## Impacte

Els tutors deixaran de generar correus automàtics de certificat FCT a alumnat. Els instructors continuaran rebent la documentació quan pertoque, sense quedar bloquejats pel camp històric `correoAlumno`.

## Validació

- `git diff --check`
- `docker compose exec -T laravel.test php artisan test --filter=SendFctEmailsTest`
- `docker compose exec -T laravel.test php artisan test --filter=AlumnoFctAvalTest`

Nota: `gh issue list` no s'ha pogut consultar perquè el token local de `gh` és invàlid.