### PR TITLE
[FIX] Restringeix certificat FOL a primer

### DIFF
--- a/app/Http/Controllers/AlumnoGrupoController.php
+++ b/app/Http/Controllers/AlumnoGrupoController.php
@@ -10,6 +10,9 @@ use Intranet\UI\Botones\BotonIcon;
 use Intranet\UI\Botones\BotonImg;
 use Intranet\Entities\Curso;
 
+/**
+ * Controlador del llistat modal d'alumnat associat a un grup.
+ */
 class AlumnoGrupoController extends ModalController
 {
     protected $perfil = 'profesor';
@@ -105,8 +108,8 @@ class AlumnoGrupoController extends ModalController
         $this->panel->setBoton('profile', new BotonIcon('alumno.carnet', ['where' => ['idGrupo', '==',  $grupoTutoria]]));
         $this->panel->setBoton('grid', new BotonImg('direccion.aFol', ['img' => 'fa-file-word-o','roles' => config('roles.rol.direccion')]));
         if (AuthUser()->departamento == self::FOL && date('Y-m-d')>config('variables.certificatFol')) {
-            $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-square-o', 'where' => ['fol', '==', 0]]));
-            $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-check', 'where' => ['fol', '==', 1]]));
+            $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-square-o', 'where' => $this->folCertificateButtonWhere(0)]));
+            $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-check', 'where' => $this->folCertificateButtonWhere(1)]));
         }
         $cursos = Curso::Activo()->get();
         foreach ($cursos as $curso) {
@@ -126,6 +129,17 @@ class AlumnoGrupoController extends ModalController
             )
         );
         
+    }
+
+    /**
+     * Restringeix la comprovació individual del certificat FOL a alumnat de primer curs.
+     *
+     * @param int $fol Estat actual del certificat FOL de l'alumne.
+     * @return array<int, int|string>
+     */
+    protected function folCertificateButtonWhere(int $fol): array
+    {
+        return ['fol', '==', $fol, 'curso', '==', 1];
     }
 
 }

--- a/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
+++ b/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Intranet\Http\Controllers\AlumnoGrupoController;
+use Intranet\UI\Botones\BotonImg;
+use Tests\TestCase;
+
+/**
+ * Proves de la visibilitat del botó individual del certificat FOL en alumnat de grup.
+ */
+class AlumnoGrupoControllerFolButtonTest extends TestCase
+{
+    public function test_boto_de_certificat_fol_nomes_renderitza_en_alumnat_de_primer(): void
+    {
+        config()->set('app.url', 'http://intranet.test');
+
+        $where = $this->controller()->folWhere(0);
+        $boto = new BotonImg('alumno.checkFol', [
+            'img' => 'fa-square-o',
+            'text' => 'Li correspon Certificat Fol',
+            'where' => $where,
+        ]);
+
+        $primer = $this->makeElement(['id' => 1, 'fol' => 0, 'curso' => 1]);
+        $segon = $this->makeElement(['id' => 2, 'fol' => 0, 'curso' => 2]);
+
+        $this->assertSame(['fol', '==', 0, 'curso', '==', 1], $where);
+        $this->assertStringContainsString('http://intranet.test/alumno/1/checkFol', $boto->render($primer));
+        $this->assertSame('', $boto->render($segon));
+
+        $whereMarcat = $this->controller()->folWhere(1);
+        $botoMarcat = new BotonImg('alumno.checkFol', [
+            'img' => 'fa-check',
+            'text' => 'Li correspon Certificat Fol',
+            'where' => $whereMarcat,
+        ]);
+
+        $primerMarcat = $this->makeElement(['id' => 3, 'fol' => 1, 'curso' => 1]);
+        $segonMarcat = $this->makeElement(['id' => 4, 'fol' => 1, 'curso' => 2]);
+
+        $this->assertSame(['fol', '==', 1, 'curso', '==', 1], $whereMarcat);
+        $this->assertStringContainsString('http://intranet.test/alumno/3/checkFol', $botoMarcat->render($primerMarcat));
+        $this->assertSame('', $botoMarcat->render($segonMarcat));
+    }
+
+    private function controller(): object
+    {
+        return new class extends AlumnoGrupoController {
+            /**
+             * Exposa la condició del botó FOL per a provar-la sense renderitzar el panell complet.
+             *
+             * @param int $fol Estat actual del certificat FOL de l'alumne.
+             * @return array<int, int|string>
+             */
+            public function folWhere(int $fol): array
+            {
+                return $this->folCertificateButtonWhere($fol);
+            }
+        };
+    }
+
+    private function makeElement(array $values): object
+    {
+        return new class($values) {
+            public function __construct(private array $values)
+            {
+                foreach ($values as $key => $value) {
+                    $this->$key = $value;
+                }
+            }
+
+            public function getKey(): int|string|null
+            {
+                return $this->values['id'] ?? null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Què canvia

- Restringeix els botons individuals `alumno.checkFol` perquè només es renderitzen en registres d'alumnat de primer curs (`curso == 1`).
- Manté les condicions existents: usuari del departament de FOL i data posterior a `variables.certificatFol`.
- Afig una regressió unitària que comprova les dos variants del botó (`fol == 0` i `fol == 1`) en alumnat de primer i segon.

## Impacte

El professorat de FOL ja no veurà l'opció de comprovació individual del certificat FOL en alumnat de segon. L'emissió de certificats i l'estat global del grup no canvien.

Closes #290

## Validació

- `php -l app/Http/Controllers/AlumnoGrupoController.php` ✅
- `php -l tests/Unit/AlumnoGrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=AlumnoGrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `docker compose ps` ⚠️ no hi ha contenidors actius per executar el test dins `laravel.test`.