### PR TITLE
[MOD] Vincula actes de tutoria al grup docent #266

### DIFF
--- a/app/Application/Reunion/ReunionFeValuationService.php
+++ b/app/Application/Reunion/ReunionFeValuationService.php
@@ -140,14 +140,14 @@ class ReunionFeValuationService
     }
 
     /**
-     * Plantilla inicial per a una acta concreta, amb dades conegudes per tutor.
+     * Plantilla inicial per a una acta concreta, amb dades conegudes pel grup o tutor.
      *
      * @param Reunion $reunion
      * @return string
      */
     public function defaultSummaryForReunion(Reunion $reunion): string
     {
-        return $this->summaryWithKnownData($this->knownSectionsForTutor((string) $reunion->idProfesor));
+        return $this->summaryWithKnownData($this->knownSectionsForReunion($reunion));
     }
 
     /**
@@ -257,6 +257,21 @@ class ReunionFeValuationService
     }
 
     /**
+     * Construeix els apartats amb les dades FE/FCT de l'acta.
+     *
+     * @param Reunion $reunion
+     * @return array<string, array<int, string>>
+     */
+    private function knownSectionsForReunion(Reunion $reunion): array
+    {
+        $fcts = $this->lfpFctsForReunion($reunion)
+            ->filter(static fn (AlumnoFct $fct): bool => (int) ($fct->calProyecto ?? 0) <= 0)
+            ->sortBy(static fn (AlumnoFct $fct): string => (string) ($fct->Alumno?->nameFull ?? $fct->Nombre));
+
+        return $this->knownSectionsForFcts($fcts);
+    }
+
+    /**
      * Construeix el resum de notes reals introduïdes per a alumnat no apte, amb cessament o amb renúncia.
      *
      * @param string $tutorDni
@@ -265,7 +280,32 @@ class ReunionFeValuationService
      */
     public function notesSummaryForTutor(string $tutorDni, ?int $moduleCourse = null): string
     {
-        $targetFcts = $this->targetFctsForTutor($tutorDni);
+        return $this->notesSummaryForFcts($this->targetFctsForTutor($tutorDni), $moduleCourse);
+    }
+
+    /**
+     * Construeix el resum de notes reals introduïdes per a una acta concreta.
+     *
+     * @param Reunion $reunion
+     * @return string
+     */
+    private function notesSummaryForReunion(Reunion $reunion): string
+    {
+        return $this->notesSummaryForFcts(
+            $this->targetFctsForReunion($reunion),
+            $this->actaModuleCourse($reunion)
+        );
+    }
+
+    /**
+     * Construeix el resum de notes reals a partir de les FCT objectiu.
+     *
+     * @param Collection<int, AlumnoFct> $targetFcts
+     * @param int|null $moduleCourse
+     * @return string
+     */
+    private function notesSummaryForFcts(Collection $targetFcts, ?int $moduleCourse = null): string
+    {
         if ($targetFcts->isEmpty()) {
             return '';
         }
@@ -329,7 +369,29 @@ class ReunionFeValuationService
      */
     public function targetFctsForTutor(string $tutorDni): Collection
     {
-        return $this->lfpFctsForTutor($tutorDni)
+        return $this->targetFctsFromLfpFcts($this->lfpFctsForTutor($tutorDni));
+    }
+
+    /**
+     * Retorna l'alumnat de l'acta que necessita notes reals de mòduls.
+     *
+     * @param Reunion $reunion
+     * @return Collection<int, AlumnoFct>
+     */
+    private function targetFctsForReunion(Reunion $reunion): Collection
+    {
+        return $this->targetFctsFromLfpFcts($this->lfpFctsForReunion($reunion));
+    }
+
+    /**
+     * Filtra les FCT LFP que necessiten notes reals.
+     *
+     * @param Collection<int, AlumnoFct> $fcts
+     * @return Collection<int, AlumnoFct>
+     */
+    private function targetFctsFromLfpFcts(Collection $fcts): Collection
+    {
+        return $fcts
             ->filter(static fn (AlumnoFct $fct): bool => (int) ($fct->calProyecto ?? 0) <= 0)
             ->filter(static fn (AlumnoFct $fct): bool => in_array((int) $fct->calificacion, [0, 3, 5], true))
             ->sortBy(static fn (AlumnoFct $fct): string => (string) ($fct->Alumno?->nameFull ?? $fct->Nombre))
@@ -344,7 +406,7 @@ class ReunionFeValuationService
      */
     public function gradeInputData(Reunion $reunion): array
     {
-        $fcts = $this->targetFctsForTutor((string) $reunion->idProfesor);
+        $fcts = $this->targetFctsForReunion($reunion);
         if ($fcts->isEmpty()) {
             return [
                 'fcts' => collect(),
@@ -578,6 +640,39 @@ class ReunionFeValuationService
     }
 
     /**
+     * Retorna les FCT LFP de l'acta, preferint el grup docent vinculat.
+     *
+     * @param Reunion $reunion
+     * @return Collection<int, AlumnoFct>
+     */
+    private function lfpFctsForReunion(Reunion $reunion): Collection
+    {
+        if ($reunion->idGrupo) {
+            return $this->lfpFctsForGrupo((string) $reunion->idGrupo);
+        }
+
+        return $this->lfpFctsForTutor((string) $reunion->idProfesor);
+    }
+
+    /**
+     * Retorna només l'alumnat FE/FCT de normativa LFP d'un grup docent.
+     *
+     * @param string $idGrupo
+     * @return Collection<int, AlumnoFct>
+     */
+    private function lfpFctsForGrupo(string $idGrupo): Collection
+    {
+        return AlumnoFct::query()
+            ->with(['Alumno.Grupo.Ciclo', 'Fct.Colaboracion.Ciclo'])
+            ->whereHas('Alumno.Grupo', static function ($query) use ($idGrupo): void {
+                $query->where('grupos.codigo', $idGrupo);
+            })
+            ->get()
+            ->filter(fn (AlumnoFct $fct): bool => $this->isLfpFct($fct))
+            ->values();
+    }
+
+    /**
      * Indica si una FCT correspon a un grup LFP.
      *
      * @param AlumnoFct $fct
@@ -663,7 +758,7 @@ class ReunionFeValuationService
      */
     public function refreshNotesOrder(Reunion $reunion): ?OrdenReunion
     {
-        $summary = $this->notesSummaryForTutor((string) $reunion->idProfesor, $this->actaModuleCourse($reunion));
+        $summary = $this->notesSummaryForReunion($reunion);
         $existing = OrdenReunion::query()
             ->forReunion($reunion->id)
             ->whereIn('descripcion', [

--- a/app/Entities/Reunion.php
+++ b/app/Entities/Reunion.php
@@ -24,6 +24,7 @@ class Reunion extends Model
     protected $fillable = [
         'tipo',
         'grupo',
+        'idGrupo',
         'curso',
         'numero',
         'fecha',
@@ -86,7 +87,16 @@ class Reunion extends Model
                 ->whereIn('idProfesor', array_filter([authUser()->dni, authUser()->sustituye_a]))
                 ->pluck('idReunion')
                 ->all();
-        return $query->whereIn('id', $reuniones)->orWhere('idProfesor', authUser()->dni);
+        $grupos = Grupo::qTutor(authUser()->dni)->pluck('codigo')->all();
+
+        return $query->where(function ($innerQuery) use ($reuniones, $grupos) {
+            $innerQuery->whereIn('id', $reuniones)
+                ->orWhere('idProfesor', authUser()->dni);
+
+            if ($grupos !== []) {
+                $innerQuery->orWhereIn('idGrupo', $grupos);
+            }
+        });
     }
     public function scopeConvocante($query, $dni=null)
     {
@@ -112,6 +122,17 @@ class Reunion extends Model
             return $query;
         }
     }
+    /**
+     * Filtra les actes pel curs acadèmic.
+     *
+     * @param mixed $query
+     * @param string|null $curso
+     * @return mixed
+     */
+    public function scopeCurso($query, $curso = null)
+    {
+        return $query->where('curso', $curso ?? Curso());
+    }
     public function scopeArchivada($query)
     {
         return $query->where('archivada', 1);
@@ -119,6 +140,24 @@ class Reunion extends Model
     public function scopeActaFinal($query, $tutor)
     {
         return $query->where('tipo', 7)->where('numero', 34)->where('idProfesor', $tutor);
+    }
+
+    /**
+     * Filtra actes d'un grup docent amb compatibilitat per actes antigues sense `idGrupo`.
+     *
+     * @param mixed $query
+     * @param Grupo $grupo
+     * @return mixed
+     */
+    public function scopeActaGrupo($query, Grupo $grupo)
+    {
+        return $query->where(function ($innerQuery) use ($grupo) {
+            $innerQuery->where('idGrupo', $grupo->codigo)
+                ->orWhere(function ($legacyQuery) use ($grupo) {
+                    $legacyQuery->whereNull('idGrupo')
+                        ->where('idProfesor', $grupo->tutor);
+                });
+        });
     }
 
     public function getTipoOptions()
@@ -143,6 +182,16 @@ class Reunion extends Model
     public function getGrupoOptions()
     {
         return hazArray(GrupoTrabajo::MisGruposTrabajo()->get(), 'id', 'literal');
+    }
+
+    /**
+     * Opcions de grup docent per a vincular actes de tutoria.
+     *
+     * @return array<string, string>
+     */
+    public function getIdGrupoOptions(): array
+    {
+        return hazArray(app(GrupoService::class)->all(), 'codigo', 'nombre');
     }
 
     public function getDepartamentoAttribute()
@@ -180,6 +229,14 @@ class Reunion extends Model
         return $this->belongsTo(GrupoTrabajo::class, 'grupo', 'id');
     }
 
+    /**
+     * Grup docent propietari de l'acta de tutoria.
+     */
+    public function GrupoDocente()
+    {
+        return $this->belongsTo(Grupo::class, 'idGrupo', 'codigo');
+    }
+
     public function Espacio()
     {
         return $this->belongsTo(Espacio::class, 'idEspacio', 'aula');
@@ -197,7 +254,7 @@ class Reunion extends Model
         }
         $colectivo =$this->Tipos()->colectivo;
         $profesor = Profesor::query()->find($this->idProfesor);
-        if (!$profesor) {
+        if (!$profesor && $colectivo !== 'Grupo') {
             return '';
         }
         $grupo = '';
@@ -212,7 +269,7 @@ class Reunion extends Model
                 $grupo = Departamento::query()->where('id', $profesor->departamento)->value('cliteral') ?? '';
                 break;
             case 'Grupo':
-                $grupo = app(GrupoService::class)->largestByTutor($profesor->dni)?->nombre ?? '';
+                $grupo = $this->grupoDocenteActual()?->nombre ?? '';
                 break;
             default:
                 $grupo = '';
@@ -222,7 +279,7 @@ class Reunion extends Model
 
     public function getCicloAttribute()
     {
-        return app(GrupoService::class)->firstByTutor($this->idProfesor)?->Ciclo->ciclo ?? '';
+        return $this->grupoDocenteActual()?->Ciclo?->ciclo ?? '';
     }
 
     public function getXtipoAttribute()
@@ -244,9 +301,21 @@ class Reunion extends Model
     }
     public function getGrupoClaseAttribute()
     {
-        return $this->Tipos()->colectivo == 'Grupo'
-            ? app(GrupoService::class)->largestByTutor($this->idProfesor)
-            : null;
+        return $this->Tipos()->colectivo == 'Grupo' ? $this->grupoDocenteActual() : null;
+    }
+
+    /**
+     * Resol el grup docent de l'acta: primer `idGrupo`, després el tutor antic.
+     *
+     * @return Grupo|null
+     */
+    public function grupoDocenteActual(): ?Grupo
+    {
+        if ($this->idGrupo) {
+            return $this->GrupoDocente;
+        }
+
+        return app(GrupoService::class)->largestByTutor($this->idProfesor);
     }
     public function getInformeAttribute()
     {

--- a/app/Http/Controllers/PanelFinCursoController.php
+++ b/app/Http/Controllers/PanelFinCursoController.php
@@ -199,7 +199,7 @@ class PanelFinCursoController extends BaseController
     {
         foreach ( config('auxiliares.reunionesControlables') as $tipo => $howManyNeeded) {
             if ($howManyNeeded){
-                $howManyAre = Reunion::Convocante()->Tipo($tipo)->Archivada()->count();
+                $howManyAre = self::actasArchivadasTutorActual((int) $tipo);
                 if ($howManyAre >= $howManyNeeded) {
                     $avisos[self::SUCCESS][] = "Acta ".TipoReunionService::find($tipo)->vliteral." Arxivada";
                 } else {
@@ -208,6 +208,32 @@ class PanelFinCursoController extends BaseController
             }
         }
     }
+
+    /**
+     * Compta les actes arxivades dels grups del tutor actual en el curs vigent.
+     *
+     * @param int $tipo
+     * @return int
+     */
+    private static function actasArchivadasTutorActual(int $tipo): int
+    {
+        $grupos = app(GrupoService::class)->qTutor(AuthUser()->dni);
+        if ($grupos->isEmpty()) {
+            return Reunion::Convocante()->Tipo($tipo)->Curso()->Archivada()->count();
+        }
+
+        return Reunion::query()
+            ->where(function ($query) use ($grupos): void {
+                foreach ($grupos as $grupo) {
+                    $query->orWhere(fn ($grupoQuery) => $grupoQuery->ActaGrupo($grupo));
+                }
+            })
+            ->Tipo($tipo)
+            ->Curso()
+            ->Archivada()
+            ->count();
+    }
+
     private static function lookAtPollsTutor(&$avisos)
     {
         $ppols = hazArray(PPoll::where('what', 'Fct')->get(), 'id', 'id');

--- a/app/Http/Controllers/ReunionController.php
+++ b/app/Http/Controllers/ReunionController.php
@@ -114,7 +114,7 @@ class ReunionController extends ModalController
     public function store(ReunionStoreRequest $request)
     {
         $this->authorize('create', Reunion::class);
-        $this->vinculaGrupoDocente($request);
+        $this->normalitzaGrupoDocente($request);
 
         $elemento = DB::transaction(function() use ($request) {
             $id = $this->persist($request);
@@ -196,6 +196,7 @@ class ReunionController extends ModalController
     {
         $elemento = Reunion::findOrFail($id);
         $this->authorize('update', $elemento);
+        $this->normalitzaGrupoDocente($request);
         $this->persist($request, $id);
         return $this->redirect();
     }
@@ -593,24 +594,24 @@ class ReunionController extends ModalController
     }
 
     /**
-     * Vincula automàticament les actes de tipus grup al grup docent actual si el formulari no l'envia.
+     * Normalitza el grup docent de l'acta segons el tipus de reunió.
+     *
+     * Les actes de grup queden vinculades al grup enviat pel formulari o, per
+     * defecte, al grup docent del tutor actual. La resta de reunions no han de
+     * persistir cap `idGrupo` accidental del formulari general.
      *
      * @param Request $request
      * @return void
      */
-    private function vinculaGrupoDocente(Request $request): void
+    private function normalitzaGrupoDocente(Request $request): void
     {
-        if ($request->filled('idGrupo')) {
-            return;
-        }
-
         $tipo = $request->input('tipo');
         if (!$tipo || (new TipoReunionService($tipo))->colectivo !== 'Grupo') {
+            $request->merge(['idGrupo' => null]);
             return;
         }
 
-        $grupo = $this->grupoTutorActual();
-        if ($grupo) {
+        if (!$request->filled('idGrupo') && $grupo = $this->grupoTutorActual()) {
             $request->merge(['idGrupo' => $grupo]);
         }
     }

--- a/app/Http/Controllers/ReunionController.php
+++ b/app/Http/Controllers/ReunionController.php
@@ -104,12 +104,17 @@ class ReunionController extends ModalController
     }
 
     protected function createWithDefaultValues( $default=[]){
-        return new Reunion(['idProfesor'=>AuthUser()->dni,'curso'=>Curso()]);
+        return new Reunion([
+            'idProfesor' => AuthUser()->dni,
+            'idGrupo' => $this->grupoTutorActual(),
+            'curso' => Curso()
+        ]);
     }
 
     public function store(ReunionStoreRequest $request)
     {
         $this->authorize('create', Reunion::class);
+        $this->vinculaGrupoDocente($request);
 
         $elemento = DB::transaction(function() use ($request) {
             $id = $this->persist($request);
@@ -152,6 +157,7 @@ class ReunionController extends ModalController
             'tipo' => ['type' => 'hidden'],
             'numero' => ['type' => 'select'],
             'grupo' => ['type' => 'hidden'],
+            'idGrupo' => ['type' => 'select'],
             'curso' => ['disabled' => 'disabled'],
             'fecha' => ['type' => 'datetime'],
             'descripcion' => ['type' => 'text'],
@@ -539,7 +545,11 @@ class ReunionController extends ModalController
     {
         foreach ($this->grupos()->all() as $grupo) {
             foreach (config('auxiliares.reunionesControlables') as $tipo => $howMany) {
-                $reuniones[$grupo->nombre][$tipo] = Reunion::Convocante($grupo->tutor)->Tipo($tipo)->Archivada()->get();
+                $reuniones[$grupo->nombre][$tipo] = Reunion::ActaGrupo($grupo)
+                    ->Tipo($tipo)
+                    ->Curso()
+                    ->Archivada()
+                    ->get();
             }
         }
         return view('reunion.control', compact('reuniones'));
@@ -556,9 +566,10 @@ class ReunionController extends ModalController
         }
         
         foreach ($grupos as $grupo) {
-            if (!Reunion::Convocante($grupo->tutor)
+            if (!Reunion::ActaGrupo($grupo)
                 ->Tipo($request->tipo)
                 ->Numero($request->numero)
+                ->Curso()
                 ->Archivada()
                 ->count()) {
                 $texto = 'Et falta per fer i/o arxivar la reunio ' . TipoReunionService::find($request->tipo)->vliteral . ' ';
@@ -569,6 +580,39 @@ class ReunionController extends ModalController
         }
         Alert::info($cont . ' Avisos enviats');
         return back();
+    }
+
+    /**
+     * Retorna el grup docent principal del tutor autenticat.
+     *
+     * @return string|null
+     */
+    private function grupoTutorActual(): ?string
+    {
+        return $this->grupos()->largestByTutor(AuthUser()->dni)?->codigo;
+    }
+
+    /**
+     * Vincula automàticament les actes de tipus grup al grup docent actual si el formulari no l'envia.
+     *
+     * @param Request $request
+     * @return void
+     */
+    private function vinculaGrupoDocente(Request $request): void
+    {
+        if ($request->filled('idGrupo')) {
+            return;
+        }
+
+        $tipo = $request->input('tipo');
+        if (!$tipo || (new TipoReunionService($tipo))->colectivo !== 'Grupo') {
+            return;
+        }
+
+        $grupo = $this->grupoTutorActual();
+        if ($grupo) {
+            $request->merge(['idGrupo' => $grupo]);
+        }
     }
 
     private function construye_pdf($id)

--- a/app/Policies/ReunionPolicy.php
+++ b/app/Policies/ReunionPolicy.php
@@ -3,6 +3,7 @@
 namespace Intranet\Policies;
 
 use Intranet\Entities\Reunion;
+use Intranet\Entities\Grupo;
 use Intranet\Policies\Concerns\InteractsWithProfesorOwnership;
 
 /**
@@ -80,7 +81,27 @@ class ReunionPolicy
      */
     private function isOwner($user, Reunion $reunion): bool
     {
-        return $this->hasProfesorIdentity($user)
-            && (string) $reunion->idProfesor === (string) $user->dni;
+        if (!$this->hasProfesorIdentity($user)) {
+            return false;
+        }
+
+        return (string) $reunion->idProfesor === (string) $user->dni
+            || $this->isTutorDelGrupo($user, $reunion);
+    }
+
+    /**
+     * Determina si l'usuari és tutor actual del grup docent de l'acta.
+     *
+     * @param mixed $user
+     */
+    private function isTutorDelGrupo($user, Reunion $reunion): bool
+    {
+        if (!$reunion->idGrupo) {
+            return false;
+        }
+
+        return Grupo::qTutor((string) $user->dni)
+            ->where('codigo', (string) $reunion->idGrupo)
+            ->exists();
     }
 }

--- a/app/Presentation/Crud/ReunionCrudSchema.php
+++ b/app/Presentation/Crud/ReunionCrudSchema.php
@@ -34,6 +34,7 @@ final class ReunionCrudSchema
         'tipo' => ['type' => 'select'],
         'numero' => ['type' => 'select'],
         'grupo' => ['type' => 'select'],
+        'idGrupo' => ['type' => 'select'],
         'curso' => ['disabled' => 'disabled'],
         'fecha' => ['type' => 'datetime'],
         'descripcion' => ['type' => 'text'],
@@ -60,6 +61,7 @@ final class ReunionCrudSchema
         'fecha' => 'required|date',
         'descripcion' => 'required|between:0,120',
         'idProfesor' => 'required',
+        'idGrupo' => 'nullable|string|max:10',
         'idEspacio' => 'required',
     ];
 }

--- a/database/migrations/2026_06_17_120000_add_id_grupo_to_reuniones_table.php
+++ b/database/migrations/2026_06_17_120000_add_id_grupo_to_reuniones_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Afig la vinculació estructural de les actes de grup al grup docent.
+     */
+    public function up(): void
+    {
+        Schema::table('reuniones', function (Blueprint $table): void {
+            $table->string('idGrupo', 10)->nullable()->after('grupo')->index();
+        });
+    }
+
+    /**
+     * Elimina la vinculació estructural al grup docent.
+     */
+    public function down(): void
+    {
+        Schema::table('reuniones', function (Blueprint $table): void {
+            $table->dropIndex(['idGrupo']);
+            $table->dropColumn('idGrupo');
+        });
+    }
+};

--- a/public/js/Reunion/create.js
+++ b/public/js/Reunion/create.js
@@ -64,6 +64,18 @@
         }
     }
 
+    function setGrupoDocenteEnabled(enabled) {
+        var idGrupo = byId('idGrupo_id');
+        if (!idGrupo) {
+            return;
+        }
+
+        idGrupo.disabled = !enabled;
+        if (!enabled) {
+            idGrupo.value = '';
+        }
+    }
+
     function fillNumeroOptions(numeracion) {
         var numero = byId('numero_id');
         if (!numero) {
@@ -77,6 +89,30 @@
             option.textContent = numeracion[key];
             numero.appendChild(option);
         });
+    }
+
+    function applyTipoReunionData(data) {
+        setDisabled('grupo_id', Number(data.select) === 0);
+        setGrupoDocenteEnabled(data.colectivo === 'Grupo');
+
+        if (data.numeracion) {
+            fillNumeroOptions(data.numeracion);
+        }
+    }
+
+    function loadTipoReunion(tipoValue) {
+        if (!tipoValue && tipoValue !== 0) {
+            setGrupoDocenteEnabled(false);
+            return;
+        }
+
+        fetchTipoReunion(tipoValue)
+            .then(function (result) {
+                applyTipoReunionData(result && result.data ? result.data : {});
+            })
+            .catch(function (error) {
+                window.console.log(error);
+            });
     }
 
     document.addEventListener('DOMContentLoaded', function () {
@@ -93,6 +129,7 @@
             if (String(tipoValue) === '9') {
                 setDisabled('fichero_id', false);
                 setDisabled('numero_id', true);
+                setGrupoDocenteEnabled(true);
                 if (descripcion) {
                     descripcion.value = 'Acta FSE';
                 }
@@ -105,18 +142,9 @@
             setDisabled('numero_id', false);
             setDisabled('objetivos_id', false);
 
-            fetchTipoReunion(tipoValue)
-                .then(function (result) {
-                    var data = result && result.data ? result.data : {};
-                    setDisabled('grupo_id', Number(data.select) === 0);
-
-                    if (data.numeracion) {
-                        fillNumeroOptions(data.numeracion);
-                    }
-                })
-                .catch(function (error) {
-                    window.console.log(error);
-                });
+            loadTipoReunion(tipoValue);
         });
+
+        loadTipoReunion(tipo.value);
     });
 })();

--- a/tests/Unit/Application/Reunion/ReunionFeValuationServiceTest.php
+++ b/tests/Unit/Application/Reunion/ReunionFeValuationServiceTest.php
@@ -266,6 +266,22 @@ class ReunionFeValuationServiceTest extends TestCase
     }
 
     /**
+     * Verifica que una acta vinculada a grup no depén del tutor convocant antic.
+     */
+    public function test_resum_fe_usa_id_grupo_encara_que_el_convocant_siga_antic(): void
+    {
+        $this->seedKnownFctData();
+
+        $summary = (new ReunionFeValuationService())->defaultSummaryForReunion(
+            $this->makeReunion(10, 7, 34, '2LFP', 'POLD')
+        );
+
+        $this->assertStringContainsString('Apta Test, Anna - Apte - 120 hores', $summary);
+        $this->assertStringContainsString('Noapta Test, Noa - No Apte - 80 hores', $summary);
+        $this->assertStringNotContainsString('Loe Test, Laia', $summary);
+    }
+
+    /**
      * Verifica que es crea el punt 10 amb notes reals introduïdes.
      */
     public function test_crea_punt_notes_reals_per_alumnat_no_apte_o_renuncia(): void
@@ -584,7 +600,7 @@ class ReunionFeValuationServiceTest extends TestCase
     /**
      * Crea una reunió Eloquent mínima per a les proves.
      */
-    private function makeReunion(int $id, int $tipo, int $numero): Reunion
+    private function makeReunion(int $id, int $tipo, int $numero, ?string $idGrupo = null, string $idProfesor = 'P1'): Reunion
     {
         $reunion = new Reunion([
             'tipo' => $tipo,
@@ -592,7 +608,8 @@ class ReunionFeValuationServiceTest extends TestCase
             'curso' => '2025',
             'fecha' => '2026-06-04 10:00:00',
             'descripcion' => 'Acta',
-            'idProfesor' => 'P1',
+            'idProfesor' => $idProfesor,
+            'idGrupo' => $idGrupo,
             'idEspacio' => 'A1',
         ]);
         $reunion->id = $id;

--- a/tests/Unit/Entities/ReunionTest.php
+++ b/tests/Unit/Entities/ReunionTest.php
@@ -18,6 +18,7 @@ class ReunionTest extends TestCase
         $schema = Schema::connection('sqlite');
 
         $schema->dropIfExists('reuniones');
+        $schema->dropIfExists('grupos');
         $schema->dropIfExists('profesores');
         $schema->dropIfExists('departamentos');
 
@@ -33,11 +34,22 @@ class ReunionTest extends TestCase
             $table->string('sustituye_a', 10)->nullable();
         });
 
+        $schema->create('grupos', function (Blueprint $table): void {
+            $table->string('codigo', 10)->primary();
+            $table->string('nombre')->nullable();
+            $table->string('tutor', 10)->nullable();
+            $table->unsignedTinyInteger('curso')->nullable();
+            $table->string('turno')->nullable();
+            $table->unsignedInteger('idCiclo')->nullable();
+            $table->timestamps();
+        });
+
         $schema->create('reuniones', function (Blueprint $table): void {
             $table->increments('id');
             $table->unsignedTinyInteger('tipo')->nullable();
             $table->unsignedTinyInteger('numero')->nullable();
             $table->string('idProfesor', 10)->nullable();
+            $table->string('idGrupo', 10)->nullable();
             $table->timestamps();
         });
     }
@@ -99,5 +111,27 @@ class ReunionTest extends TestCase
         app()->instance(GrupoService::class, $grupoService);
 
         $this->assertFalse($reunion->mostra_notes_fe);
+    }
+
+    public function test_grupo_clase_preferix_id_grupo_abans_del_tutor_convocant(): void
+    {
+        Grupo::query()->create([
+            'codigo' => 'G1',
+            'nombre' => 'Primer LFP',
+            'tutor' => 'P900',
+            'curso' => 1,
+            'turno' => 'S',
+        ]);
+
+        $reunion = Reunion::query()->create([
+            'idProfesor' => 'P100',
+            'idGrupo' => 'G1',
+            'tipo' => 7,
+            'numero' => 34,
+        ]);
+
+        $this->assertSame('G1', $reunion->grupoClase?->codigo);
+        $this->assertSame('Primer LFP', $reunion->xgrupo);
+        $this->assertTrue($reunion->mostra_notes_fe);
     }
 }

--- a/tests/Unit/Policies/ReunionPolicyTest.php
+++ b/tests/Unit/Policies/ReunionPolicyTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Policies;
 
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Intranet\Entities\Reunion;
 use Intranet\Policies\ReunionPolicy;
 use Tests\TestCase;
@@ -40,6 +43,34 @@ class ReunionPolicyTest extends TestCase
         $this->assertFalse($policy->manageParticipants($other, $reunion));
         $this->assertFalse($policy->manageOrder($other, $reunion));
         $this->assertFalse($policy->notify($other, $reunion));
+    }
+
+    public function test_update_manage_i_notify_permeten_tutor_actual_del_grup(): void
+    {
+        $schema = Schema::connection('sqlite');
+        $schema->dropIfExists('grupos');
+        $schema->dropIfExists('profesores');
+        $schema->create('profesores', function (Blueprint $table): void {
+            $table->string('dni', 10)->primary();
+            $table->string('sustituye_a', 10)->nullable();
+        });
+        $schema->create('grupos', function (Blueprint $table): void {
+            $table->string('codigo', 10)->primary();
+            $table->string('tutor', 10)->nullable();
+        });
+        DB::table('profesores')->insert(['dni' => 'PRF999', 'sustituye_a' => null]);
+        DB::table('grupos')->insert(['codigo' => 'G1', 'tutor' => 'PRF999']);
+
+        $policy = new ReunionPolicy();
+        $reunion = new Reunion();
+        $reunion->idProfesor = 'PRF001';
+        $reunion->idGrupo = 'G1';
+        $tutorActual = (object) ['dni' => 'PRF999'];
+
+        $this->assertTrue($policy->update($tutorActual, $reunion));
+        $this->assertTrue($policy->manageParticipants($tutorActual, $reunion));
+        $this->assertTrue($policy->manageOrder($tutorActual, $reunion));
+        $this->assertTrue($policy->notify($tutorActual, $reunion));
     }
 
     public function test_manage_department_report_requerix_rol_cap_de_departament(): void


### PR DESCRIPTION
## Què canvia

- Afig `idGrupo` a `reuniones` per vincular les actes de grup al grup docent estable.
- Manté `idProfesor` com a convocant/responsable, però les consultes i permisos de tutoria poden resoldre per grup.
- Les actes de tipus `Grupo` assignen per defecte el grup docent del tutor actual si el formulari no envia `idGrupo`.
- En alta i modificació, les reunions que no són de col·lectiu `Grupo` guarden `idGrupo = null`.
- El modal de creació/modificació habilita el selector de grup docent només per a tipus de reunió de col·lectiu `Grupo`; per a departament, claustre, grup de treball, COCOPE, etc. queda deshabilitat i buit.
- Actualitza els resums FE/FCT i els avisos de final de curs perquè usen el grup vinculat quan existeix.

## Per què

Les actes de tutoria no han de dependre estructuralment de la persona tutora (`idProfesor`), perquè un canvi de tutor o una substitució pot fer que l’històric quede associat a la persona equivocada. El grup docent és la unitat estable de propietat de l’acta.

## Validació

- `node --check public/js/Reunion/create.js`
- `git diff --check`

No s'ha pogut executar PHPUnit en este entorn perquè no hi ha `php` local. `gh auth status` també falla per token CLI invàlid, però s'ha pogut crear el PR amb el connector GitHub.

Closes #266