### PR TITLE
[codex] [FIX] Ajusta operacions i ordre de factures

### DIFF
--- a/app/Http/Controllers/LoteController.php
+++ b/app/Http/Controllers/LoteController.php
@@ -7,6 +7,7 @@ use Intranet\Http\Controllers\Core\ModalController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Intranet\UI\Botones\BotonBasico;
+use Intranet\UI\Botones\BotonImg;
 use Intranet\Entities\Articulo;
 use Intranet\Entities\ArticuloLote;
 use Intranet\Entities\Lote;
@@ -33,8 +34,14 @@ class LoteController extends ModalController
      */
     protected $vista = 'lote.index';
 
-    protected $gridFields = [ 'registre', 'proveedor','factura','procedencia', 'estado','fechaAlta','departamento'];
+    /**
+     * @var array<int, string>
+     */
+    protected $gridFields = ['registre', 'proveedor', 'factura', 'procedencia', 'estado', 'fechaAlta', 'departament'];
 
+    /**
+     * Retorna les factures ordenades de més recents a més antigues.
+     */
     protected function search()
     {
         return Lote::query()
@@ -46,10 +53,10 @@ class LoteController extends ModalController
                     $query->where('espacio', 'INVENT');
                 },
             ])
+            ->orderByDesc('fechaAlta')
+            ->orderByDesc('registre')
             ->get();
     }
-
-
 
     public function store(LoteRequest $request)
     {
@@ -85,7 +92,15 @@ class LoteController extends ModalController
 
     protected function iniBotones()
     {
-        $this->panel->setBoton('index', new BotonBasico('direccion.lote.create', ['text'=>'Nova Factura','roles' => [config('roles.rol.direccion'), config('roles.rol.administrador')]]));
+        $roles = [config('roles.rol.direccion'), config('roles.rol.administrador')];
+
+        $this->panel->setBoton(
+            'index',
+            new BotonBasico('direccion.lote.create', ['text' => 'Nova Factura', 'roles' => $roles])
+        );
+        $this->panel->setBoton('grid', new BotonImg('lote.edit', ['roles' => $roles], 'direccion'));
+        $this->panel->setBoton('grid', new BotonImg('lote.capture', ['img' => 'fa-list', 'roles' => $roles], 'direccion'));
+        $this->panel->setBoton('grid', new BotonImg('lote.print', ['img' => 'fa-file-pdf-o', 'roles' => $roles], 'direccion'));
     }
 
     /**
@@ -94,10 +109,11 @@ class LoteController extends ModalController
      * @throws NotFoundDomainException
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    protected function print($id,$posicion=1){
+    public function print($id, $posicion = 1)
+    {
         $lote = $this->findModelOrFail(Lote::class, (string) $id, 'Lot no trobat', ['lote_id' => $id]);
         $this->authorize('update', $lote);
-        return $this->hazPdf('pdf.inventario.lote', $lote->Materiales, $posicion, 'portrait',[210,297],5)->stream();
+        return $this->hazPdf('pdf.inventario.lote', $lote->Materiales, $posicion, 'portrait', [210, 297], 5)->stream();
     }
 
     /**
@@ -105,10 +121,11 @@ class LoteController extends ModalController
      * @throws NotFoundDomainException
      * @return \Illuminate\View\View
      */
-    protected function capture($lote){
+    public function capture($lote)
+    {
         $this->authorize('update', $this->findModelOrFail(Lote::class, (string) $lote, 'Lot no trobat', ['lote_id' => $lote]));
-        $materiales = Material::whereNotNull('fechaultimoinventario')->where('inventariable',0)->get();
-        return view('lote.inventario',compact('lote','materiales'));
+        $materiales = Material::whereNotNull('fechaultimoinventario')->where('inventariable', 0)->get();
+        return view('lote.inventario', compact('lote', 'materiales'));
     }
 
     /**
@@ -117,35 +134,42 @@ class LoteController extends ModalController
      * @throws NotFoundDomainException
      * @return void
      */
-    protected function postCapture($lote,Request $request){
-       $this->authorize('update', $this->findModelOrFail(Lote::class, (string) $lote, 'Lot no trobat', ['lote_id' => $lote]));
-       foreach ($request->except('_token') as $key => $value){
-           $material = Material::find($key);
-           if (!$material) {
-               throw new NotFoundDomainException('Material no trobat', ['material_id' => $key]);
-           }
-           if (!$value) {
-               $value = $material->descripcion;
-           }
-           DB::transaction(function () use ($material,$value,$lote){
-               $articulo = Articulo::where('descripcion',$value)->first();
-               if (!$articulo){
-                   $articulo = new Articulo(['descripcion'=>$value]);
-                   $articulo->save();
-               }
-               $articulo_lote = new ArticuloLote(['lote_id'=>$lote,'articulo_id'=>$articulo->id,'marca'=>$material->marca,'modelo'=>$material->modelo,'unidades'=>$material->unidades]);
-               $articulo_lote->save();
-               for ($i=0; $i<$material->unidades;$i++){
-                 $new = $material->replicate();
-                 $new->unidades = 1;
-                 $new->inventariable = 1;
-                 $new->fechaultimoinventario = null;
-                 $new->articulo_lote_id = $articulo_lote->id;
-                 $new->save();
-               }
-               $material->delete();
-           });
-       }
+    public function postCapture($lote, Request $request)
+    {
+        $this->authorize('update', $this->findModelOrFail(Lote::class, (string) $lote, 'Lot no trobat', ['lote_id' => $lote]));
+        foreach ($request->except('_token') as $key => $value) {
+            $material = Material::find($key);
+            if (!$material) {
+                throw new NotFoundDomainException('Material no trobat', ['material_id' => $key]);
+            }
+            if (!$value) {
+                $value = $material->descripcion;
+            }
+            DB::transaction(function () use ($material, $value, $lote) {
+                $articulo = Articulo::where('descripcion', $value)->first();
+                if (!$articulo) {
+                    $articulo = new Articulo(['descripcion' => $value]);
+                    $articulo->save();
+                }
+                $articulo_lote = new ArticuloLote([
+                    'lote_id' => $lote,
+                    'articulo_id' => $articulo->id,
+                    'marca' => $material->marca,
+                    'modelo' => $material->modelo,
+                    'unidades' => $material->unidades,
+                ]);
+                $articulo_lote->save();
+                for ($i = 0; $i < $material->unidades; $i++) {
+                    $new = $material->replicate();
+                    $new->unidades = 1;
+                    $new->inventariable = 1;
+                    $new->fechaultimoinventario = null;
+                    $new->articulo_lote_id = $articulo_lote->id;
+                    $new->save();
+                }
+                $material->delete();
+            });
+        }
     }
 
 }

--- a/resources/assets/js/custom.js
+++ b/resources/assets/js/custom.js
@@ -2741,7 +2741,18 @@ if (typeof NProgress != 'undefined') {
 				var shouldSkipLegacyDatatable = datatableModel && managedModels.indexOf(datatableModel) !== -1;
 
 				if ($legacyDatatable.length && !shouldSkipLegacyDatatable && !$.fn.dataTable.isDataTable($legacyDatatable[0])) {
-				  $legacyDatatable.DataTable();
+				  var legacyDatatableOptions = {};
+				  var legacyDataOrder = $legacyDatatable.attr('data-order');
+
+				  if (legacyDataOrder) {
+					try {
+					  legacyDatatableOptions.order = JSON.parse(legacyDataOrder);
+					} catch (error) {
+					  intranetDebugLog('data-order invalid');
+					}
+				  }
+
+				  $legacyDatatable.DataTable(legacyDatatableOptions);
 				}
 
 				$('#datatable-keytable').DataTable({

--- a/resources/lang/ca/models.php
+++ b/resources/lang/ca/models.php
@@ -484,6 +484,8 @@ return array(
             'show' => 'Factura :quien',
             'index' => 'Llibre de Factures',
             'edit' => 'Editar Factura',
+            'capture' => 'Capturar materials',
+            'print' => 'Imprimir factura',
             'create' => 'Nova Factura',
         ),
         'Articulolote' => array(

--- a/resources/lang/en/models.php
+++ b/resources/lang/en/models.php
@@ -484,6 +484,8 @@ return array(
             'show' => 'Factura :quien',
             'index' => 'Llibre de Factures',
             'edit' => 'Editar Factura',
+            'capture' => 'Capturar materials',
+            'print' => 'Imprimir factura',
             'create' => 'Nova Factura',
         ),
         'Articulolote' => array(

--- a/resources/lang/es/models.php
+++ b/resources/lang/es/models.php
@@ -482,6 +482,8 @@ return array(
             'show' => 'Factura :quien',
             'index' => 'Libro de Facturas',
             'edit' => 'Editar Factura',
+            'capture' => 'Capturar materiales',
+            'print' => 'Imprimir factura',
             'create' => 'Nueva Factura',
         ),
         'Articulolote' => array(

--- a/resources/views/components/grid/table.blade.php
+++ b/resources/views/components/grid/table.blade.php
@@ -11,7 +11,8 @@
            name="{{ $panel->getModel() }}"
            class="table table-striped table-bordered display nowrap dtr-inline collapsed"
            style="width:100%" data-page-length="25"
-           @if($panel->getModel() === 'Task') data-order='[[0,"desc"]]' @endif>
+           @if($panel->getModel() === 'Task') data-order='[[0,"desc"]]' @endif
+           @if($panel->getModel() === 'Lote') data-order='[[5,"desc"],[0,"desc"]]' @endif>
 
         <thead>
             <x-grid.header :panel="$panel" :pestana="$pestana" />

--- a/tests/Feature/GridTableComponentTest.php
+++ b/tests/Feature/GridTableComponentTest.php
@@ -92,6 +92,28 @@ class GridTableComponentTest extends TestCase
         $this->assertSame('[[0,"desc"]]', $table?->getAttribute('data-order'));
     }
 
+    public function test_taula_de_lote_ordena_per_data_i_registre_descendent_per_defecte(): void
+    {
+        $panel = new Panel('Lote', ['registre', 'proveedor', 'factura', 'procedencia', 'estado', 'fechaAlta', 'departament']);
+        $pestana = $panel->getPestanas()[0];
+
+        $html = Blade::render(
+            '<x-grid.table :panel="$panel" :pestana="$pestana" :elementos="$elementos" />',
+            [
+                'panel' => $panel,
+                'pestana' => $pestana,
+                'elementos' => new Collection(),
+            ]
+        );
+
+        $document = new DOMDocument();
+        @$document->loadHTML($html);
+
+        $table = (new DOMXPath($document))->query('//table[@id="datatable"]')->item(0);
+
+        $this->assertSame('[[5,"desc"],[0,"desc"]]', $table?->getAttribute('data-order'));
+    }
+
     public function test_nom_edat_d_alumno_fct_renderitza_icona_controlada_sense_escapar_html(): void
     {
         $panel = new Panel('AlumnoFct', ['NomEdat']);

--- a/tests/Feature/LoteIndexViewTest.php
+++ b/tests/Feature/LoteIndexViewTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
+use Intranet\Entities\Departamento;
 use Intranet\Entities\Lote;
-use Intranet\UI\Panels\Panel;
+use Intranet\Http\Controllers\LoteController;
 use Tests\TestCase;
 
 /**
@@ -17,11 +19,44 @@ class LoteIndexViewTest extends TestCase
 {
     public function test_index_de_lots_renderitza_files_del_panell(): void
     {
-        $panel = new Panel(
-            'Lote',
-            ['registre', 'proveedor', 'factura', 'procedencia', 'estado', 'fechaAlta', 'departamento']
-        );
-        $pestana = $panel->getPestanas()[0];
+        auth('profesor')->setUser(new class () implements Authenticatable {
+            public string $dni = '00000000T';
+            public int $rol = 22;
+
+            public function getAuthIdentifierName(): string
+            {
+                return 'dni';
+            }
+
+            public function getAuthIdentifier(): string
+            {
+                return $this->dni;
+            }
+
+            public function getAuthPasswordName(): string
+            {
+                return 'password';
+            }
+
+            public function getAuthPassword(): string
+            {
+                return '';
+            }
+
+            public function getRememberToken(): ?string
+            {
+                return null;
+            }
+
+            public function setRememberToken($value): void
+            {
+            }
+
+            public function getRememberTokenName(): string
+            {
+                return 'remember_token';
+            }
+        });
 
         $lote = new Lote([
             'registre' => 'LOT-001',
@@ -30,10 +65,15 @@ class LoteIndexViewTest extends TestCase
             'procedencia' => 0,
             'fechaAlta' => '2026-06-19',
         ]);
+        $lote->setRelation('Departamento', new Departamento(['vliteral' => 'Informàtica']));
         $lote->setAttribute('articulo_lote_count', 0);
         $lote->setAttribute('materiales_count', 0);
         $lote->setAttribute('materiales_invent_count', 0);
 
+        $controller = new LoteController();
+        $this->callProtectedMethod($controller, 'iniBotones');
+        $panel = $this->getProtectedProperty($controller, 'panel');
+        $pestana = $panel->getPestanas()[0];
         $panel->setElementos(new Collection([$lote]));
 
         $view = file_get_contents(resource_path('views/lote/index.blade.php'));
@@ -47,5 +87,9 @@ class LoteIndexViewTest extends TestCase
         $this->assertStringContainsString('<tbody>', $html);
         $this->assertStringContainsString('LOT-001', $html);
         $this->assertStringContainsString('FAC-001', $html);
+        $this->assertStringContainsString('Informàtica', $html);
+        $this->assertStringContainsString('/direccion/lote/LOT-001/edit', $html);
+        $this->assertStringContainsString('/direccion/lote/LOT-001/capture', $html);
+        $this->assertStringContainsString('/direccion/lote/LOT-001/print', $html);
     }
 }


### PR DESCRIPTION
## Resum
- Mostra les operacions de fila disponibles en direccion/lote: editar, capturar materials i imprimir.
- Mostra el literal correcte del departament usant el camp calculat departament.
- Ordena les factures de més recents a més antigues en consulta i en la inicialització de DataTables.
- Fa públics els mètodes enrutats print, capture i postCapture perquè Laravel els puga invocar.

## Base
Aquest PR està apilat sobre codex-fix-lote-panel-factures per no modificar el PR original ni duplicar-ne el diff contra main.

Refs #272

## Validació
- php artisan test --filter=LoteIndexViewTest
- php artisan test --filter=GridTableComponentTest
- php artisan test --filter=LoteTest
- php artisan test --filter=RouteNameContractTest
- git diff --check