### PR TITLE
[FIX] Restaura botons FOL per departament literal

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -156,7 +156,10 @@ class GrupoController extends IntranetController
      */
     protected function isFolTeacher(): bool
     {
-        return (int) AuthUser()->departamento === self::FOL;
+        $profesor = AuthUser();
+
+        return (int) $profesor->departamento === self::FOL
+            || strtolower((string) $profesor->xdepartamento) === 'fol';
     }
 
     /**

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Illuminate\Support\Facades\Auth;
+use Intranet\Entities\Departamento;
 use Intranet\Entities\Grupo;
 use Intranet\Entities\Profesor;
 use Intranet\Http\Controllers\GrupoController;
@@ -49,12 +50,24 @@ class GrupoControllerFolButtonTest extends TestCase
         $this->assertSame('', $botoMarcat->render($segonMarcat));
     }
 
-    public function test_botonera_fol_usa_el_departament_numeric_de_fol(): void
+    public function test_botonera_fol_usa_el_departament_numeric_o_literal_de_fol(): void
     {
         Auth::guard('profesor')->setUser(new Profesor([
             'dni' => 'FOL01',
             'departamento' => 12,
         ]));
+
+        $this->assertTrue($this->controller()->isFol());
+
+        $profesorFolLiteral = new Profesor([
+            'dni' => 'FOL02',
+            'departamento' => 99,
+        ]);
+        $profesorFolLiteral->setRelation('Departamento', new Departamento([
+            'depcurt' => 'Fol',
+        ]));
+
+        Auth::guard('profesor')->setUser($profesorFolLiteral);
 
         $this->assertTrue($this->controller()->isFol());
 


### PR DESCRIPTION
## Què canvia

- `GrupoController::isFolTeacher()` torna a acceptar el departament literal `xdepartamento = Fol` a més del codi numèric `departamento = 12`.
- El filtre de grups de primer es manté, de manera que els botons FOL no tornen a aparéixer en grups de segon.
- El test de la botonera cobreix tant el cas numèric com el cas literal.

## Motiu

El canvi anterior havia substituït la comprovació antiga `xdepartamento === 'Fol'` per `departamento === 12`. En producció, la professora de FOL pot estar arribant amb el departament resolt pel literal `Fol`; en eixe cas el bloc que crea els botons ni tan sols s'executava i no apareixia cap botó en `/grupo`.

Relates #290

## Validació

- `php -l app/Http/Controllers/GrupoController.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `docker compose ps` ⚠️ sense contenidors actius per executar la prova dins Docker.