### PR TITLE
[FIX] Mostra promoció en acta extraordinària

### DIFF
--- a/resources/views/pdf/reunion/actaAvaluacio.blade.php
+++ b/resources/views/pdf/reunion/actaAvaluacio.blade.php
@@ -27,17 +27,7 @@
     </div>
 @endif
 --}}
-@if ($datosInforme->informe)
-    <div class="container">
-        <br/>
-        <strong>Promoció de l'alumnat</strong>
-        <ul style='list-style:none'>
-            @foreach ($datosInforme->alumnos()->orderBy('apellido1')->orderBy('apellido2')->get() as $alumno)
-                <strong><li>{{ $alumno->nameFull }} - @if ($alumno->pivot->capacitats == 3) NO @else SI @endif</strong> - {{config('auxiliares.promociona')[$alumno->pivot->capacitats]}}</li>
-            @endforeach
-        </ul>
-    </div>
-@endif
+@includeWhen($datosInforme->extraOrdinaria, 'pdf.reunion.partials.promocio', ['datosInforme' => $datosInforme])
 @include('pdf.reunion.partials.asistents')
 @include('pdf.reunion.partials.signatura')
 {{--

--- a/resources/views/pdf/reunion/partials/promocio.blade.php
+++ b/resources/views/pdf/reunion/partials/promocio.blade.php
@@ -1,0 +1,26 @@
+@php
+    $opcionsPromocio = config('auxiliares.promociona', []);
+@endphp
+<div class="container">
+    <br/>
+    <strong>Promoció de l'alumnat</strong>
+    <ul style='list-style:none'>
+        @foreach ($datosInforme->alumnos()->orderBy('apellido1')->orderBy('apellido2')->get() as $alumno)
+            @php
+                $capacitats = (int) data_get($alumno, 'pivot.capacitats', 0);
+                $decisio = match ($capacitats) {
+                    1 => 'SI',
+                    3 => 'NO',
+                    default => 'Sense determinar',
+                };
+                $textPromocio = $opcionsPromocio[$capacitats] ?? null;
+            @endphp
+            <li>
+                <strong>{{ $alumno->nameFull }} - {{ $decisio }}</strong>
+                @if ($textPromocio)
+                    - {{ $textPromocio }}
+                @endif
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/tests/Feature/ReunionActaAvaluacioViewTest.php
+++ b/tests/Feature/ReunionActaAvaluacioViewTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+/**
+ * Proves de la secció de promoció en l'acta extraordinària.
+ */
+class ReunionActaAvaluacioViewTest extends TestCase
+{
+    public function test_acta_extraordinaria_mostra_promocio_i_no_promocio(): void
+    {
+        $html = view('pdf.reunion.partials.promocio', [
+            'datosInforme' => new FakeActaExtraordinaria([
+                $this->alumne('Aitana Pla Soler', 1),
+                $this->alumne('Bernat Ribes Gil', 3),
+            ]),
+        ])->render();
+
+        $this->assertStringContainsString('Promoció de l\'alumnat', $html);
+        $this->assertStringContainsString('Aitana Pla Soler - SI', $html);
+        $this->assertStringContainsString('Promociona', $html);
+        $this->assertStringContainsString('Bernat Ribes Gil - NO', $html);
+        $this->assertStringContainsString('No Promociona', $html);
+    }
+
+    public function test_acta_extraordinaria_no_falla_amb_capacitats_no_previstes(): void
+    {
+        $html = view('pdf.reunion.partials.promocio', [
+            'datosInforme' => new FakeActaExtraordinaria([
+                $this->alumne('Carme Vidal Mas', 0),
+            ]),
+        ])->render();
+
+        $this->assertStringContainsString('Carme Vidal Mas - Sense determinar', $html);
+    }
+
+    private function alumne(string $nameFull, int $capacitats): object
+    {
+        return (object) [
+            'nameFull' => $nameFull,
+            'pivot' => (object) ['capacitats' => $capacitats],
+        ];
+    }
+}
+
+/**
+ * Doble mínim de l'acta amb alumnat ordenable per a renderitzar la vista.
+ */
+class FakeActaExtraordinaria
+{
+    public function __construct(private readonly array $alumnes)
+    {
+    }
+
+    public function alumnos(): FakeActaAlumnesQuery
+    {
+        return new FakeActaAlumnesQuery($this->alumnes);
+    }
+}
+
+/**
+ * Doble mínim de query Eloquent utilitzat per la plantilla.
+ */
+class FakeActaAlumnesQuery
+{
+    public function __construct(private readonly array $alumnes)
+    {
+    }
+
+    public function orderBy(string $column): self
+    {
+        return $this;
+    }
+
+    public function get(): Collection
+    {
+        return collect($this->alumnes);
+    }
+}


### PR DESCRIPTION
## Què canvia

- L'acta extraordinària d'avaluació torna a mostrar la secció de promoció de l'alumnat.
- La secció usa el valor de `alumno_reuniones.capacitats` per mostrar `SI - Promociona` o `NO - No Promociona`.
- Els valors no previstos es mostren com a `Sense determinar` per evitar errors en generar el PDF.

## Motiu

S'havia perdut o quedava massa acoblada la visualització de si l'alumnat promociona en l'acta extraordinària.

## Validació

- `php artisan test --filter=ReunionActaAvaluacioViewTest`