### PR TITLE
[FIX] Usa departament FOL numeric en grups

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -30,6 +30,7 @@ class GrupoController extends IntranetController
     const DIRECCION ='roles.rol.direccion';
     const TUTOR ='roles.rol.tutor';
     const ORIENTADOR ='roles.rol.orientador';
+    const FOL = 12;
 
 
     use Imprimir;
@@ -123,7 +124,7 @@ class GrupoController extends IntranetController
 
 
 
-        if (AuthUser()->xdepartamento === 'Fol' && date('Y-m-d') > config('variables.certificatFol')) {
+        if ($this->isFolTeacher() && date('Y-m-d') > config('variables.certificatFol')) {
             $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>$this->folCertificateButtonWhere(0)]));
             $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>$this->folCertificateButtonWhere(1)]));
         }
@@ -148,6 +149,14 @@ class GrupoController extends IntranetController
     protected function folCertificateButtonWhere(int $fol): array
     {
         return ['fol', '==', $fol, 'curso', '==', 1];
+    }
+
+    /**
+     * Indica si l'usuari autenticat pertany al departament de FOL.
+     */
+    protected function isFolTeacher(): bool
+    {
+        return (int) AuthUser()->departamento === self::FOL;
     }
 
     /**

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Auth;
 use Intranet\Entities\Grupo;
+use Intranet\Entities\Profesor;
 use Intranet\Http\Controllers\GrupoController;
 use Intranet\UI\Botones\BotonImg;
 use Tests\TestCase;
@@ -47,6 +49,23 @@ class GrupoControllerFolButtonTest extends TestCase
         $this->assertSame('', $botoMarcat->render($segonMarcat));
     }
 
+    public function test_botonera_fol_usa_el_departament_numeric_de_fol(): void
+    {
+        Auth::guard('profesor')->setUser(new Profesor([
+            'dni' => 'FOL01',
+            'departamento' => 12,
+        ]));
+
+        $this->assertTrue($this->controller()->isFol());
+
+        Auth::guard('profesor')->setUser(new Profesor([
+            'dni' => 'INF01',
+            'departamento' => 1,
+        ]));
+
+        $this->assertFalse($this->controller()->isFol());
+    }
+
     private function controller(): object
     {
         return new class extends GrupoController {
@@ -59,6 +78,14 @@ class GrupoControllerFolButtonTest extends TestCase
             public function folWhere(int $fol): array
             {
                 return $this->folCertificateButtonWhere($fol);
+            }
+
+            /**
+             * Exposa el criteri de departament FOL per a provar-lo.
+             */
+            public function isFol(): bool
+            {
+                return $this->isFolTeacher();
             }
         };
     }


### PR DESCRIPTION
## Què canvia

- Canvia el criteri que habilita la botonera FOL en `/grupo`: deixa d'usar `AuthUser()->xdepartamento === 'Fol'` i passa a usar el departament numèric `12`, igual que `AlumnoGrupoController`.
- Afig `GrupoController::isFolTeacher()` per centralitzar el criteri.
- Amplia `GrupoControllerFolButtonTest` per comprovar que el departament `12` activa el criteri FOL i un altre departament no.

## Motiu

El botó podia no aparéixer si el literal curt del departament no coincidia exactament amb `Fol` (majúscules/minúscules o relació no carregada). La pantalla d'alumnat ja usava el departament numèric, que és més estable.

Relates #290

## Validació

- `php -l app/Http/Controllers/GrupoController.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.