### PR TITLE
[codex] [FIX] Mostra factures en el panell de lots

### DIFF
--- a/resources/views/lote/index.blade.php
+++ b/resources/views/lote/index.blade.php
@@ -3,8 +3,9 @@
     <title>{{$panel->getTitulo()}}</title>
 @endsection
 @section('grid')
+    @php($pestana = $panel->getPestanas()[0])
     <x-botones :panel="$panel" tipo="index" :elemento="$elemento ?? null" /><br/>
-    <x-grid.table :panel="$panel" :mostrarBody="false" />
+    <x-grid.table :panel="$panel" :pestana="$pestana" :elementos="$panel->getElementos($pestana)" />
 @endsection
 @section('titulo')
     {{$panel->getTitulo()}}

--- a/tests/Feature/LoteIndexViewTest.php
+++ b/tests/Feature/LoteIndexViewTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Blade;
+use Intranet\Entities\Lote;
+use Intranet\UI\Panels\Panel;
+use Tests\TestCase;
+
+/**
+ * Proves de regressió de la graella de lots de direcció.
+ */
+class LoteIndexViewTest extends TestCase
+{
+    public function test_index_de_lots_renderitza_files_del_panell(): void
+    {
+        $panel = new Panel(
+            'Lote',
+            ['registre', 'proveedor', 'factura', 'procedencia', 'estado', 'fechaAlta', 'departamento']
+        );
+        $pestana = $panel->getPestanas()[0];
+
+        $lote = new Lote([
+            'registre' => 'LOT-001',
+            'proveedor' => 'Proveïdor test',
+            'factura' => 'FAC-001',
+            'procedencia' => 0,
+            'fechaAlta' => '2026-06-19',
+        ]);
+        $lote->setAttribute('articulo_lote_count', 0);
+        $lote->setAttribute('materiales_count', 0);
+        $lote->setAttribute('materiales_invent_count', 0);
+
+        $panel->setElementos(new Collection([$lote]));
+
+        $view = file_get_contents(resource_path('views/lote/index.blade.php'));
+        $html = Blade::render(
+            '<x-grid.table :panel="$panel" :pestana="$pestana" :elementos="$panel->getElementos($pestana)" />',
+            compact('panel', 'pestana')
+        );
+
+        $this->assertStringContainsString(':elementos="$panel->getElementos($pestana)"', (string) $view);
+        $this->assertStringNotContainsString(':mostrarBody="false"', (string) $view);
+        $this->assertStringContainsString('<tbody>', $html);
+        $this->assertStringContainsString('LOT-001', $html);
+        $this->assertStringContainsString('FAC-001', $html);
+    }
+}

--- a/tests/Unit/Entities/LoteTest.php
+++ b/tests/Unit/Entities/LoteTest.php
@@ -76,4 +76,43 @@ class LoteTest extends TestCase
         $this->assertSame(2, $lotes->get('L-200')->estado);
         $this->assertSame(3, $lotes->get('L-300')->estado);
     }
+
+    public function test_estado_accessor_usa_comptadors_carregats_com_en_el_panell_de_lots(): void
+    {
+        DB::table('lotes')->insert([
+            ['registre' => 'L-000'],
+            ['registre' => 'L-100'],
+            ['registre' => 'L-200'],
+            ['registre' => 'L-300'],
+        ]);
+
+        DB::table('articulos_lote')->insert([
+            ['id' => 10, 'lote_id' => 'L-100', 'articulo_id' => 1, 'unidades' => 2],
+            ['id' => 20, 'lote_id' => 'L-200', 'articulo_id' => 2, 'unidades' => 1],
+            ['id' => 30, 'lote_id' => 'L-300', 'articulo_id' => 3, 'unidades' => 1],
+        ]);
+
+        DB::table('materiales')->insert([
+            ['articulo_lote_id' => 20, 'espacio' => 'INVENT'],
+            ['articulo_lote_id' => 30, 'espacio' => 'AULA1'],
+        ]);
+
+        $lotes = Lote::query()
+            ->withCount([
+                'ArticuloLote',
+                'Materiales',
+                'Materiales as materiales_invent_count' => static function ($query): void {
+                    $query->where('espacio', 'INVENT');
+                },
+            ])
+            ->orderBy('registre')
+            ->get()
+            ->keyBy('registre');
+
+        $this->assertSame(0, $lotes->get('L-000')->estado);
+        $this->assertSame(1, $lotes->get('L-100')->estado);
+        $this->assertSame(2, $lotes->get('L-200')->estado);
+        $this->assertSame(3, $lotes->get('L-300')->estado);
+        $this->assertSame(1, $lotes->get('L-200')->materiales_invent_count);
+    }
 }


### PR DESCRIPTION
## Resum
- Corregeix la vista de direccion/lote perquè la graella renderitze el cos i els elements del panell.
- Afig una regressió de vista per evitar que es torne a desactivar mostrarBody.
- Afig cobertura del camí amb withCount de Lote, ArticuloLote i Materiales usat pel panell.

## Causa arrel
La vista resources/views/lote/index.blade.php estava cridant el component de taula amb mostrarBody=false i sense passar els elementos del Panel. Això deixava la taula sense tbody encara que LoteController::search retornara registres.

També s’ha validat la sospita de relacions/comptadors post-migració amb una prova específica sobre withCount i l’estat calculat.

Closes #272

## Validació
- php artisan test --filter=LoteIndexViewTest
- php artisan test --filter=LoteTest
- php artisan test --filter=GridTableComponentTest
- php artisan test --filter=RouteNameContractTest
- git diff --check