### PR TITLE
[FIX] Restringeix comprovació de certificat FOL a grups de primer #290

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -124,8 +124,8 @@ class GrupoController extends IntranetController
 
 
         if (AuthUser()->xdepartamento === 'Fol' && date('Y-m-d') > config('variables.certificatFol')) {
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>['fol','==', 0]]));
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>['fol','==', 1]]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>['fol','==', 0, 'curso','==', 1]]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>['fol','==', 1, 'curso','==', 1]]));
         }
 
         $this->panel->setBoton('grid',new BotonImg('direccion.fol',

--- a/app/Http/Controllers/PanelFinCursoController.php
+++ b/app/Http/Controllers/PanelFinCursoController.php
@@ -114,7 +114,7 @@ class PanelFinCursoController extends BaseController
     private static function lookForCheckFol(&$avisos)
     {
         foreach (app(GrupoService::class)->misGrupos() as $grupo) {
-            if ($grupo->fol == 0) {
+            if ($grupo->curso == 1 && $grupo->fol == 0) {
                 $avisos[self::DANGER][] = "FOL Grupo no revisado : ".$grupo->nombre;
             }
         }


### PR DESCRIPTION
## Resum
- El botó de revisió de grup a `/grupo` i la tasca de `/fiCurs` mostraven grups de 2n curs com a "pendent FOL", perquè cap dels dos filtrava per curs.
- S'afig `curso == 1` al `where` del botó (`GrupoController::iniBotones`) i a `PanelFinCursoController::lookForCheckFol`.
- Validat amb dades reals: professorat de cicles LFP (mòdul "Itinerario personal per a l'ocupabilitat I/II") també ha de revisar-se sols en 1r, mai en 2n.

## Test plan
- [x] Verificar a `/grupo` que el checkbox FOL sols apareix en grups de 1r per a un professor del departament FOL.
- [x] Verificar que `/fiCurs` sols llista grups de 1r pendents de revisió FOL.

Referència: #290