### PR TITLE
[FIX] Normalitza departament i data dels botons FOL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ PDF_DRIVER="SnappyPdf"
 WKHTMLTOPDF_BINARY="/usr/local/bin/wkhtmltopdf"
 WKHTMLTOIMAGE_BINARY="/usr/local/bin/wkhtmltoimage"
 PDFTK_BINARY="/usr/local/bin/pdftk"
+CERTIFICAT_FOL_DATE=
 
 # Laravel Nova
 NOVA_GUARD="profesor"

--- a/app/Http/Controllers/AlumnoGrupoController.php
+++ b/app/Http/Controllers/AlumnoGrupoController.php
@@ -109,7 +109,7 @@ class AlumnoGrupoController extends ModalController
         $this->panel->setBoton('grid', new BotonImg('alumno.carnet', ['where' => ['idGrupo', '==',  $grupoTutoria]]));
         $this->panel->setBoton('profile', new BotonIcon('alumno.carnet', ['where' => ['idGrupo', '==',  $grupoTutoria]]));
         $this->panel->setBoton('grid', new BotonImg('direccion.aFol', ['img' => 'fa-file-word-o','roles' => config('roles.rol.direccion')]));
-        if (AuthUser()->departamento == self::FOL && date('Y-m-d')>config('variables.certificatFol')) {
+        if (AuthUser()->departamento == self::FOL && $this->folCertificatePeriodIsOpen()) {
             $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-square-o', 'where' => $this->folCertificateButtonWhere(0)]));
             $this->panel->setBoton('grid', new BotonImg('alumno.checkFol', ['img' => 'fa-check', 'where' => $this->folCertificateButtonWhere(1)]));
         }
@@ -142,6 +142,20 @@ class AlumnoGrupoController extends ModalController
     protected function folCertificateButtonWhere(int $fol): array
     {
         return ['fol', '==', $fol, 'curso', '==', 1];
+    }
+
+    /**
+     * Indica si el període de comprovació FOL està obert.
+     */
+    protected function folCertificatePeriodIsOpen(): bool
+    {
+        $startDate = trim((string) config('variables.certificatFol', ''));
+
+        if ($startDate === '' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $startDate)) {
+            return true;
+        }
+
+        return date('Y-m-d') > $startDate;
     }
 
 }

--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -124,7 +124,7 @@ class GrupoController extends IntranetController
 
 
 
-        if ($this->isFolTeacher() && date('Y-m-d') > config('variables.certificatFol')) {
+        if ($this->isFolTeacher() && $this->folCertificatePeriodIsOpen()) {
             $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>$this->folCertificateButtonWhere(0)]));
             $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>$this->folCertificateButtonWhere(1)]));
         }
@@ -161,6 +161,20 @@ class GrupoController extends IntranetController
 
         return (int) $profesor->departamento === self::FOL
             || $departamentoLiteral === 'fol';
+    }
+
+    /**
+     * Indica si el període de comprovació FOL està obert.
+     */
+    protected function folCertificatePeriodIsOpen(): bool
+    {
+        $startDate = trim((string) config('variables.certificatFol', ''));
+
+        if ($startDate === '' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $startDate)) {
+            return true;
+        }
+
+        return date('Y-m-d') > $startDate;
     }
 
     /**

--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -157,9 +157,10 @@ class GrupoController extends IntranetController
     protected function isFolTeacher(): bool
     {
         $profesor = AuthUser();
+        $departamentoLiteral = strtolower(trim((string) $profesor->xdepartamento));
 
         return (int) $profesor->departamento === self::FOL
-            || strtolower((string) $profesor->xdepartamento) === 'fol';
+            || $departamentoLiteral === 'fol';
     }
 
     /**

--- a/config/variables.php
+++ b/config/variables.php
@@ -7,6 +7,7 @@ return [
     'comisionFCTexterna' => 1,
     'httpFCTexterna' => 'http://www.fpxativa.es/admin',
     'enquestaInstructor' => 'https://forms.office.com/r/rMqmGzMbTn',
+    'certificatFol' => env('CERTIFICAT_FOL_DATE', null),
     'actividadImg' => 0,
     'altaInstructores' => 0,
     'ipDomotica' => env('DOMOTICA_DEVICE_ENDPOINT', 'http://172.16.10.74/api/devices/{dispositivo}/action'),

--- a/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
+++ b/tests/Unit/AlumnoGrupoControllerFolButtonTest.php
@@ -49,6 +49,15 @@ class AlumnoGrupoControllerFolButtonTest extends TestCase
         $this->assertSame('', $botoMarcat->render($segonMarcat));
     }
 
+    public function test_periode_fol_no_amaga_botons_si_la_variable_no_esta_configurada(): void
+    {
+        config()->set('variables.certificatFol', null);
+        $this->assertTrue($this->controller()->folPeriodIsOpen());
+
+        config()->set('variables.certificatFol', date('Y-m-d', strtotime('+1 day')));
+        $this->assertFalse($this->controller()->folPeriodIsOpen());
+    }
+
     private function controller(): object
     {
         return new class extends AlumnoGrupoController {
@@ -61,6 +70,14 @@ class AlumnoGrupoControllerFolButtonTest extends TestCase
             public function folWhere(int $fol): array
             {
                 return $this->folCertificateButtonWhere($fol);
+            }
+
+            /**
+             * Exposa la finestra temporal FOL per provar configuració absent.
+             */
+            public function folPeriodIsOpen(): bool
+            {
+                return $this->folCertificatePeriodIsOpen();
             }
         };
     }

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -64,7 +64,7 @@ class GrupoControllerFolButtonTest extends TestCase
             'departamento' => 99,
         ]);
         $profesorFolLiteral->setRelation('Departamento', new Departamento([
-            'depcurt' => 'Fol',
+            'depcurt' => ' FOL ',
         ]));
 
         Auth::guard('profesor')->setUser($profesorFolLiteral);

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -79,6 +79,24 @@ class GrupoControllerFolButtonTest extends TestCase
         $this->assertFalse($this->controller()->isFol());
     }
 
+    public function test_periode_fol_no_amaga_botons_si_la_variable_no_esta_configurada(): void
+    {
+        config()->set('variables.certificatFol', null);
+        $this->assertTrue($this->controller()->folPeriodIsOpen());
+
+        config()->set('variables.certificatFol', '');
+        $this->assertTrue($this->controller()->folPeriodIsOpen());
+
+        config()->set('variables.certificatFol', 'data-no-valida');
+        $this->assertTrue($this->controller()->folPeriodIsOpen());
+
+        config()->set('variables.certificatFol', date('Y-m-d', strtotime('+1 day')));
+        $this->assertFalse($this->controller()->folPeriodIsOpen());
+
+        config()->set('variables.certificatFol', date('Y-m-d', strtotime('-1 day')));
+        $this->assertTrue($this->controller()->folPeriodIsOpen());
+    }
+
     private function controller(): object
     {
         return new class extends GrupoController {
@@ -99,6 +117,14 @@ class GrupoControllerFolButtonTest extends TestCase
             public function isFol(): bool
             {
                 return $this->isFolTeacher();
+            }
+
+            /**
+             * Exposa la finestra temporal FOL per provar configuració absent o mal formada.
+             */
+            public function folPeriodIsOpen(): bool
+            {
+                return $this->folCertificatePeriodIsOpen();
             }
         };
     }


### PR DESCRIPTION
## Què canvia

- Normalitza `xdepartamento` amb `trim()` i minúscules perquè `Fol`, `FOL`, `fol` o valors amb espais no amaguen la botonera FOL.
- Declara `variables.certificatFol` en `config/variables.php` amb `CERTIFICAT_FOL_DATE` en `.env.example`.
- Encapsula la finestra temporal FOL en `folCertificatePeriodIsOpen()` en `/grupo` i en alumnat de grup.
- Si `certificatFol` no existeix, està buida o està mal formada, la botonera no s'amaga. Si té una data futura `Y-m-d`, es continua respectant el bloqueig.
- Afig tests per a la normalització del departament i per a la variable absent, buida, mal formada, futura i passada.

## Motiu

La clau `variables.certificatFol` s'estava usant però no estava declarada en `config/variables.php`. Això deixava la visibilitat dels botons depenent d'una configuració implícita o de cache de producció. A més, un literal de departament amb majúscules o espais podia impedir que es crearen els botons.

Relates #290

## Validació

- `php -l config/variables.php` ✅
- `php -l app/Http/Controllers/GrupoController.php` ✅
- `php -l app/Http/Controllers/AlumnoGrupoController.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `php -l tests/Unit/AlumnoGrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `php artisan test --filter=AlumnoGrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `docker compose ps` ⚠️ sense contenidors actius per executar la prova dins Docker.