### PR TITLE
[FIX] Ajusta agregació Excel FE tutors per grup #275

### DIFF
--- a/app/Application/Poll/PollWorkflowService.php
+++ b/app/Application/Poll/PollWorkflowService.php
@@ -93,6 +93,11 @@ class PollWorkflowService
         ];
     }
 
+    /**
+     * Calcula els resultats agregats d'una enquesta per a gràfiques i exportació.
+     *
+     * @return array<string, mixed>|null
+     */
     public function allVotes(int|string $id, GrupoService $grupoService): ?array
     {
         $poll = Poll::find($id);
@@ -113,10 +118,12 @@ class PollWorkflowService
         $this->initValues($votes, $optionsNumeric, $grupoService);
         $votes['all'] = $allVotes->groupBy('option_id');
         $modelo::aggregate($votes, $option1, $option2, $poll);
+        $availableEvaluationsByGroup = $modelo::availableEvaluationsByGroup($poll);
 
         $stats = [
             'all' => [],
             'grup' => [],
+            'grup_summary' => [],
             'cicle' => [],
             'departament' => [],
         ];
@@ -136,9 +143,17 @@ class PollWorkflowService
                     $stats[$bucket][$nameGroup][$optionId] = [
                         'avg' => $avg !== null ? round((float) $avg, 1) : null,
                         'count' => $optionVote->groupBy('user_id')->count(),
+                        'received_count' => $optionVote->groupBy('user_id')->count(),
                     ];
                 }
             }
+        }
+
+        foreach ($votes['grup'] as $nameGroup => $groupVotes) {
+            $stats['grup_summary'][$nameGroup] = $this->summarizeGroupValuations(
+                $groupVotes,
+                $availableEvaluationsByGroup[$nameGroup] ?? 0
+            );
         }
 
         $hasVotes = [
@@ -151,7 +166,7 @@ class PollWorkflowService
             foreach ($stats[$bucket] as $nameGroup => $groupStats) {
                 $hasVotes[$bucket][$nameGroup] = false;
                 foreach ($groupStats as $stat) {
-                    if ($stat['count'] > 0) {
+                    if (($stat['received_count'] ?? $stat['count']) > 0) {
                         $hasVotes[$bucket][$nameGroup] = true;
                         break;
                     }
@@ -221,6 +236,35 @@ class PollWorkflowService
             'selectHasVotes' => $selectHasVotes,
             'student_select_groups' => $studentSelectGroups,
         ];
+    }
+
+    /**
+     * Resumeix totes les respostes numèriques del grup en una valoració única.
+     *
+     * @param array<int|string, Collection<int, mixed>> $groupVotes
+     * @return array{avg: float|null, received_count: int, company_count: int}
+     */
+    private function summarizeGroupValuations(array $groupVotes, int $companyCount): array
+    {
+        $numericVotes = collect($groupVotes)->flatMap(static fn(Collection $optionVotes): Collection => $optionVotes);
+        $avg = $numericVotes->avg('value');
+
+        return [
+            'avg' => $avg !== null ? round((float) $avg, 1) : null,
+            'received_count' => $this->countReceivedValuations($numericVotes),
+            'company_count' => $companyCount,
+        ];
+    }
+
+    /**
+     * Compta una valoració per cada parella FCT/respondedor.
+     */
+    private function countReceivedValuations(Collection $votes): int
+    {
+        return $votes
+            ->map(static fn(object $vote): string => ($vote->idOption1 ?? 'sense-fct') . ':' . $vote->user_id)
+            ->unique()
+            ->count();
     }
 
     private function userKey(Poll $poll, object $user): string

--- a/app/Entities/Poll/Fct.php
+++ b/app/Entities/Poll/Fct.php
@@ -68,6 +68,35 @@ class Fct extends ModelPoll
     }
 
     /**
+     * Calcula les empreses/FCT avaluables associades a cada grup.
+     *
+     * Una mateixa FCT només compta una vegada dins del grup encara que tinga
+     * més d'un alumne o més d'una resposta de tutor/cotutor.
+     *
+     * @return array<string, int>
+     */
+    public static function availableEvaluationsByGroup(?Poll $poll = null): array
+    {
+        $fctsByGroup = [];
+
+        foreach (realFct::with(['Colaboracion.Ciclo', 'Alumnos.Grupo'])->esFct()->get() as $fct) {
+            $ciclo = $fct?->Colaboracion?->Ciclo;
+            if (!$ciclo) {
+                continue;
+            }
+
+            foreach (self::groupCodesForFct($fct, (int) $ciclo->id) as $groupCode) {
+                $fctsByGroup[$groupCode] ??= [];
+                $fctsByGroup[$groupCode][(int) $fct->id] = true;
+            }
+        }
+
+        return collect($fctsByGroup)
+            ->map(static fn(array $fcts): int => count($fcts))
+            ->all();
+    }
+
+    /**
      * Retorna els codis de grup de l'alumnat associat a la FCT dins del cicle.
      *
      * @return array<int, string>

--- a/app/Entities/Poll/ModelPoll.php
+++ b/app/Entities/Poll/ModelPoll.php
@@ -37,6 +37,16 @@ abstract class ModelPoll
     {}
 
     /**
+     * Retorna el nombre d'empreses/FCT avaluables per grup quan el model ho pot calcular.
+     *
+     * @return array<string, int>
+     */
+    public static function availableEvaluationsByGroup(?Poll $poll = null): array
+    {
+        return [];
+    }
+
+    /**
      * Permet al model descartar respostes que no corresponen al context de la poll.
      */
     public static function filterVotesForPoll(Collection $votes, Poll $poll): Collection

--- a/app/Exports/PollResultsExport.php
+++ b/app/Exports/PollResultsExport.php
@@ -3,6 +3,8 @@
 namespace Intranet\Exports;
 
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 /**
  * Exporta els resultats agregats d'una enquesta en diverses pestanyes Excel.
@@ -58,7 +60,12 @@ class PollResultsExport implements WithMultipleSheets
         $sheets = [
             new PollResultsSheet('poll.partials.resolts.excel_general', 'Resultats', $data),
             new PollResultsSheet('poll.partials.resolts.excel_departament', 'Departaments', $data),
-            new PollResultsSheet('poll.partials.resolts.excel_grup', 'Grups', $data),
+            new PollResultsSheet(
+                'poll.partials.resolts.excel_grup',
+                'Grups',
+                $data,
+                $this->groupSheetColumnFormats()
+            ),
         ];
 
         foreach ($this->studentSelectGroups as $sheetData) {
@@ -83,5 +90,23 @@ class PollResultsExport implements WithMultipleSheets
         $cycleName = $group->Ciclo?->ciclo ?? $group->idCiclo ?? '';
 
         return trim($group->codigo . ' ' . $cycleName);
+    }
+
+    /**
+     * Formata les columnes de mitjana de la pestanya Grups amb dos decimals.
+     *
+     * @return array<string, string>
+     */
+    private function groupSheetColumnFormats(): array
+    {
+        $formats = [];
+        $firstAverageColumn = 4;
+        $lastAverageColumn = $firstAverageColumn + $this->options_numeric->count() - 1;
+
+        for ($column = $firstAverageColumn; $column <= $lastAverageColumn; $column++) {
+            $formats[Coordinate::stringFromColumnIndex($column)] = NumberFormat::FORMAT_NUMBER_00;
+        }
+
+        return $formats;
     }
 }

--- a/app/Exports/PollResultsSheet.php
+++ b/app/Exports/PollResultsSheet.php
@@ -4,22 +4,28 @@ namespace Intranet\Exports;
 
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\FromView;
+use Maatwebsite\Excel\Concerns\WithColumnFormatting;
 use Maatwebsite\Excel\Concerns\WithTitle;
 
 /**
  * Fulla Excel basada en una vista Blade.
  */
-class PollResultsSheet implements FromView, WithTitle
+class PollResultsSheet implements FromView, WithTitle, WithColumnFormatting
 {
     private $view;
     private $title;
     private $data;
+    private $columnFormats;
 
-    public function __construct(string $view, string $title, array $data)
+    /**
+     * @param array<string, string> $columnFormats
+     */
+    public function __construct(string $view, string $title, array $data, array $columnFormats = [])
     {
         $this->view = $view;
         $this->title = $title;
         $this->data = $data;
+        $this->columnFormats = $columnFormats;
     }
 
     public function view(): View
@@ -33,5 +39,15 @@ class PollResultsSheet implements FromView, WithTitle
         $title = preg_replace('/\s+/', ' ', $title) ?: 'Fulla';
 
         return mb_substr($title, 0, 31);
+    }
+
+    /**
+     * Defineix formats nadius d'Excel per columna.
+     *
+     * @return array<string, string>
+     */
+    public function columnFormats(): array
+    {
+        return $this->columnFormats;
     }
 }

--- a/resources/views/poll/partials/resolts/excel_grup.blade.php
+++ b/resources/views/poll/partials/resolts/excel_grup.blade.php
@@ -1,8 +1,10 @@
-@php($colspan = $options_numeric->count() + 1)
+@php($colspan = $options_numeric->count() + 3)
 <table>
     <thead>
     <tr>
         <th>Resultat Enquesta {{$poll->title}}</th>
+        <th>Empreses del grup</th>
+        <th>Valoracions totals</th>
         @foreach ($options_numeric as $item)
             <th>{{ $item->question_label }}</th>
         @endforeach
@@ -14,14 +16,14 @@
     </tr>
     @foreach ($votes['grup'] as $nameGroup => $grupVotes)
         @if ($hasVotes['grup'][$nameGroup] ?? false)
+            @php($summary = $stats['grup_summary'][$nameGroup] ?? ['company_count' => 0, 'received_count' => 0])
             <tr>
                 <td>{{ \Intranet\Entities\Grupo::find($nameGroup)->nombre }}</td>
+                <td>{{ $summary['company_count'] }}</td>
+                <td>{{ $summary['received_count'] }}</td>
                 @foreach ($grupVotes as $optionId => $optionVote)
-                    <td>
-                        @if (($stats['grup'][$nameGroup][$optionId]['count'] ?? 0) > 0)
-                            {{ $stats['grup'][$nameGroup][$optionId]['avg'] }} / {{ $stats['grup'][$nameGroup][$optionId]['count'] }}
-                        @endif
-                    </td>
+                    @php($avg = $stats['grup'][$nameGroup][$optionId]['avg'] ?? null)
+                    <td>{{ $avg ?? '' }}</td>
                 @endforeach
             </tr>
         @endif

--- a/specs/fct.md
+++ b/specs/fct.md
@@ -54,8 +54,29 @@ Especificació del comportament esperat per al domini FCT. Tecnologia-agnòstica
 **When** fa `GET /signatura/{id}/pdf`  
 **Then** el servidor retorna un PDF vàlid (Content-Type `application/pdf`)
 
+## Enquestes FE tutors
+
+### Escenari 7: ✅ Exportar resultats per grup amb preguntes d'empresa agregades
+
+**Given** que una enquesta FE de tutors té respostes numèriques sobre FCT/empresa vinculades a alumnat d'un grup  
+**When** s'exporta la pestanya **Grups** a Excel  
+**Then**
+- Es mostren les preguntes numèriques de valoració d'empresa com a columnes
+- Cada columna de pregunta mostra la mitjana aritmètica de les respostes rebudes en eixe grup
+- Les mitjanes s'exporten com a valors numèrics d'Excel i amb format de dos decimals
+
+### Escenari 8: ✅ Mostrar empreses i valoracions totals per grup
+
+**Given** que un grup té diverses empreses/FCT avaluables i només una part han rebut valoració  
+**When** s'exporta la pestanya **Grups** a Excel  
+**Then**
+- La columna `Empreses del grup` compta les FCT/empreses avaluables del grup
+- La columna `Valoracions totals` compta una valoració per cada parella FCT/respondedor
+- Una resposta de cotutor sobre la mateixa FCT incrementa les valoracions totals però no duplica les empreses del grup
+
 ## Regles de negoci invariants
 
 - `sendTo` i `signed` no es poden modificar directament des de cap controlador sense passar per `SignaturaStatusService` o `EmailPostSendService`.
 - Abans d'enviar a instructor: verificar existència de `Fct`, `Instructor`, `email`, `nombre`.
 - Canvis a `sendTo`/`signed` requereixen revisar: `A1Finder`, `A2Finder`, `A3Finder`, `MailFinders/*`, `SignaturaStatusService`, `EmailPostSendService`.
+- En la pestanya **Grups** de l'Excel FE tutors, les mitjanes s'han d'exportar com a números, no com a text.

--- a/tests/Unit/Application/Poll/PollWorkflowServiceTest.php
+++ b/tests/Unit/Application/Poll/PollWorkflowServiceTest.php
@@ -785,6 +785,252 @@ class PollWorkflowServiceTest extends TestCase
         $this->assertSame(1, $result['stats']['grup']['2CAE'][42]['count']);
     }
 
+    public function test_all_votes_fct_de_tutor_mostra_preguntes_empreses_i_valoracions_per_grup(): void
+    {
+        DB::table('departamentos')->insert([
+            'id' => 1,
+            'cliteral' => 'Sanitat',
+            'vliteral' => 'Sanitat',
+        ]);
+
+        DB::table('ciclos')->insert([
+            'id' => 8,
+            'ciclo' => 'Cures auxiliars',
+            'departamento' => 1,
+        ]);
+
+        DB::table('grupos')->insert([
+            ['codigo' => '2CAE', 'nombre' => '2CAE', 'idCiclo' => 8, 'curso' => 2],
+        ]);
+
+        DB::table('alumnos')->insert([
+            [
+                'nia' => 'NIA10',
+                'dni' => 'DNI10',
+                'nombre' => 'Ada',
+                'apellido1' => 'Lovelace',
+                'apellido2' => 'Test',
+                'email' => 'ada@test.local',
+            ],
+            [
+                'nia' => 'NIA20',
+                'dni' => 'DNI20',
+                'nombre' => 'Grace',
+                'apellido1' => 'Hopper',
+                'apellido2' => 'Test',
+                'email' => 'grace@test.local',
+            ],
+            [
+                'nia' => 'NIA30',
+                'dni' => 'DNI30',
+                'nombre' => 'Katherine',
+                'apellido1' => 'Johnson',
+                'apellido2' => 'Test',
+                'email' => 'katherine@test.local',
+            ],
+            [
+                'nia' => 'NIA40',
+                'dni' => 'DNI40',
+                'nombre' => 'Margaret',
+                'apellido1' => 'Hamilton',
+                'apellido2' => 'Test',
+                'email' => 'margaret@test.local',
+            ],
+        ]);
+
+        DB::table('alumnos_grupos')->insert([
+            ['idAlumno' => 'NIA10', 'idGrupo' => '2CAE'],
+            ['idAlumno' => 'NIA20', 'idGrupo' => '2CAE'],
+            ['idAlumno' => 'NIA30', 'idGrupo' => '2CAE'],
+            ['idAlumno' => 'NIA40', 'idGrupo' => '2CAE'],
+        ]);
+
+        DB::table('colaboraciones')->insert([
+            'id' => 100,
+            'idCiclo' => 8,
+        ]);
+
+        DB::table('fcts')->insert([
+            ['id' => 200, 'idColaboracion' => 100],
+            ['id' => 201, 'idColaboracion' => 100],
+            ['id' => 202, 'idColaboracion' => 100],
+            ['id' => 203, 'idColaboracion' => 100],
+        ]);
+
+        DB::table('alumno_fcts')->insert([
+            ['idFct' => 200, 'idAlumno' => 'NIA10'],
+            ['idFct' => 201, 'idAlumno' => 'NIA20'],
+            ['idFct' => 202, 'idAlumno' => 'NIA30'],
+            ['idFct' => 203, 'idAlumno' => 'NIA40'],
+        ]);
+
+        $idPPoll = (int) DB::table('ppolls')->insertGetId([
+            'title' => 'Enquesta tutor avaluació FCT',
+            'what' => 'Fct',
+            'anonymous' => 0,
+            'remains' => 0,
+        ]);
+
+        $idPoll = (int) DB::table('polls')->insertGetId([
+            'title' => 'Enquesta Tutor Avaluació FE',
+            'desde' => '2026-03-01',
+            'hasta' => '2026-03-31',
+            'idPPoll' => $idPPoll,
+            'curs' => null,
+        ]);
+
+        DB::table('options')->insert([
+            [
+                'id' => 43,
+                'question' => 'Valora la predisposició o grau de col·laboració de l’empresa en la FE.',
+                'scala' => 10,
+                'choices' => null,
+                'idCiclo' => null,
+                'ppoll_id' => $idPPoll,
+            ],
+            [
+                'id' => 44,
+                'question' => 'Valora el desenvolupament de les pràctiques en l’empresa.',
+                'scala' => 10,
+                'choices' => null,
+                'idCiclo' => null,
+                'ppoll_id' => $idPPoll,
+            ],
+        ]);
+
+        DB::table('votes')->insert([
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'TUTOR1',
+                'option_id' => 43,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 10,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'TUTOR1',
+                'option_id' => 44,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 6,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'COTUTOR1',
+                'option_id' => 43,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 6,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'COTUTOR1',
+                'option_id' => 44,
+                'idOption1' => 200,
+                'idOption2' => null,
+                'value' => 8,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'TUTOR2',
+                'option_id' => 43,
+                'idOption1' => 201,
+                'idOption2' => null,
+                'value' => 8,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'idPoll' => $idPoll,
+                'user_id' => 'TUTOR2',
+                'option_id' => 44,
+                'idOption1' => 201,
+                'idOption2' => null,
+                'value' => 10,
+                'text' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $grupo = new Grupo();
+        $grupo->codigo = '2CAE';
+
+        $grupoService = $this->createMock(GrupoService::class);
+        $grupoService
+            ->method('all')
+            ->willReturn(new EloquentCollection([$grupo]));
+
+        $service = new PollWorkflowService();
+        $result = $service->allVotes($idPoll, $grupoService);
+
+        $this->assertNotNull($result);
+        $this->assertTrue($result['hasVotes']['grup']['2CAE']);
+        $this->assertSame(4, $result['stats']['grup_summary']['2CAE']['company_count']);
+        $this->assertSame(3, $result['stats']['grup_summary']['2CAE']['received_count']);
+        $this->assertSame(8.0, $result['stats']['grup']['2CAE'][43]['avg']);
+        $this->assertSame(8.0, $result['stats']['grup']['2CAE'][44]['avg']);
+    }
+
+    public function test_excel_grup_renderitza_les_mitjanes_com_a_valors_numerics(): void
+    {
+        DB::table('grupos')->insert([
+            'codigo' => '2CAE',
+            'nombre' => '2CAE',
+            'idCiclo' => null,
+            'curso' => 2,
+        ]);
+
+        $html = view('poll.partials.resolts.excel_grup', [
+            'poll' => (object) ['title' => 'Enquesta FE'],
+            'votes' => [
+                'grup' => [
+                    '2CAE' => [
+                        43 => collect([(object) ['value' => 8.5]]),
+                    ],
+                ],
+            ],
+            'options_numeric' => collect([
+                (object) ['id' => 43, 'question_label' => 'Valora la predisposició o grau de col·laboració de l’empresa en la FE.'],
+            ]),
+            'options_select' => collect(),
+            'hasVotes' => [
+                'grup' => [
+                    '2CAE' => true,
+                ],
+            ],
+            'stats' => [
+                'grup' => [
+                    '2CAE' => [
+                        43 => ['avg' => 8.5],
+                    ],
+                ],
+                'grup_summary' => [
+                    '2CAE' => ['company_count' => 4, 'received_count' => 3],
+                ],
+            ],
+            'select_stats' => ['grup' => []],
+            'select_hasVotes' => ['grup' => []],
+        ])->render();
+
+        $this->assertStringContainsString('8.5', $html);
+        $this->assertStringNotContainsString('8,5', $html);
+    }
+
     /**
      * Crea una plantilla d'enquesta mínima per als tests del workflow.
      *
@@ -898,6 +1144,7 @@ class PollWorkflowServiceTest extends TestCase
         $schema->create('fcts', function (Blueprint $table): void {
             $table->unsignedInteger('id')->primary();
             $table->unsignedInteger('idColaboracion')->nullable();
+            $table->unsignedTinyInteger('asociacion')->default(1);
         });
 
         $schema->create('alumno_fcts', function (Blueprint $table): void {

--- a/tests/Unit/Exports/PollResultsExportTest.php
+++ b/tests/Unit/Exports/PollResultsExportTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exports;
+
+use Intranet\Exports\PollResultsExport;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use Tests\TestCase;
+
+/**
+ * Proves unitàries de l'exportació de resultats de polls.
+ */
+class PollResultsExportTest extends TestCase
+{
+    public function test_la_fulla_grups_formata_les_mitjanes_amb_dos_decimals(): void
+    {
+        $export = new PollResultsExport(
+            (object) ['title' => 'Enquesta FE'],
+            ['grup' => []],
+            collect([
+                (object) ['id' => 1],
+                (object) ['id' => 2],
+            ]),
+            collect(),
+            ['grup' => []],
+            [],
+            [],
+            []
+        );
+
+        $sheets = $export->sheets();
+
+        $this->assertSame(
+            [
+                'D' => NumberFormat::FORMAT_NUMBER_00,
+                'E' => NumberFormat::FORMAT_NUMBER_00,
+            ],
+            $sheets[2]->columnFormats()
+        );
+    }
+}


### PR DESCRIPTION
## Resum

Fixes #275

- Ajusta la pestanya **Grups** de l'Excel FE tutors perquè mostre empreses del grup, valoracions totals i les preguntes numèriques d'empresa agregades per grup.
- Calcula les empreses/FCT avaluables per grup deduplicant la mateixa FCT.
- Manté les mitjanes com a valors numèrics d'Excel i aplica format de dos decimals a les columnes de resultat.
- Actualitza `specs/fct.md` amb els escenaris implementats.

## Validació

- `php artisan test --filter=PollWorkflowServiceTest`
- `php artisan test --filter=PollResultsExportTest`
- `php -l app/Exports/PollResultsExport.php`
- `php -l app/Exports/PollResultsSheet.php`
- `php -l app/Application/Poll/PollWorkflowService.php`
- `php -l app/Entities/Poll/Fct.php`
- `php -l app/Entities/Poll/ModelPoll.php`

## Notes

`gh auth status` informa que el token local de `gh` és invàlid, així que el PR s'ha creat amb el connector GitHub. La branca s'ha pujat correctament via el remot SSH de Git.