### PR TITLE
[FIX] Mostra certificat FOL en grups de primer

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -124,12 +124,12 @@ class GrupoController extends IntranetController
 
 
         if (AuthUser()->xdepartamento === 'Fol' && date('Y-m-d') > config('variables.certificatFol')) {
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>['fol','==', 0]]));
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>['fol','==', 1]]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>$this->folCertificateButtonWhere(0)]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>$this->folCertificateButtonWhere(1)]));
         }
 
         $this->panel->setBoton('grid',new BotonImg('direccion.fol',
-            ['img' => 'fa-file-word-o','roles' => config(self::DIRECCION),'where'=>['fol','==', 1]]));
+            ['img' => 'fa-file-word-o','roles' => config(self::DIRECCION),'where'=>$this->folCertificateButtonWhere(1)]));
         $cursos = Curso::Activo()->get();
         foreach ($cursos as $curso) {
             if (($curso->aforo == 0) || ($curso->NAlumnos < $curso->aforo * config('variables.reservaAforo'))){
@@ -137,6 +137,17 @@ class GrupoController extends IntranetController
 
             }
         }
+    }
+
+    /**
+     * Restringeix la comprovació de certificats FOL als grups de primer curs.
+     *
+     * @param int $fol Estat actual de comprovació FOL del grup.
+     * @return array<int, int|string>
+     */
+    protected function folCertificateButtonWhere(int $fol): array
+    {
+        return ['fol', '==', $fol, 'curso', '==', 1];
     }
 
     /**

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Intranet\Entities\Grupo;
+use Intranet\Http\Controllers\GrupoController;
+use Intranet\UI\Botones\BotonImg;
+use Tests\TestCase;
+
+/**
+ * Proves de la visibilitat del botó de comprovació FOL en la graella de grups.
+ */
+class GrupoControllerFolButtonTest extends TestCase
+{
+    public function test_boto_de_certificat_fol_de_grup_nomes_renderitza_en_grups_de_primer(): void
+    {
+        config()->set('app.url', 'http://intranet.test');
+
+        $where = $this->controller()->folWhere(0);
+        $boto = new BotonImg('grupo.fol', [
+            'img' => 'fa-square-o',
+            'text' => 'Comprovat a quin alumnat li correspon Certificat fol',
+            'where' => $where,
+        ]);
+
+        $primer = $this->makeGrupo('1CF', 0, 1);
+        $segon = $this->makeGrupo('2CF', 0, 2);
+
+        $this->assertSame(['fol', '==', 0, 'curso', '==', 1], $where);
+        $this->assertStringContainsString('http://intranet.test/grupo/1CF/fol', $boto->render($primer));
+        $this->assertSame('', $boto->render($segon));
+
+        $whereMarcat = $this->controller()->folWhere(1);
+        $botoMarcat = new BotonImg('grupo.fol', [
+            'img' => 'fa-check',
+            'text' => 'Comprovat a quin alumnat li correspon Certificat fol',
+            'where' => $whereMarcat,
+        ]);
+
+        $primerMarcat = $this->makeGrupo('1DAW', 1, 1);
+        $segonMarcat = $this->makeGrupo('2DAW', 1, 2);
+
+        $this->assertSame(['fol', '==', 1, 'curso', '==', 1], $whereMarcat);
+        $this->assertStringContainsString('http://intranet.test/grupo/1DAW/fol', $botoMarcat->render($primerMarcat));
+        $this->assertSame('', $botoMarcat->render($segonMarcat));
+    }
+
+    private function controller(): object
+    {
+        return new class extends GrupoController {
+            /**
+             * Exposa la condició del botó FOL per a provar-la sense renderitzar el panell complet.
+             *
+             * @param int $fol Estat actual de comprovació FOL del grup.
+             * @return array<int, int|string>
+             */
+            public function folWhere(int $fol): array
+            {
+                return $this->folCertificateButtonWhere($fol);
+            }
+        };
+    }
+
+    private function makeGrupo(string $codigo, int $fol, int $curso): Grupo
+    {
+        $grupo = new Grupo();
+        $grupo->codigo = $codigo;
+        $grupo->fol = $fol;
+        $grupo->curso = $curso;
+
+        return $grupo;
+    }
+}


### PR DESCRIPTION
## Què canvia

- Restringeix els botons `grupo.fol` de la vista `/grupo` perquè només es mostren en grups de primer curs (`curso == 1`).
- Aplica la mateixa restricció al botó de direcció `direccion.fol` per evitar accions FOL en grups de segon amb estat antic `fol == 1`.
- Afig una regressió unitària que comprova les dos variants del botó (`fol == 0` i `fol == 1`) en grups de primer i segon.

## Motiu

Els PRs anteriors havien corregit la graella d'alumnat (`alumno.checkFol`), però la vista `/grupo` usa `GrupoController::iniBotones()` i encara no filtrava per curs.

Relates #290

## Validació

- `php -l app/Http/Controllers/GrupoController.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.