### PR TITLE
[FIX] Limita faltes comunicades al justificant #267

### DIFF
--- a/app/Application/Falta/FaltaService.php
+++ b/app/Application/Falta/FaltaService.php
@@ -17,6 +17,9 @@ use Illuminate\Support\Carbon;
  */
 class FaltaService
 {
+    /**
+     * Crea una falta de professorat.
+     */
     public function create(Request $request): int
     {
         $request->merge(['baja' => $request->boolean('baja') ? 1 : 0]);
@@ -47,8 +50,21 @@ class FaltaService
         return (int) $falta->fillAll($request);
     }
 
-    public function update(int|string $id, Request $request): Falta
+    /**
+     * Actualitza una falta.
+     *
+     * Quan la falta ja està enviada, només Direcció ha de poder modificar les
+     * dades de la comunicació. La resta de fluxos només poden substituir el
+     * justificant.
+     */
+    public function update(int|string $id, Request $request, bool $canEditSubmittedData = false): Falta
     {
+        $falta = Falta::findOrFail($id);
+
+        if ((int) $falta->estado >= 1 && !$canEditSubmittedData) {
+            return $this->updateJustificant($id, $request);
+        }
+
         $diaCompleto = $request->boolean('dia_completo') ? 1 : 0;
 
         $request->merge([
@@ -57,7 +73,6 @@ class FaltaService
             'hasta' => esMayor($request->desde, $request->hasta) ? $request->desde : $request->hasta,
         ]);
 
-        $falta = Falta::findOrFail($id);
         $falta->fillAll($request);
 
         $falta = $falta->fresh();
@@ -90,6 +105,9 @@ class FaltaService
         return $falta;
     }
 
+    /**
+     * Comunica la falta a Direcció i ajusta l'estat inicial.
+     */
     public function init(int|string $id): Falta
     {
         $falta = Falta::findOrFail($id);
@@ -107,6 +125,9 @@ class FaltaService
         return $falta->fresh();
     }
 
+    /**
+     * Tramita l'alta d'una baixa llarga i reactiva el professor.
+     */
     public function alta(int|string $id): Falta
     {
         /** @var Falta $falta */

--- a/app/Http/Controllers/API/FaltaController.php
+++ b/app/Http/Controllers/API/FaltaController.php
@@ -2,14 +2,34 @@
 
 namespace Intranet\Http\Controllers\API;
 
+use Intranet\Application\Falta\FaltaService;
 use Intranet\Entities\Falta;
 use Illuminate\Http\Request;
-use \DB;
 
+/**
+ * API per a faltes de professorat.
+ */
 class FaltaController extends ApiResourceController
 {
 
     protected $model = 'Falta';
-    
 
+    /**
+     * Actualitza una falta respectant la restricció de faltes ja comunicades.
+     */
+    public function update(Request $request, $id)
+    {
+        $falta = Falta::find($id);
+
+        if (!$falta) {
+            return $this->sendNotFound("Not found: Falta #{$id}");
+        }
+
+        $user = $request->user('sanctum') ?? $request->user('api') ?? authUser();
+        $isDireccion = $user && esRol($user->rol, config('roles.rol.direccion'));
+
+        app(FaltaService::class)->update($id, $request, (bool) $isDireccion);
+
+        return $this->sendResponse(['updated' => true], 'OK');
+    }
 }

--- a/app/Http/Controllers/FaltaController.php
+++ b/app/Http/Controllers/FaltaController.php
@@ -112,14 +112,16 @@ class FaltaController extends ModalController
         $falta = $this->findModelOrFail(Falta::class, (int) $id, 'Falta no trobada', ['falta_id' => $id]);
         $this->authorize('update', $falta);
 
-        if ((int) $falta->estado >= 1 && !UserisAllow(config('roles.rol.direccion'))) {
+        $isDireccion = UserisAllow(config('roles.rol.direccion'));
+
+        if ((int) $falta->estado >= 1 && !$isDireccion) {
             $this->validate($request, ['fichero' => 'nullable|mimes:pdf,jpg,jpeg,png']);
             $this->faltas()->updateJustificant($id, $request);
             return $this->redirect();
         }
 
         $this->validate($request, (new FaltaRequest())->rules());
-        $this->faltas()->update($id, $request);
+        $this->faltas()->update($id, $request, $isDireccion);
         return $this->redirect();
     }
 

--- a/app/Livewire/FaltaDireccionPanel.php
+++ b/app/Livewire/FaltaDireccionPanel.php
@@ -295,7 +295,7 @@ class FaltaDireccionPanel extends Component
             }
 
             $this->authorize('update', $falta);
-            $this->faltas()->update($this->formFaltaId, $this->buildFormRequest());
+            $this->faltas()->update($this->formFaltaId, $this->buildFormRequest(), true);
             $this->message = 'Falta actualitzada correctament.';
         } else {
             $this->authorize('create', Falta::class);

--- a/public/js/Falta/modal.js
+++ b/public/js/Falta/modal.js
@@ -17,7 +17,68 @@
         return !!(element && element.checked);
     }
 
+    function isSubmittedFalta() {
+        var method = byId('metodo');
+        var estado = byId('estado_id');
+
+        return method && method.value.toUpperCase() === 'PUT' && estado && Number(estado.value) >= 1;
+    }
+
+    function fieldContainer(element) {
+        if (!element) {
+            return null;
+        }
+
+        if ((element.getAttribute('type') || '').toLowerCase() === 'hidden') {
+            return null;
+        }
+
+        return element.closest('.form-group') || element.closest('.item') || element.parentElement;
+    }
+
+    function setFieldEditable(id, editable) {
+        var element = byId(id);
+        var container = fieldContainer(element);
+
+        if (container) {
+            container.style.display = '';
+        }
+
+        if (element && id !== 'fichero_id') {
+            element.disabled = !editable;
+        }
+    }
+
+    function updateSubmittedFormState() {
+        var onlyJustificant = isSubmittedFalta();
+        var editableFields = [
+            'idProfesor_id',
+            'estado_id',
+            'desde_id',
+            'hasta_id',
+            'baja_id',
+            'dia_completo_id',
+            'hora_ini_id',
+            'hora_fin_id',
+            'motivos_id',
+            'observaciones_id'
+        ];
+
+        editableFields.forEach(function (id) {
+            setFieldEditable(id, !onlyJustificant);
+        });
+
+        setFieldEditable('fichero_id', true);
+    }
+
     function updateFaltaState() {
+        if (isSubmittedFalta()) {
+            updateSubmittedFormState();
+            return;
+        }
+
+        updateSubmittedFormState();
+
         var baja = isChecked('baja_id');
         var diaCompleto = isChecked('dia_completo_id');
 

--- a/tests/Unit/FaltaControllerTest.php
+++ b/tests/Unit/FaltaControllerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use Intranet\Application\Falta\FaltaService;
 use Intranet\Entities\Profesor;
 use Intranet\Http\Controllers\FaltaController;
 use Tests\TestCase;
@@ -386,6 +387,103 @@ class FaltaControllerTest extends TestCase
         $this->assertSame(2, (int) $falta->estado);
         $this->assertNotEmpty($falta->fichero);
         Storage::disk('local')->assertExists($falta->fichero);
+    }
+
+    public function test_servei_update_de_falta_enviada_sense_permis_conserva_les_dades(): void
+    {
+        DB::table('profesores')->insert([
+            'dni' => 'P908',
+            'rol' => config('roles.rol.profesor'),
+            'activo' => 1,
+            'fecha_baja' => null,
+            'sustituye_a' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $faltaId = DB::table('faltas')->insertGetId([
+            'idProfesor' => 'P908',
+            'desde' => '2026-02-10',
+            'hasta' => '2026-02-10',
+            'hora_ini' => null,
+            'hora_fin' => null,
+            'motivos' => 1,
+            'observaciones' => 'Original',
+            'baja' => 0,
+            'dia_completo' => 1,
+            'estado' => 1,
+            'fichero' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        app(FaltaService::class)->update($faltaId, new Request([
+            'idProfesor' => 'P999',
+            'desde' => '2026-03-01',
+            'hasta' => '2026-03-02',
+            'motivos' => 3,
+            'observaciones' => 'Canvi no permés',
+            'dia_completo' => '0',
+            'hora_ini' => '09:00',
+            'hora_fin' => '10:00',
+        ]));
+
+        $falta = DB::table('faltas')->where('id', $faltaId)->first();
+        $this->assertSame('P908', $falta->idProfesor);
+        $this->assertSame('2026-02-10', $falta->desde);
+        $this->assertSame('2026-02-10', $falta->hasta);
+        $this->assertSame(1, (int) $falta->motivos);
+        $this->assertSame('Original', $falta->observaciones);
+        $this->assertSame(1, (int) $falta->dia_completo);
+        $this->assertNull($falta->hora_ini);
+        $this->assertNull($falta->hora_fin);
+        $this->assertSame(1, (int) $falta->estado);
+    }
+
+    public function test_servei_update_de_falta_enviada_amb_permis_de_direccio_edita_les_dades(): void
+    {
+        DB::table('profesores')->insert([
+            'dni' => 'P909',
+            'rol' => config('roles.rol.profesor'),
+            'activo' => 1,
+            'fecha_baja' => null,
+            'sustituye_a' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $faltaId = DB::table('faltas')->insertGetId([
+            'idProfesor' => 'P909',
+            'desde' => '2026-02-10',
+            'hasta' => '2026-02-10',
+            'hora_ini' => null,
+            'hora_fin' => null,
+            'motivos' => 1,
+            'observaciones' => 'Original',
+            'baja' => 0,
+            'dia_completo' => 1,
+            'estado' => 1,
+            'fichero' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        app(FaltaService::class)->update($faltaId, new Request([
+            'idProfesor' => 'P909',
+            'desde' => '2026-03-01',
+            'hasta' => '2026-03-02',
+            'motivos' => 3,
+            'observaciones' => 'Canvi de Direcció',
+            'dia_completo' => '1',
+        ]), true);
+
+        $falta = DB::table('faltas')->where('id', $faltaId)->first();
+        $this->assertSame('P909', $falta->idProfesor);
+        $this->assertSame('2026-03-01', $falta->desde);
+        $this->assertSame('2026-03-02', $falta->hasta);
+        $this->assertSame(3, (int) $falta->motivos);
+        $this->assertSame('Canvi de Direcció', $falta->observaciones);
+        $this->assertSame(1, (int) $falta->dia_completo);
     }
 
     private function createSchema(): void


### PR DESCRIPTION
## Canvis

- Limita l'actualització de faltes ja comunicades (`estado >= 1`) perquè el professorat només puga pujar o substituir el justificant.
- Manté l'edició completa per a Direcció des del panell Livewire i des del controlador/API quan correspon.
- En el modal legacy del professorat, mostra totes les dades de la falta comunicada en mode no editable i deixa actiu només el camp `Justificant`.
- Afig regressions unitàries per al bypass del servei i per a l'edició completa de Direcció.

## Causa

El controlador del professor ja desviava alguns casos cap al justificant, però el servei i l'API encara permetien actualitzar tots els camps si se'ls cridava directament. A més, la primera correcció de la UI amagava camps, cosa que no era una bona experiència en el formulari legacy.

## Validació

- `node --check public/js/Falta/modal.js`
- `php artisan test --filter=FaltaControllerTest`
- `php artisan test --filter=FaltaDireccionPanelTest`
- `php artisan test --filter=FaltaControllerFeatureTest`