### PR TITLE
[FIX] Accepta justificants jpeg en fitxers adjunts

### DIFF
--- a/app/Entities/Concerns/BatoiModels.php
+++ b/app/Entities/Concerns/BatoiModels.php
@@ -332,7 +332,7 @@ trait BatoiModels
         }
 
         // Validar extensió
-        $allowedExtensions = ['pdf', 'docx', 'xlsx', 'jpg', 'png', 'webp', 'heic', 'heif', 'zip'];
+        $allowedExtensions = ['pdf', 'docx', 'xlsx', 'jpg', 'jpeg', 'png', 'webp', 'heic', 'heif', 'zip'];
         $extension = strtolower($file->getClientOriginalExtension());
 
         if (!in_array($extension, $allowedExtensions)) {

--- a/tests/Unit/Entities/ArticuloTest.php
+++ b/tests/Unit/Entities/ArticuloTest.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Facades\Storage;
 use Intranet\Entities\Articulo;
 use Tests\TestCase;
 
+/**
+ * Proves unitàries de l'entitat Articulo.
+ */
 class ArticuloTest extends TestCase
 {
     protected function setUp(): void
@@ -89,5 +92,18 @@ class ArticuloTest extends TestCase
         $this->assertSame('Articulos/25.jpg', $path);
         Storage::disk('public')->assertExists('Articulos/25.jpg');
     }
-}
 
+    public function test_fill_file_accepta_extensio_jpeg(): void
+    {
+        Storage::fake('public');
+
+        $articulo = new Articulo();
+        $articulo->id = 26;
+        $file = UploadedFile::fake()->image('foto.jpeg');
+
+        $path = $articulo->fillFile($file);
+
+        $this->assertSame('Articulos/26.jpeg', $path);
+        Storage::disk('public')->assertExists('Articulos/26.jpeg');
+    }
+}


### PR DESCRIPTION
## Resum
- Afig `jpeg` a l'allowlist compartida de `fillFile()`.
- Afig una prova unitària perquè els fitxers `.jpeg` es guarden correctament.

## Causa
La validació de faltes permetia `.jpeg`, però la capa comuna de guardat de fitxers només acceptava `jpg`, i acabava mostrant format invàlid.

## Proves
- `docker compose exec -T laravel.test php artisan test --filter=ArticuloTest`
- `git diff --check`