### PR TITLE
[FIX] Resol curs FOL des del grup

### DIFF
--- a/app/Entities/AlumnoGrupo.php
+++ b/app/Entities/AlumnoGrupo.php
@@ -82,6 +82,15 @@ class AlumnoGrupo extends Model
     {
         return $this->Alumno->fol;
     }
+
+    /**
+     * Retorna el curs acadèmic del grup on està matriculat l'alumne.
+     */
+    public function getCursoAttribute()
+    {
+        return $this->Grupo?->curso;
+    }
+
     public function getFotoAttribute()
     {
         return $this->Alumno->foto;

--- a/app/Http/Controllers/AlumnoGrupoController.php
+++ b/app/Http/Controllers/AlumnoGrupoController.php
@@ -42,7 +42,9 @@ class AlumnoGrupoController extends ModalController
     public function search()
     {
         $this->titulo = ['quien' => $this->search];
-        return AlumnoGrupo::where('idGrupo', $this->search)->get();
+        return AlumnoGrupo::with(['Alumno', 'Grupo'])
+            ->where('idGrupo', $this->search)
+            ->get();
     }
 
     /*

--- a/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
+++ b/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Intranet\Entities\Alumno;
+use Intranet\Entities\AlumnoGrupo;
+use Intranet\Entities\Grupo;
 use Intranet\Http\Controllers\AlumnoGrupoController;
 use Intranet\UI\Botones\BotonImg;
 use Tests\TestCase;
@@ -24,8 +27,8 @@ class AlumnoGrupoControllerFolButtonTest extends TestCase
             'where' => $where,
         ]);
 
-        $primer = $this->makeElement(['id' => 1, 'fol' => 0, 'curso' => 1]);
-        $segon = $this->makeElement(['id' => 2, 'fol' => 0, 'curso' => 2]);
+        $primer = $this->makeAlumnoGrupo('1', 0, 1);
+        $segon = $this->makeAlumnoGrupo('2', 0, 2);
 
         $this->assertSame(['fol', '==', 0, 'curso', '==', 1], $where);
         $this->assertStringContainsString('http://intranet.test/alumno/1/checkFol', $boto->render($primer));
@@ -38,8 +41,8 @@ class AlumnoGrupoControllerFolButtonTest extends TestCase
             'where' => $whereMarcat,
         ]);
 
-        $primerMarcat = $this->makeElement(['id' => 3, 'fol' => 1, 'curso' => 1]);
-        $segonMarcat = $this->makeElement(['id' => 4, 'fol' => 1, 'curso' => 2]);
+        $primerMarcat = $this->makeAlumnoGrupo('3', 1, 1);
+        $segonMarcat = $this->makeAlumnoGrupo('4', 1, 2);
 
         $this->assertSame(['fol', '==', 1, 'curso', '==', 1], $whereMarcat);
         $this->assertStringContainsString('http://intranet.test/alumno/3/checkFol', $botoMarcat->render($primerMarcat));
@@ -62,20 +65,22 @@ class AlumnoGrupoControllerFolButtonTest extends TestCase
         };
     }
 
-    private function makeElement(array $values): object
+    private function makeAlumnoGrupo(string $nia, int $fol, int $curso): AlumnoGrupo
     {
-        return new class($values) {
-            public function __construct(private array $values)
-            {
-                foreach ($values as $key => $value) {
-                    $this->$key = $value;
-                }
-            }
+        $alumne = new Alumno();
+        $alumne->nia = $nia;
+        $alumne->fol = $fol;
 
-            public function getKey(): int|string|null
-            {
-                return $this->values['id'] ?? null;
-            }
-        };
+        $grup = new Grupo();
+        $grup->codigo = 'G' . $curso;
+        $grup->curso = $curso;
+
+        $alumneGrup = new AlumnoGrupo();
+        $alumneGrup->idAlumno = $nia;
+        $alumneGrup->idGrupo = $grup->codigo;
+        $alumneGrup->setRelation('Alumno', $alumne);
+        $alumneGrup->setRelation('Grupo', $grup);
+
+        return $alumneGrup;
     }
 }

--- a/tests/Unit/Entities/AlumnoGrupoTest.php
+++ b/tests/Unit/Entities/AlumnoGrupoTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Intranet\Entities\AlumnoGrupo;
+use Intranet\Entities\Grupo;
 use Tests\TestCase;
 
 class AlumnoGrupoTest extends TestCase
@@ -45,6 +46,17 @@ class AlumnoGrupoTest extends TestCase
 
         $this->assertNotNull($row);
         $this->assertSame('A002', $row->idAlumno);
+    }
+
+    public function test_curso_resol_el_curs_del_grup_associat(): void
+    {
+        $grupo = new Grupo();
+        $grupo->curso = 1;
+
+        $alumnoGrupo = new AlumnoGrupo();
+        $alumnoGrupo->setRelation('Grupo', $grupo);
+
+        $this->assertSame(1, $alumnoGrupo->curso);
     }
 
     private function createSchema(): void


### PR DESCRIPTION
## Què canvia

- Exposa `AlumnoGrupo->curso` a partir de `AlumnoGrupo->Grupo->curso`, que és on realment viu el curs del grup.
- Carrega `Alumno` i `Grupo` en la cerca del llistat d'alumnat del grup per evitar que la graella resolga el curs sense relació carregada.
- Ajusta el test del botó FOL perquè use entitats reals `AlumnoGrupo`, `Alumno` i `Grupo`, no un objecte artificial amb `curso` directe.
- Afig una prova específica de l'accessor `AlumnoGrupo->curso`.

## Motiu

El PR #291 va restringir el botó per `curso == 1`, però `alumnos_grupos` no té columna `curso`; el camp està en `grupos`. Sense este accessor, el botó no podia decidir correctament si l'alumnat era de primer o segon.

Relates #290

## Validació

- `php -l app/Http/Controllers/AlumnoGrupoController.php` ✅
- `php -l app/Entities/AlumnoGrupo.php` ✅
- `php -l tests/Unit/AlumnoGrupoControllerFolButtonTest.php` ✅
- `php -l tests/Unit/Entities/AlumnoGrupoTest.php` ✅
- `git diff --check` ✅
- PHPUnit no executat localment: falta `vendor/autoload.php`.