### PR TITLE
[FIX] Renderitza atributs data-* en BotonImg/BotonIcon i confirma grupo.fol #303

### DIFF
--- a/app/Http/Controllers/GrupoController.php
+++ b/app/Http/Controllers/GrupoController.php
@@ -124,8 +124,16 @@ class GrupoController extends IntranetController
 
 
         if (AuthUser()->xdepartamento === 'Fol' && date('Y-m-d') > config('variables.certificatFol')) {
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-square-o','where'=>['fol','==', 0]]));
-            $this->panel->setBoton('grid',new BotonImg('grupo.fol',['img' => 'fa-check','where'=>['fol','==', 1]]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',[
+                'img' => 'fa-square-o',
+                'where'=>['fol','==', 0],
+                'data-confirm' => 'Confirmes que has revisat el certificat FOL de tot l\'alumnat del grup?',
+            ]));
+            $this->panel->setBoton('grid',new BotonImg('grupo.fol',[
+                'img' => 'fa-check',
+                'where'=>['fol','==', 1],
+                'data-confirm' => 'Confirmes que vols desmarcar la revisió FOL del grup?',
+            ]));
         }
 
         $this->panel->setBoton('grid',new BotonImg('direccion.fol',

--- a/app/UI/Botones/Boton.php
+++ b/app/UI/Botones/Boton.php
@@ -233,14 +233,15 @@ abstract class Boton
 
     // torna data del boto en format html
     /**
-     * Retorna els atributs `data-*` en format HTML.
+     * Retorna els atributs `data-*` en format HTML, amb el valor escapat
+     * perquè les vistes els imprimeixen sense escapar (`{!! $data !!}`).
      */
     protected function data(): string
     {
         $cadena = "";
         foreach ($this->atributos as $key => $value) {
             if (substr($key, 0, 5)=='data-') {
-                $cadena .= " ".$key."='".$value."'";
+                $cadena .= " ".$key."='".e($value)."'";
             }
         }
         return $cadena;

--- a/app/UI/Botones/BotonIcon.php
+++ b/app/UI/Botones/BotonIcon.php
@@ -20,6 +20,7 @@ class BotonIcon extends BotonElemento
             'href' => $this->href($key),
             'class' => $this->clase(),
             'id' => $this->id($key),
+            'data' => $this->data(),
             'disabled' => $this->disabledAttr(),
             'target' => $this->target,
             'rel' => $this->rel,

--- a/app/UI/Botones/BotonImg.php
+++ b/app/UI/Botones/BotonImg.php
@@ -31,6 +31,7 @@ class BotonImg extends BotonElemento
             'href' => $this->href($key),
             'class' => $this->clase(),
             'id' => $this->id($key),
+            'data' => $this->data(),
             'disabled' => $this->disabledAttr(),
             'target' => $this->target,
             'rel' => $this->rel,

--- a/resources/views/components/buttons/icon.blade.php
+++ b/resources/views/components/buttons/icon.blade.php
@@ -4,7 +4,8 @@
    @isset($rel) rel="{{$rel}}" @endisset
    @isset($ariaLabel) aria-label="{{$ariaLabel}}" @endisset
    @isset($title) title="{{$title}}" @endisset
-   {!! $disabled !!}>
+   {!! $disabled !!}
+   {!! $data !!}>
     @isset($icon)
         <em class='fa {{$icon}}'></em>
     @endisset

--- a/resources/views/components/buttons/img.blade.php
+++ b/resources/views/components/buttons/img.blade.php
@@ -5,7 +5,8 @@
    @isset($ariaLabel) aria-label="{{$ariaLabel}}" @endisset
    @isset($title) title="{{$title}}" @endisset
    @isset($onclick) onclick="{{$onclick}}" @endisset
-   {!! $disabled !!}>
+   {!! $disabled !!}
+   {!! $data !!}>
     @isset($img)
         <em class='fa {{$img}}' alt="{{$text}}" title="{{$text}}"></em>
     @else

--- a/tests/Unit/BotonesTest.php
+++ b/tests/Unit/BotonesTest.php
@@ -160,6 +160,46 @@ class BotonesTest extends TestCase
         $this->assertStringContainsString("data-confirm='Segur que vols eliminar?'", $html);
     }
 
+    public function test_boton_img_renderitza_data_confirm(): void
+    {
+        $boto = new BotonImg('grupo.fol', [
+            'img' => 'fa-square-o',
+            'roles' => 3,
+            'data-confirm' => 'Confirmes la revisió del grup?',
+        ]);
+
+        $html = $boto->render($this->makeElement(['id' => 7]));
+
+        $this->assertStringContainsString("data-confirm='Confirmes la revisió del grup?'", $html);
+    }
+
+    public function test_boton_icon_renderitza_data_confirm(): void
+    {
+        $boto = new BotonIcon('actividad.delete', [
+            'text' => 'Eliminar',
+            'roles' => 3,
+            'data-confirm' => 'Segur que vols eliminar esta activitat?',
+        ]);
+
+        $html = $boto->render($this->makeElement(['id' => 4]));
+
+        $this->assertStringContainsString("data-confirm='Segur que vols eliminar esta activitat?'", $html);
+    }
+
+    public function test_data_confirm_escapa_el_valor(): void
+    {
+        $boto = new BotonImg('grupo.fol', [
+            'img' => 'fa-square-o',
+            'roles' => 3,
+            'data-confirm' => "Confirmes la revisió de l'alumnat?",
+        ]);
+
+        $html = $boto->render($this->makeElement(['id' => 7]));
+
+        $this->assertStringContainsString("data-confirm='Confirmes la revisió de l&#039;alumnat?'", $html);
+        $this->assertStringNotContainsString("data-confirm='Confirmes la revisió de l'alumnat?'", $html);
+    }
+
     public function test_boton_admet_data_loading_text(): void
     {
         $boto = new BotonPost('profesor.edit', [


### PR DESCRIPTION
Tanca #303.

## Què fa

1. **Repara el bug**: `BotonImg::html()` i `BotonIcon::html()` ara passen `data()` a les seues vistes, i `img.blade.php` / `icon.blade.php` el rendericen — igual que ja feien `basic` i `post`. Amb això tornen a funcionar les confirmacions ja escrites als botons d'eliminar activitat (`ActividadController:548,553`) i eliminar instructor (`InstructorController:71`), que es descartaven silenciosament.
2. **Escapa el valor** dels atributs `data-*` a `Boton::data()` amb `e()`: les vistes l'imprimeixen amb `{!! !!}` i un missatge amb apòstrof (habitual en valencià) trencava l'atribut HTML.
3. **Afig confirmació a `grupo.fol`**: marcar o desmarcar la revisió del certificat FOL d'un grup complet ara demana confirmació (relacionat amb #290).

## Verificació

- 3 tests nous a `BotonesTest`: `data-confirm` renderitzat en `BotonImg` i `BotonIcon`, i escapat del valor amb apòstrof (abans del fix, els dos primers fallaven).
- Suite relacionada: `php artisan test --filter="Grupo|Actividad|Panel|Boton"` → 183 passed.
- Renderitzat real comprovat amb tinker: l'atribut apareix amb l'apòstrof escapat (`&#039;`).
- El gestor JS global de `[data-confirm]` (`ppIntranet.js:127`) està actiu per defecte: cap vista defineix la secció `legacy_features`, i sense eixe dataset `hasLegacyFeature` retorna `true`.

## Nota fora d'abast

`BotonConfirmacion` (i l'ús de `'class' => 'confirm'` a `ComisionController:172`) confia en una classe CSS `confirm` que cap JS gestiona actualment — un altre mecanisme de confirmació mort. No es toca ací; anotat a #303 per si es vol obrir issue pròpia.
