### PR TITLE
[FIX] Detecta primer FOL amb codis de grup flexibles

### DIFF
--- a/app/Entities/Grupo.php
+++ b/app/Entities/Grupo.php
@@ -179,8 +179,27 @@ class Grupo extends Model
      */
     public function getFolCertificableAttribute(): bool
     {
-        return (int) $this->curso === 1
-            || str_starts_with(trim((string) $this->codigo), '1');
+        if ((int) $this->curso === 1) {
+            return true;
+        }
+
+        foreach ([$this->codigo, $this->nombre] as $value) {
+            $text = strtolower(trim((string) $value));
+
+            if ($text === '') {
+                continue;
+            }
+
+            if (preg_match('/\b(1r?|primer|primero)\b/u', $text)) {
+                return true;
+            }
+
+            if (preg_match('/\d/', $text, $matches)) {
+                return $matches[0] === '1';
+            }
+        }
+
+        return false;
     }
 
     public function getProyectoAttribute()

--- a/tests/Unit/Entities/GrupoTest.php
+++ b/tests/Unit/Entities/GrupoTest.php
@@ -147,18 +147,33 @@ class GrupoTest extends TestCase
     {
         $primerPerCurs = new Grupo();
         $primerPerCurs->codigo = 'CF';
+        $primerPerCurs->nombre = 'Cicle formatiu';
         $primerPerCurs->curso = 1;
 
-        $primerPerCodi = new Grupo();
-        $primerPerCodi->codigo = '1DAW';
-        $primerPerCodi->curso = 2;
+        $primerPerCodiInicial = new Grupo();
+        $primerPerCodiInicial->codigo = '1DAW';
+        $primerPerCodiInicial->nombre = 'Desenvolupament web';
+        $primerPerCodiInicial->curso = 2;
+
+        $primerPerCodiFinal = new Grupo();
+        $primerPerCodiFinal->codigo = 'DAW1';
+        $primerPerCodiFinal->nombre = 'Desenvolupament web';
+        $primerPerCodiFinal->curso = 2;
+
+        $primerPerNom = new Grupo();
+        $primerPerNom->codigo = 'DAW';
+        $primerPerNom->nombre = 'Primer DAW';
+        $primerPerNom->curso = 2;
 
         $segon = new Grupo();
-        $segon->codigo = '2DAW';
+        $segon->codigo = 'DAW2';
+        $segon->nombre = 'Segon DAW';
         $segon->curso = 2;
 
         $this->assertTrue($primerPerCurs->folCertificable);
-        $this->assertTrue($primerPerCodi->folCertificable);
+        $this->assertTrue($primerPerCodiInicial->folCertificable);
+        $this->assertTrue($primerPerCodiFinal->folCertificable);
+        $this->assertTrue($primerPerNom->folCertificable);
         $this->assertFalse($segon->folCertificable);
     }
 

--- a/tests/Unit/GrupoControllerFolButtonTest.php
+++ b/tests/Unit/GrupoControllerFolButtonTest.php
@@ -28,11 +28,11 @@ class GrupoControllerFolButtonTest extends TestCase
             'where' => $where,
         ]);
 
-        $primer = $this->makeGrupo('1CF', 0, 1);
+        $primer = $this->makeGrupo('CF1', 0, 2);
         $segon = $this->makeGrupo('2CF', 0, 2);
 
         $this->assertSame(['fol', '==', 0, 'folCertificable', '==', true], $where);
-        $this->assertStringContainsString('http://intranet.test/grupo/1CF/fol', $boto->render($primer));
+        $this->assertStringContainsString('http://intranet.test/grupo/CF1/fol', $boto->render($primer));
         $this->assertSame('', $boto->render($segon));
 
         $whereMarcat = $this->controller()->folWhere(1);
@@ -42,11 +42,11 @@ class GrupoControllerFolButtonTest extends TestCase
             'where' => $whereMarcat,
         ]);
 
-        $primerMarcat = $this->makeGrupo('1DAW', 1, 1);
-        $segonMarcat = $this->makeGrupo('2DAW', 1, 2);
+        $primerMarcat = $this->makeGrupo('DAW1', 1, 2);
+        $segonMarcat = $this->makeGrupo('DAW2', 1, 2);
 
         $this->assertSame(['fol', '==', 1, 'folCertificable', '==', true], $whereMarcat);
-        $this->assertStringContainsString('http://intranet.test/grupo/1DAW/fol', $botoMarcat->render($primerMarcat));
+        $this->assertStringContainsString('http://intranet.test/grupo/DAW1/fol', $botoMarcat->render($primerMarcat));
         $this->assertSame('', $botoMarcat->render($segonMarcat));
     }
 


### PR DESCRIPTION
## Què canvia

- Fa `Grupo::folCertificable` més robust:
  - manté `curso == 1` quan està informat correctament;
  - detecta primer si el primer dígit del codi o del nom és `1` (`1DAW`, `DAW1`, `CF1`, etc.);
  - detecta literals com `primer`, `primero` o `1r`.
- Amplia tests de `Grupo` i del botó de `/grupo` amb codis on el curs va al final.

## Motiu

La importació de `grupos` no ompli `curso` directament; per tant, filtrar només per `curso == 1` o per codis que comencen per `1` era massa fràgil. Si els codis reals són del tipus `CF1` o `DAW1`, el botó quedava ocult en tots els grups.

Relates #290

## Validació

- `php -l app/Entities/Grupo.php` ✅
- `php -l tests/Unit/Entities/GrupoTest.php` ✅
- `php -l tests/Unit/GrupoControllerFolButtonTest.php` ✅
- `git diff --check` ✅
- `php artisan test --filter=GrupoControllerFolButtonTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `php artisan test --filter=GrupoTest` ⚠️ no executat: falta `vendor/autoload.php` en el checkout local.
- `docker compose ps` ⚠️ sense contenidors actius per executar la prova dins Docker.