### PR TITLE
[FIX] Evita errors en informes d'alumnat FCT

### DIFF
--- a/public/js/datepicker.js
+++ b/public/js/datepicker.js
@@ -6,8 +6,31 @@
         var dateTimeInputs = document.querySelectorAll('input[type="text"].datetime');
         var hasPickerTargets = dateInputs.length || timeInputs.length || dateTimeInputs.length;
 
+        function toNativeDate(value) {
+            var trimmed = (value || '').toString().trim();
+            var match = trimmed.match(/^(\d{2})[-\/](\d{2})[-\/](\d{4})$/);
+
+            if (!match) {
+                return value;
+            }
+
+            return match[3] + '-' + match[2] + '-' + match[1];
+        }
+
+        function toNativeDateTime(value) {
+            var trimmed = (value || '').toString().trim();
+            var match = trimmed.match(/^(\d{2})[-\/](\d{2})[-\/](\d{4})(?:\s+(\d{2}):(\d{2}))?$/);
+
+            if (!match) {
+                return value;
+            }
+
+            return match[3] + '-' + match[2] + '-' + match[1] + 'T' + (match[4] || '00') + ':' + (match[5] || '00');
+        }
+
         function applyNativeFallback() {
             dateInputs.forEach(function (input) {
+                input.value = toNativeDate(input.value);
                 input.setAttribute('type', 'date');
             });
 
@@ -16,6 +39,7 @@
             });
 
             dateTimeInputs.forEach(function (input) {
+                input.value = toNativeDateTime(input.value);
                 input.setAttribute('type', 'datetime-local');
             });
         }

--- a/public/js/extended.js
+++ b/public/js/extended.js
@@ -29,11 +29,10 @@
         }
     }
 
-    function fetchInformeOptions(informeCode) {
-        var url = '/api/documentacionFCT/' + informeCode;
-        var formSeleccion = document.getElementById('formSeleccion');
-        if (formSeleccion) {
-            formSeleccion.setAttribute('action', url.substring(4));
+    function apiGet(url) {
+        var apiAuth = window.intranetApiAuth || {};
+        if (typeof apiAuth.apiGet === 'function') {
+            return apiAuth.apiGet(url);
         }
 
         var auth = typeof window.apiAuthOptions === 'function' ? window.apiAuthOptions() : { headers: {}, data: {} };
@@ -53,6 +52,20 @@
         });
     }
 
+    function fetchInformeOptions(informeCode) {
+        if (!informeCode) {
+            return Promise.resolve({ data: [] });
+        }
+
+        var url = '/api/documentacionFCT/' + informeCode;
+        var formSeleccion = document.getElementById('formSeleccion');
+        if (formSeleccion) {
+            formSeleccion.setAttribute('action', url.substring(4));
+        }
+
+        return apiGet(url);
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('.selecciona').forEach(function (button) {
             button.addEventListener('click', function (event) {
@@ -61,9 +74,8 @@
                 openModal('seleccion');
 
                 var formSeleccion = document.getElementById('formSeleccion');
-                var defaultUrl = '/api/documentacionFCT/pg0301';
                 if (formSeleccion) {
-                    formSeleccion.setAttribute('action', defaultUrl.substring(4));
+                    formSeleccion.setAttribute('action', '');
                 }
             });
         });

--- a/resources/views/intranet/partials/modal/extended.blade.php
+++ b/resources/views/intranet/partials/modal/extended.blade.php
@@ -23,10 +23,10 @@
                 @if(file_exists(authUser()->pathCertificate))
                         <div style="border: 1px solid black;background-color:#ddd" >
                                 <h3 style="text-align: center">Signatura Digital</h3>
-                                <label class="control-label" for="password">Introduir Password Intranet:</label>
-                                <input type="password" id="decrypt" name="decrypt" class="form-control"/>
-                                <label class="control-label" for="password">Introduir Password Certificat:</label>
-                                <input type="password" id="cert" name="cert" class="form-control"/>
+                                <label class="control-label" for="extended-decrypt">Introduir Password Intranet:</label>
+                                <input type="password" id="extended-decrypt" name="decrypt" class="form-control"/>
+                                <label class="control-label" for="extended-cert">Introduir Password Certificat:</label>
+                                <input type="password" id="extended-cert" name="cert" class="form-control"/>
                         </div>
                 @endif
         </div>

--- a/resources/views/intranet/partials/modal/saoPassword.blade.php
+++ b/resources/views/intranet/partials/modal/saoPassword.blade.php
@@ -8,14 +8,14 @@
         @endforeach
     </select>
     <br/>
-    <label class="control-label" for="password">Introduir Password SAO:</label>
-    <input type="password" id="password" name="password" class="form-control"/>
+    <label class="control-label" for="sao-password">Introduir Password SAO:</label>
+    <input type="password" id="sao-password" name="password" class="form-control"/>
     @if(file_exists(storage_path('app/zip/'.authUser()->fileName.'.tmp')))
-        <div id="decrypt" hidden>
-            <label class="control-label" for="password">Introduir Password Intranet:</label>
-            <input type="password" id="decrypt" name="decrypt" class="form-control"/>
-            <label class="control-label" for="password">Introduir Password Certificat:</label>
-            <input type="password" id="cert" name="cert" class="form-control"/>
+        <div id="decrypt-fields" hidden>
+            <label class="control-label" for="sao-decrypt">Introduir Password Intranet:</label>
+            <input type="password" id="sao-decrypt" name="decrypt" class="form-control"/>
+            <label class="control-label" for="sao-cert">Introduir Password Certificat:</label>
+            <input type="password" id="sao-cert" name="cert" class="form-control"/>
         </div>
     @endif
     <x-ui.errors />

--- a/resources/views/intranet/partials/modal/signatura.blade.php
+++ b/resources/views/intranet/partials/modal/signatura.blade.php
@@ -16,24 +16,24 @@
     @if(file_exists(storage_path('app/zip/'.authUser()->fileName.'.tmp')))
         <div style="border: 1px solid black;background-color:#ddd" >
             <h3 style="text-align: center">Signatura Digital</h3>
-            <label class="control-label" for="password">Introduir Password Intranet:</label>
-            <input type="password" id="decrypt" name="decrypt" class="form-control"/>
-            <label class="control-label" for="password">Introduir Password Certificat:</label>
-            <input type="password" id="cert" name="cert" class="form-control"/>
+            <label class="control-label" for="signatura-decrypt">Introduir Password Intranet:</label>
+            <input type="password" id="signatura-decrypt" name="decrypt" class="form-control"/>
+            <label class="control-label" for="signatura-cert">Introduir Password Certificat:</label>
+            <input type="password" id="signatura-cert" name="cert" class="form-control"/>
         </div>
     @else
         <div  style="border: 1px solid black;background-color:#ddd">
             <h3 style="text-align: center">Signatura Digital</h3>
             <p>Si vols que es signe digitalment hauràs de pujar el certificat</p>
-            <label class="control-label" for="password">Introduir Password Certificat:</label>
-            <input type="password" id="cert" name="cert" class="form-control"/>
+            <label class="control-label" for="signatura-cert-upload">Introduir Password Certificat:</label>
+            <input type="password" id="signatura-cert-upload" name="cert" class="form-control"/>
             <label class="control-label" for="file">Introduir Certificat:</label>
             <input type="file" id="file" name="file" class="form-control"/>
         </div>
     @endif
     <br/>
-    <label class="control-label" for="password">Introduir Password SAO:</label>
-    <input type="password" id="password" name="password" class="form-control"/>
+    <label class="control-label" for="signatura-password">Introduir Password SAO:</label>
+    <input type="password" id="signatura-password" name="password" class="form-control"/>
     <x-ui.errors />
 
 </x-modal>

--- a/resources/views/intranet/partials/modal/signaturaA1.blade.php
+++ b/resources/views/intranet/partials/modal/signaturaA1.blade.php
@@ -10,14 +10,14 @@
     @if(file_exists(storage_path('app/zip/'.authUser()->fileName.'.tmp')))
         <div style="border: 1px solid black;background-color:#ddd" >
             <h3 style="text-align: center">Signatura Digital</h3>
-            <label class="control-label" for="password">Introduir Password Intranet:</label>
-            <input type="password" id="decrypt" name="decrypt" class="form-control"/>
-            <label class="control-label" for="password">Introduir Password Certificat:</label>
-            <input type="password" id="cert" name="cert" class="form-control"/>
+            <label class="control-label" for="signatura-a1-decrypt">Introduir Password Intranet:</label>
+            <input type="password" id="signatura-a1-decrypt" name="decrypt" class="form-control"/>
+            <label class="control-label" for="signatura-a1-cert">Introduir Password Certificat:</label>
+            <input type="password" id="signatura-a1-cert" name="cert" class="form-control"/>
         </div>
     @endif
-    <label class="control-label" for="password">Introduir Password SAO:</label>
-    <input type="password" id="password" name="password" class="form-control"/>
+    <label class="control-label" for="signatura-a1-password">Introduir Password SAO:</label>
+    <input type="password" id="signatura-a1-password" name="password" class="form-control"/>
     <x-ui.errors />
 
 </x-modal>


### PR DESCRIPTION
## Què canvia

- Normalitza valors `dd-mm-aaaa`/`dd/mm/aaaa` abans d'activar el fallback natiu de `input[type=date]` en `datepicker.js`.
- Evita peticions a `/api/documentacionFCT/` quan encara no hi ha cap informe seleccionat i reutilitza el helper comú d'autenticació API en `extended.js`.
- Fa únics els `id` dels camps de password/certificat en els modals FCT, mantenint els mateixos `name` perquè el backend continue rebent els camps esperats.

## Per què

En entrar a `alumnofct` i obrir la selecció d'informes, el navegador rebutjava dates com `22-06-2026` en inputs natius i la selecció podia llançar una crida API invàlida o sense l'autenticació comuna. A més, diversos modals compartien `id="password"`, cosa que generava avisos DOM i podia afectar selectors.

## Validació

- `node --check public/js/datepicker.js`
- `node --check public/js/extended.js`
- `git diff --check`

No s'ha pogut validar PHP: `php` no està instal·lat al host i el daemon de Docker no estava actiu.