### PR TITLE
[FIX] Conserva notes FE en acta extraordinària

### DIFF
--- a/app/Application/Reunion/ReunionFeValuationService.php
+++ b/app/Application/Reunion/ReunionFeValuationService.php
@@ -58,7 +58,7 @@ class ReunionFeValuationService
         if ($existing) {
             $this->removeDeprecatedSecondYearInstruction($existing);
             $this->removeDeprecatedSecretaryInstruction($existing);
-            $this->refreshNotesOrder($reunion);
+            $this->refreshNotesOrder($reunion, true);
 
             return $existing;
         }
@@ -393,7 +393,7 @@ class ReunionFeValuationService
     {
         return $fcts
             ->filter(static fn (AlumnoFct $fct): bool => (int) ($fct->calProyecto ?? 0) <= 0)
-            ->filter(static fn (AlumnoFct $fct): bool => in_array((int) $fct->calificacion, [0, 3, 5], true))
+            ->filter(fn (AlumnoFct $fct): bool => in_array($this->effectiveQualification($fct), [0, 3, 5], true))
             ->sortBy(static fn (AlumnoFct $fct): string => (string) ($fct->Alumno?->nameFull ?? $fct->Nombre))
             ->values();
     }
@@ -589,24 +589,24 @@ class ReunionFeValuationService
         $fcts = collect($fcts);
         return [
             'aptes' => $this->formatFctRows(
-                $fcts->where('calificacion', 1),
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 1),
                 true
             ),
             'no_aptes' => $this->formatFctRows(
-                $fcts->where('calificacion', 0),
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 0),
                 true
             ),
             'convalidats' => $this->formatFctRows(
-                $fcts->where('calificacion', 2)
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 2)
             ),
             'cessaments' => $this->formatFctRows(
-                $fcts->where('calificacion', 3)
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 3)
             ),
             'expulsions' => $this->formatExpulsionRows(
-                $fcts->where('calificacion', 4)
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 4)
             ),
             'renuncies' => $this->formatRenunciaRows(
-                $fcts->where('calificacion', 5)
+                $fcts->filter(fn (AlumnoFct $fct): bool => $this->effectiveQualification($fct) === 5)
             )
         ];
     }
@@ -751,14 +751,65 @@ class ReunionFeValuationService
     }
 
     /**
+     * Retorna la qualificació que ha d'usar l'acta FE, aplicant la regla de 1r LFP amb 100 hores.
+     *
+     * @param AlumnoFct $fct
+     * @return int|null
+     */
+    private function effectiveQualification(AlumnoFct $fct): ?int
+    {
+        $qualification = $fct->calificacion === null ? null : (int) $fct->calificacion;
+
+        if (in_array($qualification, [null, 0], true) && $this->isCompletedFirstCourseFe($fct)) {
+            return 1;
+        }
+
+        return $qualification;
+    }
+
+    /**
+     * Indica si una FE LFP de 1r té les 100 hores completades i s'ha de considerar apta.
+     *
+     * @param AlumnoFct $fct
+     * @return bool
+     */
+    private function isCompletedFirstCourseFe(AlumnoFct $fct): bool
+    {
+        $grupo = $this->resolveGrupoForFct($fct);
+
+        return $this->resolveNormativa($fct, $grupo) === 'LFP'
+            && (int) ($grupo?->curso ?? 0) === 1
+            && (int) ($fct->horasTotal ?? $fct->horas ?? 0) >= 100;
+    }
+
+    /**
+     * Retorna l'etiqueta de qualificació efectiva per al resum de l'acta.
+     *
+     * @param AlumnoFct $fct
+     * @return string
+     */
+    private function qualificationLabel(AlumnoFct $fct): string
+    {
+        return match ($this->effectiveQualification($fct)) {
+            0 => 'No Apte',
+            1 => 'Apte',
+            2 => 'Convalidat/Exempt',
+            3 => 'Cessament',
+            4 => 'Cessament Disciplinari (Expulsat)',
+            5 => 'Renúncia / No realitzada',
+            default => 'No Avaluat',
+        };
+    }
+
+    /**
      * Garantix el punt de notes reals si hi ha notes introduïdes.
      *
      * @param Reunion $reunion
+     * @param bool $preserveExistingSummary
      * @return OrdenReunion|null
      */
-    public function refreshNotesOrder(Reunion $reunion): ?OrdenReunion
+    public function refreshNotesOrder(Reunion $reunion, bool $preserveExistingSummary = false): ?OrdenReunion
     {
-        $summary = $this->notesSummaryForReunion($reunion);
         $existing = OrdenReunion::query()
             ->forReunion($reunion->id)
             ->whereIn('descripcion', [
@@ -767,6 +818,17 @@ class ReunionFeValuationService
                 self::LEGACY_NOTES_ORDER_DESCRIPTION_WITH_RENUNCIA,
             ])
             ->first();
+
+        if ($preserveExistingSummary && $existing) {
+            if ($existing->descripcion !== self::NOTES_ORDER_DESCRIPTION) {
+                $existing->descripcion = self::NOTES_ORDER_DESCRIPTION;
+                $existing->save();
+            }
+
+            return $existing;
+        }
+
+        $summary = $this->notesSummaryForReunion($reunion);
         if ($summary === '') {
             if ($existing) {
                 $existing->delete();
@@ -850,7 +912,7 @@ class ReunionFeValuationService
         $rows = [];
         foreach ($fcts as $fct) {
             $name = e((string) ($fct->Alumno?->nameFull ?? $fct->Nombre));
-            $qualification = e((string) $fct->qualificacio);
+            $qualification = e($this->qualificationLabel($fct));
             $hours = $includeHours ? ' - ' . (int) $fct->horasTotal . ' hores' : '';
             $rows[] = $name . ' - ' . $qualification . $hours;
         }

--- a/tests/Unit/Application/Reunion/ReunionFeValuationServiceTest.php
+++ b/tests/Unit/Application/Reunion/ReunionFeValuationServiceTest.php
@@ -167,6 +167,42 @@ class ReunionFeValuationServiceTest extends TestCase
     }
 
     /**
+     * Verifica que entrar a l'acta no recalcula el punt de notes editat pel tutor.
+     */
+    public function test_entrada_acta_conserva_punt_notes_ja_editat(): void
+    {
+        $this->seedKnownFctData();
+        $this->seedModuleGrades();
+        DB::table('ordenes_reuniones')->insert([
+            [
+                'idReunion' => 10,
+                'orden' => 9,
+                'descripcion' => ReunionFeValuationService::ORDER_DESCRIPTION,
+                'resumen' => 'Resum FE',
+            ],
+            [
+                'idReunion' => 10,
+                'orden' => 10,
+                'descripcion' => ReunionFeValuationService::NOTES_ORDER_DESCRIPTION,
+                'resumen' => 'Text modificat pel tutor',
+            ],
+        ]);
+
+        $this->serviceWithAvalFcts($this->avalFcts())->ensureOrder(
+            $this->makeReunion(10, 7, 34),
+            'LFP'
+        );
+
+        $this->assertSame(
+            'Text modificat pel tutor',
+            DB::table('ordenes_reuniones')
+                ->where('idReunion', 10)
+                ->where('descripcion', ReunionFeValuationService::NOTES_ORDER_DESCRIPTION)
+                ->value('resumen')
+        );
+    }
+
+    /**
      * Verifica que s'elimina la instrucció antiga de 2n en actes ja creades.
      */
     public function test_elimina_text_antic_de_grups_de_segon_si_ja_existix(): void
@@ -337,6 +373,27 @@ class ReunionFeValuationServiceTest extends TestCase
             [0 => 'No Superat', 5 => '5', 6 => '6', 7 => '7', 8 => '8', 9 => '9', 10 => '10'],
             $data['gradeOptions']
         );
+    }
+
+    /**
+     * Verifica que la FE de 1r LFP amb 100 hores es tracta com a apta i no arrossega el mòdul optatiu.
+     */
+    public function test_fe_de_primer_amb_cent_hores_es_apta_i_no_demana_notes_de_moduls(): void
+    {
+        $this->seedKnownFctData();
+        $this->seedModuleGrades();
+
+        $summary = (new ReunionFeValuationService())->defaultSummaryForReunion(
+            $this->makeReunion(11, 7, 35, '1LFP')
+        );
+        $data = (new ReunionFeValuationService())->gradeInputData(
+            $this->makeReunion(11, 7, 35, '1LFP')
+        );
+
+        $this->assertStringContainsString('Optativa Test, Ona - Apte - 100 hores', $summary);
+        $this->assertStringNotContainsString('Optativa Test, Ona - No Apte', $summary);
+        $this->assertNotContains('A9', $data['fcts']->pluck('idAlumno')->all());
+        $this->assertFalse($data['results']->has('A9-3'));
     }
 
     /**
@@ -642,8 +699,10 @@ class ReunionFeValuationServiceTest extends TestCase
             ['id' => 4, 'idColaboracion' => 2, 'asociacion' => 1],
             ['id' => 5, 'idColaboracion' => 3, 'asociacion' => 1],
             ['id' => 6, 'idColaboracion' => 2, 'asociacion' => 1],
+            ['id' => 7, 'idColaboracion' => 2, 'asociacion' => 1],
         ]);
         DB::table('grupos')->insert([
+            ['codigo' => '1LFP', 'nombre' => 'Primer LFP', 'tutor' => 'P1', 'idCiclo' => 100, 'curso' => 1],
             ['codigo' => '2LFP', 'nombre' => 'Segon LFP', 'tutor' => 'P1', 'idCiclo' => 100, 'curso' => 2],
             ['codigo' => '2LOE', 'nombre' => 'Segon LOE', 'tutor' => 'P1', 'idCiclo' => 200, 'curso' => 2],
         ]);
@@ -656,6 +715,7 @@ class ReunionFeValuationServiceTest extends TestCase
             ['nia' => 'A6', 'nombre' => 'Cesc', 'apellido1' => 'Cessament', 'apellido2' => 'Test'],
             ['nia' => 'A7', 'nombre' => 'Pau', 'apellido1' => 'Projecte', 'apellido2' => 'Test'],
             ['nia' => 'A8', 'nombre' => 'Elsa', 'apellido1' => 'Expulsio', 'apellido2' => 'Test'],
+            ['nia' => 'A9', 'nombre' => 'Ona', 'apellido1' => 'Optativa', 'apellido2' => 'Test'],
         ]);
         DB::table('alumnos_grupos')->insert([
             ['idAlumno' => 'A1', 'idGrupo' => '2LFP'],
@@ -666,6 +726,7 @@ class ReunionFeValuationServiceTest extends TestCase
             ['idAlumno' => 'A6', 'idGrupo' => '2LFP'],
             ['idAlumno' => 'A7', 'idGrupo' => '2LFP'],
             ['idAlumno' => 'A8', 'idGrupo' => '2LFP'],
+            ['idAlumno' => 'A9', 'idGrupo' => '1LFP'],
         ]);
         DB::table('alumno_fcts')->insert([
             ['idFct' => 1, 'idAlumno' => 'A1', 'idProfesor' => 'P1', 'calificacion' => 1, 'calProyecto' => null, 'horas' => 120],
@@ -676,6 +737,7 @@ class ReunionFeValuationServiceTest extends TestCase
             ['idFct' => 6, 'idAlumno' => 'A6', 'idProfesor' => 'P1', 'calificacion' => 3, 'calProyecto' => null, 'horas' => 0],
             ['idFct' => 6, 'idAlumno' => 'A7', 'idProfesor' => 'P1', 'calificacion' => 0, 'calProyecto' => 4, 'horas' => 90],
             ['idFct' => 6, 'idAlumno' => 'A8', 'idProfesor' => 'P1', 'calificacion' => 4, 'calProyecto' => null, 'horas' => 0],
+            ['idFct' => 7, 'idAlumno' => 'A9', 'idProfesor' => 'P1', 'calificacion' => 0, 'calProyecto' => null, 'horas' => 100],
         ]);
     }
 
@@ -687,14 +749,17 @@ class ReunionFeValuationServiceTest extends TestCase
         DB::table('modulos')->insert([
             ['codigo' => 'M1', 'cliteral' => 'Módulo práctico', 'vliteral' => 'Mòdul pràctic'],
             ['codigo' => 'M2', 'cliteral' => 'Módulo de primero', 'vliteral' => 'Mòdul de primer'],
+            ['codigo' => 'M3', 'cliteral' => 'Módulo optativo', 'vliteral' => 'Mòdul optatiu'],
         ]);
         DB::table('modulo_ciclos')->insert([
             ['id' => 1, 'idModulo' => 'M1', 'idCiclo' => 100, 'curso' => '2'],
             ['id' => 2, 'idModulo' => 'M2', 'idCiclo' => 100, 'curso' => '1'],
+            ['id' => 3, 'idModulo' => 'M3', 'idCiclo' => 100, 'curso' => '1'],
         ]);
         DB::table('modulo_grupos')->insert([
             ['id' => 1, 'idModuloCiclo' => 1, 'idGrupo' => '2LFP'],
             ['id' => 2, 'idModuloCiclo' => 2, 'idGrupo' => '2LFP'],
+            ['id' => 3, 'idModuloCiclo' => 3, 'idGrupo' => '1LFP'],
         ]);
         DB::table('alumno_resultados')->insert([
             ['idAlumno' => 'A1', 'idModuloGrupo' => 1, 'nota' => 8],
@@ -702,6 +767,7 @@ class ReunionFeValuationServiceTest extends TestCase
             ['idAlumno' => 'A2', 'idModuloGrupo' => 2, 'nota' => 9],
             ['idAlumno' => 'A4', 'idModuloGrupo' => 1, 'nota' => 5],
             ['idAlumno' => 'A6', 'idModuloGrupo' => 1, 'nota' => 5],
+            ['idAlumno' => 'A9', 'idModuloGrupo' => 3, 'nota' => 8],
         ]);
     }
 
@@ -714,7 +780,7 @@ class ReunionFeValuationServiceTest extends TestCase
     {
         return AlumnoFct::query()
             ->with('Alumno')
-            ->whereIn('idAlumno', ['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8'])
+            ->whereIn('idAlumno', ['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9'])
             ->get();
     }
 


### PR DESCRIPTION
## Què canvia

- Conserva el punt de `Notes Formacio en Centre` si el tutor ja l'ha editat i torna a entrar a l'acta.
- Tracta la FE LFP de 1r amb 100 hores com a `Apte` en l'acta, evitant que entre en el punt de notes pendents.
- Evita que una nota del mòdul optatiu s'arrossegue com si fora la qualificació FE.

## Per què

En tornar a obrir una acta final o extraordinària LFP, el servei recalculava sempre el punt de notes FE a partir de `alumno_resultados`. Això podia substituir modificacions manuals del tutor i fer aparéixer alumnat de FE de 1r amb 100 hores amb la nota del mòdul optatiu.

## Impacte

L'acta respecta els canvis manuals ja guardats i classifica correctament l'alumnat de FE de 1r completada com a apte.

Relacionat amb #215.

## Validació

- `php artisan test --filter=ReunionFeValuationServiceTest`
- `php -l app/Application/Reunion/ReunionFeValuationService.php`
- `php -l tests/Unit/Application/Reunion/ReunionFeValuationServiceTest.php`