### PR TITLE
[FIX] Detecta grups FOL de primer per curs o codi

### DIFF
--- a/app/Entities/Grupo.php
+++ b/app/Entities/Grupo.php
@@ -174,6 +174,15 @@ class Grupo extends Model
         return $query->where('curso', $curso);
     }
 
+    /**
+     * Indica si el grup ha de mostrar les accions de comprovació del certificat FOL.
+     */
+    public function getFolCertificableAttribute(): bool
+    {
+        return (int) $this->curso === 1
+            || str_starts_with(trim((string) $this->codigo), '1');
+    }
+
     public function getProyectoAttribute()
     {
         $ciclo = $this->Ciclo;

--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -148,7 +148,7 @@ class GrupoController extends IntranetController
      */
     protected function folCertificateButtonWhere(int $fol): array
     {
-        return ['fol', '==', $fol, 'curso', '==', 1];
+        return ['fol', '==', $fol, 'folCertificable', '==', true];
     }
 
     /**

--- a/tests/Unit/Entities/GrupoTest.php
+++ b/tests/Unit/Entities/GrupoTest.php
@@ -143,6 +143,25 @@ class GrupoTest extends TestCase
         $this->assertSame(['GB'], $codigos);
     }
 
+    public function test_accessor_fol_certificable_detecta_grups_de_primer_per_curs_o_codi(): void
+    {
+        $primerPerCurs = new Grupo();
+        $primerPerCurs->codigo = 'CF';
+        $primerPerCurs->curso = 1;
+
+        $primerPerCodi = new Grupo();
+        $primerPerCodi->codigo = '1DAW';
+        $primerPerCodi->curso = 2;
+
+        $segon = new Grupo();
+        $segon->codigo = '2DAW';
+        $segon->curso = 2;
+
+        $this->assertTrue($primerPerCurs->folCertificable);
+        $this->assertTrue($primerPerCodi->folCertificable);
+        $this->assertFalse($segon->folCertificable);
+    }
+
     public function test_scope_departamento_filtra_grups_per_cicle(): void
     {
         DB::table('ciclos')->insert([

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -30,7 +30,7 @@ class GrupoControllerFolButtonTest extends TestCase
         $primer = $this->makeGrupo('1CF', 0, 1);
         $segon = $this->makeGrupo('2CF', 0, 2);
 
-        $this->assertSame(['fol', '==', 0, 'curso', '==', 1], $where);
+        $this->assertSame(['fol', '==', 0, 'folCertificable', '==', true], $where);
         $this->assertStringContainsString('http://intranet.test/grupo/1CF/fol', $boto->render($primer));
         $this->assertSame('', $boto->render($segon));
 
@@ -44,7 +44,7 @@ class GrupoControllerFolButtonTest extends TestCase
         $primerMarcat = $this->makeGrupo('1DAW', 1, 1);
         $segonMarcat = $this->makeGrupo('2DAW', 1, 2);
 
-        $this->assertSame(['fol', '==', 1, 'curso', '==', 1], $whereMarcat);
+        $this->assertSame(['fol', '==', 1, 'folCertificable', '==', true], $whereMarcat);
         $this->assertStringContainsString('http://intranet.test/grupo/1DAW/fol', $botoMarcat->render($primerMarcat));
         $this->assertSame('', $botoMarcat->render($segonMarcat));
     }


### PR DESCRIPTION
## Què canvia

- Afig `Grupo::folCertificable` per decidir si un grup ha de mostrar accions FOL.
- Considera de primer els grups amb `curso == 1` o amb codi que comença per `1`, per cobrir dades reals on `curso` no estiga informant com esperem.
- `GrupoController` deixa de filtrar directament per `curso` i usa `folCertificable`.
- Amplia tests de model i controlador.

## Motiu

Els botons de `/grupo` continuaven sense aparéixer perquè la condició directa `curso == 1` era massa fràgil en les dades reals. El botó ha de mostrar-se en grups de primer encara que el camp `curso` no arribe amb el valor esperat.

Fixes #290

## Validació

- `php -l app/Entities/Grupo.php` ✅
- `php -l app/Http/Controllers/GrupoController.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `php -l tests/Unit/Entities/GrupoTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.