### PR TITLE
[FIX] Elimina manifestos Composer abans d'actualitzar

### DIFF
--- a/app/Http/Controllers/ActualizacionController.php
+++ b/app/Http/Controllers/ActualizacionController.php
@@ -28,10 +28,12 @@ class ActualizacionController extends Controller
             'resolved_branch' => $this->resolveBranch(),
         ]);
 
-        if (File::exists(base_path('composer.lock'))) {
-            File::delete(base_path('composer.lock'));
-            Alert::info('composer.lock eliminat');
-            Log::info('composer.lock eliminat durant /actualizacion.');
+        foreach (['composer.json', 'composer.lock'] as $composerFile) {
+            if (File::exists(base_path($composerFile))) {
+                File::delete(base_path($composerFile));
+                Alert::info($composerFile.' eliminat');
+                Log::info($composerFile.' eliminat durant /actualizacion.');
+            }
         }
 
         $branch = $this->resolveBranch();


### PR DESCRIPTION
## Canvi

- El procediment `/actualizacion` ara comprova `composer.json` i `composer.lock` abans de fer `git pull`.
- Si qualsevol dels dos fitxers existeix, l'elimina amb la mateixa alerta i log que ja s'usaven per a `composer.lock`.

## Impacte

Evita conflictes locals en actualitzacions quan `composer.json` també ha quedat modificat o desalineat abans del pull.

## Validació

- `php -l app/Http/Controllers/ActualizacionController.php`

Closes #268